### PR TITLE
Show-Parent-Comment for nested comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -156,16 +156,15 @@ class CommentsItem extends PureComponent {
 
   renderShowParent = () => {
     const comment = this.props.comment;
-    const level = this.props.level || 1
+    const level = this.props.comment.level || 1
 
-    return comment.parentCommentId ? (
+    return (comment.parentCommentId && (level === 1)) &&
       <FontIcon
         //onClick={this.toggleShowParent}
         className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
       >
         subdirectory_arrow_left
       </FontIcon>
-    ) : level != 1 && <div className="recent-comment-username-spacing">○</div>
   }
 
   renderCommentBottom = () => {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -105,6 +105,7 @@ class CommentsItem extends PureComponent {
         {!comment.deleted && this.renderCommentBottom()}
       </div>
     )
+
     if (comment) {
       return (
         <div className={
@@ -115,8 +116,9 @@ class CommentsItem extends PureComponent {
           )}
         >
           <div className="comments-item-body">
-            <div className="comments-item-meta">
+            <div className="comments-item-meta recent-comments-node">
               <a className="comments-collapse" onClick={this.props.toggleCollapse}>[<span>{this.props.collapsed ? "+" : "-"}</span>]</a>
+              {this.renderShowParent()}
               {!comment.deleted && <span>
                 <Components.UsersName user={comment.user}/>
               </span>}
@@ -150,6 +152,20 @@ class CommentsItem extends PureComponent {
     } else {
       return null
     }
+  }
+
+  renderShowParent = () => {
+    const comment = this.props.comment;
+    const level = this.props.level || 1
+
+    return comment.parentCommentId ? (
+      <FontIcon
+        //onClick={this.toggleShowParent}
+        className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
+      >
+        subdirectory_arrow_left
+      </FontIcon>
+    ) : level != 1 && <div className="recent-comment-username-spacing">○</div>
   }
 
   renderCommentBottom = () => {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -99,6 +99,7 @@ class CommentsItem extends PureComponent {
   render() {
     const currentUser = this.props.currentUser;
     const comment = this.props.comment;
+    const level = this.props.comment.level || 1;
     const commentBody = this.props.collapsed ? "" : (
       <div>
         {this.state.showEdit ? this.renderEdit() : this.renderComment()}
@@ -118,7 +119,13 @@ class CommentsItem extends PureComponent {
           <div className="comments-item-body">
             <div className="comments-item-meta recent-comments-node">
               <a className="comments-collapse" onClick={this.props.toggleCollapse}>[<span>{this.props.collapsed ? "+" : "-"}</span>]</a>
-              {this.renderShowParent()}
+              {(comment.parentCommentId && (level === 1)) &&
+                <FontIcon
+                  //onClick={this.toggleShowParent}
+                  className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
+                >
+                  subdirectory_arrow_left
+                </FontIcon>}
               {!comment.deleted && <span>
                 <Components.UsersName user={comment.user}/>
               </span>}
@@ -153,20 +160,7 @@ class CommentsItem extends PureComponent {
       return null
     }
   }
-
-  renderShowParent = () => {
-    const comment = this.props.comment;
-    const level = this.props.comment.level || 1
-
-    return (comment.parentCommentId && (level === 1)) &&
-      <FontIcon
-        //onClick={this.toggleShowParent}
-        className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
-      >
-        subdirectory_arrow_left
-      </FontIcon>
-  }
-
+  
   renderCommentBottom = () => {
     const comment = this.props.comment;
     const currentUser = this.props.currentUser;

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -42,6 +42,7 @@ class CommentsItem extends PureComponent {
       showEdit: false,
       showReport: false,
       showStats: false,
+      showParent: false
     };
   }
 
@@ -88,6 +89,10 @@ class CommentsItem extends PureComponent {
     this.props.flash("Successfully deleted comment", "success");
   }
 
+  toggleShowParent = () => {
+    this.setState({showParent:!this.state.showParent})
+  }
+
   handleLinkClick = (event) => {
     const { comment, router } = this.props;
     event.preventDefault()
@@ -112,16 +117,31 @@ class CommentsItem extends PureComponent {
         <div className={
           classNames(
             "comments-item",
+            "recent-comments-node",
             {deleted: comment.deleted && !comment.deletedPublic,
-            "public-deleted": comment.deletedPublic}
+            "public-deleted": comment.deletedPublic,
+            "showParent": this.state.showParent},
           )}
         >
+
+          { comment.parentCommentId && this.state.showParent && (
+            <div className="recent-comment-parent">
+              <Components.RecentCommentsSingle
+                currentUser={this.props.currentUser}
+                documentId={comment.parentCommentId}
+                level={level + 1}
+                expanded={true}
+                key={comment.parentCommentId}
+              />
+            </div>
+          )}
+
           <div className="comments-item-body">
-            <div className="comments-item-meta recent-comments-node">
+            <div className="comments-item-meta">
               <a className="comments-collapse" onClick={this.props.toggleCollapse}>[<span>{this.props.collapsed ? "+" : "-"}</span>]</a>
               {(comment.parentCommentId && (level === 1)) &&
                 <FontIcon
-                  //onClick={this.toggleShowParent}
+                  onClick={this.toggleShowParent}
                   className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
                 >
                   subdirectory_arrow_left
@@ -160,7 +180,7 @@ class CommentsItem extends PureComponent {
       return null
     }
   }
-  
+
   renderCommentBottom = () => {
     const comment = this.props.comment;
     const currentUser = this.props.currentUser;

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -83,7 +83,7 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
                 { comment.parentCommentId ? (
                   <FontIcon
                     onClick={this.toggleShowParent}
-                    className={classNames("material-icons","comments-show-parent",{active:this.state.showParent})}
+                    className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
                   >
                     subdirectory_arrow_left
                   </FontIcon>

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -83,7 +83,7 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
                 { comment.parentCommentId ? (
                   <FontIcon
                     onClick={this.toggleShowParent}
-                    className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
+                    className={classNames("material-icons","comments-show-parent",{active:this.state.showParent})}
                   >
                     subdirectory_arrow_left
                   </FontIcon>

--- a/packages/lesswrong/components/comments/recentDiscussionThread.jsx
+++ b/packages/lesswrong/components/comments/recentDiscussionThread.jsx
@@ -163,10 +163,13 @@ class RecentDiscussionThread extends PureComponent {
           <div className={"comments-items"}>
             {results.map(comment =>
               <div key={comment._id}>
-                <Components.RecentCommentsItem
-                  comment={comment}
+                <Components.CommentsNode
                   currentUser={currentUser}
-                  editMutation={editMutation}/>
+                  comment={comment}
+                  key={comment._id}
+                  editMutation={editMutation}
+                  post={post}
+                />
               </div>
             )}
           </div>}

--- a/packages/lesswrong/components/comments/recentDiscussionThread.jsx
+++ b/packages/lesswrong/components/comments/recentDiscussionThread.jsx
@@ -15,9 +15,11 @@ import moment from 'moment';
 import { bindActionCreators } from 'redux';
 import withNewEvents from '../../lib/events/withNewEvents.jsx';
 import { connect } from 'react-redux';
+import { unflatten } from '../../lib/modules/utils/unflatten';
 
 import Users from "meteor/vulcan:users";
 import FontIcon from 'material-ui/FontIcon';
+
 class RecentDiscussionThread extends PureComponent {
 
   constructor(props) {
@@ -80,6 +82,8 @@ class RecentDiscussionThread extends PureComponent {
 
   render() {
     const { post, results, loading, editMutation, currentUser } = this.props
+    const resultsClone = _.map(results, _.clone); // we don't want to modify the objects we got from props
+    const nestedComments = unflatten(resultsClone, {idProperty: '_id', parentIdProperty: 'parentCommentId'});
 
     if (!loading && results && !results.length && post.commentCount != null) {
       return null
@@ -161,7 +165,7 @@ class RecentDiscussionThread extends PureComponent {
         <div className="recent-discussion-thread-comment-list">
           {loading || !results ? <Loading /> :
           <div className={"comments-items"}>
-            {results.map(comment =>
+            {nestedComments.map(comment =>
               <div key={comment._id}>
                 <Components.CommentsNode
                   currentUser={currentUser}

--- a/packages/lesswrong/components/posts/PostsCommentsThreadWrapper.jsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThreadWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withList, Components, registerComponent, Utils} from 'meteor/vulcan:core';
+import { withList, Components, registerComponent} from 'meteor/vulcan:core';
+import { unflatten } from '../../lib/modules/utils/unflatten';
 import { Comments } from 'meteor/example-forum';
 
 
@@ -12,7 +13,7 @@ const PostsCommentsThreadWrapper = (props, /* context*/) => {
     return <div className="posts-comments-thread"><Components.Loading/></div>
   } else {
     const resultsClone = _.map(results, _.clone); // we don't want to modify the objects we got from props
-    const nestedComments = Utils.unflatten(resultsClone, {idProperty: '_id', parentIdProperty: 'parentCommentId'});
+    const nestedComments = unflatten(resultsClone, {idProperty: '_id', parentIdProperty: 'parentCommentId'});
     return (
       <div className="posts-comments-thread-wrapper">
         <Components.PostsCommentsThread


### PR DESCRIPTION
Issue #568 

The ‘show parent’ button from RecentCommentsItem.jsx has been copied to CommentsItem.jsx, with the button only appearing when the comment has a parent that it isn’t already nested inside.

Taking advantage of this change, RecentDisscussionThread.jsx unflattens the recent comments it’s rendering, and displays them using CommentsNode components rather than RecentCommentsItem.

I’ve avoided touching the Sass files since apparently there are some major changes to them going on in another branch. Due to this, I’ve ended up using .recent-comments-node and .recent-comments-show-parent in places they weren’t quite meant for. It shouldn’t cause any problems but might be worth tidying up once the CSS has settled down.

When you click the ‘show parent’ button, it shows the parent as a RecentCommentsItem. It would probably be desirable to replace that with a CommentsItem as well, which would be more consistent and allow RecentCommentsItem to be deleted entirely. However, getting a CommentsItem to display correctly under those circumstances involves some non-trivial manipulation of the styles on it, so I’m leaving that alone for now as well