### PR TITLE
Fix warnings

### DIFF
--- a/packages/lesswrong/components/comments/CommentsListSection.jsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.jsx
@@ -99,8 +99,8 @@ class CommentsListSection extends Component {
             terms={{view: "postVisits", limit: 4, postId: post._id, userId: currentUser._id}}
             clickCallback={this.handleDateChange}/>}
           <Divider />
-          {suggestedHighlightDates.map((date) => {
-            return <MenuItem onClick={() => this.handleDateChange(date)}>
+          {suggestedHighlightDates.map((date,i) => {
+            return <MenuItem key={i} onClick={() => this.handleDateChange(date)}>
               {date.calendar().toString()}
             </MenuItem>
           })}

--- a/packages/lesswrong/lib/events/callbacks_async.js
+++ b/packages/lesswrong/lib/events/callbacks_async.js
@@ -3,6 +3,12 @@ import intercomClient from './server.js';
 
 
 function sendIntercomEvent (event, user) {
+  if (intercomClient == null) {
+    // If no intercomToken is configured, then intercomClient will be null,
+    // and this is a dev install with Intercom disabled. Don't try to send
+    // Intercom events in that case (it just causes spurious error messages.)
+    return;
+  }
   if (user && event && event.intercom) {
     // Append documentId to metadata passed to intercom
     event.properties = {

--- a/packages/lesswrong/lib/events/server.js
+++ b/packages/lesswrong/lib/events/server.js
@@ -3,7 +3,7 @@ import Intercom from 'intercom-client';
 
 // Initiate Intercom on the server
 const intercomToken = getSetting("intercomToken", null);
-let intercomClient = {}
+let intercomClient = null;
 if (intercomToken) {
   intercomClient = new Intercom.Client({ token: getSetting("intercomToken") });
 }
@@ -11,4 +11,4 @@ if (intercomToken) {
 import './callbacks_async.js';
 
 
-export default intercomClient
+export default intercomClient;


### PR DESCRIPTION
Fix two warnings that were spamming up the console/logs: a stack trace that showed up if you hadn't configured an Intercom API key (ie, on development installs), and a warning about missing keys in CommentsListSection.