### PR TITLE
Fix for missing author in RSS feed posts

### DIFF
--- a/packages/example-forum/lib/server/rss.js
+++ b/packages/example-forum/lib/server/rss.js
@@ -43,7 +43,7 @@ export const servePostRSS = (terms, url) => {
       // LESSWRONG - changed how author is set for RSS because
       // LessWrong posts don't reliably have post.author defined.
       //author: post.author,
-      author: Users.getUserNameById(post.userId),
+      author: Users.getDisplayNameById(post.userId),
       date: post.postedAt,
       guid: post._id,
       url: Posts.getPageUrl(post, true)

--- a/packages/example-forum/lib/server/rss.js
+++ b/packages/example-forum/lib/server/rss.js
@@ -43,7 +43,7 @@ export const servePostRSS = (terms, url) => {
       // LESSWRONG - changed how author is set for RSS because
       // LessWrong posts don't reliably have post.author defined.
       //author: post.author,
-      author: `${Users.getUserNameById(post.userId)}`,
+      author: Users.getUserNameById(post.userId),
       date: post.postedAt,
       guid: post._id,
       url: Posts.getPageUrl(post, true)

--- a/packages/example-forum/lib/server/rss.js
+++ b/packages/example-forum/lib/server/rss.js
@@ -5,6 +5,9 @@ import { Comments } from '../modules/comments/index.js';
 import { Utils, getSetting, registerSetting } from 'meteor/vulcan:core';
 import { Picker } from 'meteor/meteorhacks:picker';
 
+// LESSWRONG - this import wasn't needed until fixing author below.
+import Users from 'meteor/vulcan:users';
+
 registerSetting('forum.RSSLinksPointTo', 'link', 'Where to point RSS links to');
 
 Posts.addView('rss', Posts.views.new); // default to 'new' view for RSS feed
@@ -37,7 +40,10 @@ export const servePostRSS = (terms, url) => {
     const feedItem = {
       title: post.title,
       description: `${post.htmlBody || ""}<br/><br/>${postLink}`,
-      author: post.author,
+      // LESSWRONG - changed how author is set for RSS because
+      // LessWrong posts don't reliably have post.author defined.
+      //author: post.author,
+      author: `${Users.getUserNameById(post.userId)}`,
       date: post.postedAt,
       guid: post._id,
       url: Posts.getPageUrl(post, true)


### PR DESCRIPTION
A fix for [issue 210](https://github.com/Discordius/Lesswrong2/issues/210) and its duplicate, [issue 543](https://github.com/Discordius/Lesswrong2/issues/543).

Post.author is null in the database for most posts. (The pattern I think leads to the few posts having an author set is moving posts around, e.g. move to frontpage, curate, or sticky seems to cause the author to populate.)

This pull request would make
```
<dc:creator>
    <![CDATA[ username ]]>
</dc:creator>
```
show up for every post in RSS regardless of whether the author field has ever been populated.

(I'm not sure if there's a different, more preferred way to handle this without editing example-forum since there's no custom lesswrong rss stuff.)