### PR TITLE
fix InlineToolbar styles - don't inherit content-body styles

### DIFF
--- a/packages/lesswrong/components/async/AsyncEditorFormComponent.jsx
+++ b/packages/lesswrong/components/async/AsyncEditorFormComponent.jsx
@@ -236,15 +236,17 @@ class AsyncEditorFormComponent extends Component {
     const className = classNames("editor", "content-body", {"content-editor-is-empty": !contentState.hasText()})
 
     return (
-      <div className={className} onClick={this.focus}>
-        <Editor
-          editorState={this.state.editorState}
-          onChange={this.onChange}
-          spellCheck={true}
-          plugins={this.plugins}
-          keyBindingFn={myKeyBindingFn}
-          ref={(element) => { this.editor = element; }}
-        />
+      <div>
+        <div className={className} onClick={this.focus}>
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            spellCheck={true}
+            plugins={this.plugins}
+            keyBindingFn={myKeyBindingFn}
+            ref={(element) => { this.editor = element; }}
+          />
+        </div>
         <InlineToolbar />
         <AlignmentTool />
       </div>


### PR DESCRIPTION
`.content-body` passes `font-size: 1.4rem` to the toolbar which results in a ~2px margin above buttons:
<img width="175" alt="screen shot 2018-07-05 at 12 14 50" src="https://user-images.githubusercontent.com/89368/42314630-1d1d03fa-804e-11e8-82e9-4135c0e657b5.png">

This PR fixes this problem.

---

The separator is still misaligned even with this patch, though:
<img width="174" alt="screen shot 2018-07-05 at 12 22 25" src="https://user-images.githubusercontent.com/89368/42314657-2da176b6-804e-11e8-9728-272811d477f0.png">

Which is, as far as I can tell, partially because of LW2 styles, but not entirely. `inline-block` positioning sucks, it'd be better if inline-toolbar just used flexbox. Oh well.