### PR TITLE
Refactor Section to use Material theme object, create SectionTitleLink component

### DIFF
--- a/packages/lesswrong/components/common/Home.jsx
+++ b/packages/lesswrong/components/common/Home.jsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent, withCurrentUser} from 'meteor/vulcan:core';
 import React from 'react';
-import { Link } from 'react-router';
 
 const testCollections = [
   {
@@ -117,7 +116,7 @@ const Home = (props, context) => {
         title="Community"
         titleLink="/community"
         titleComponent={<div>
-          <Components.SectionTitleLink className="events-near-you" to="/community">
+          <Components.SectionTitleLink to="/community">
             Find Events Nearby
           </Components.SectionTitleLink>
         </div>}

--- a/packages/lesswrong/components/common/Home.jsx
+++ b/packages/lesswrong/components/common/Home.jsx
@@ -81,7 +81,9 @@ const Home = (props, context) => {
           contentStyle={{marginTop: '-20px'}}
           title="Recommended Reading"
           titleLink="/library"
-          titleComponent= {<Link className="recommended-reading-library" to="/library">Sequence Library</Link>}
+          titleComponent= {<Components.SectionTitleLink to="/library">
+            Sequence Library
+          </Components.SectionTitleLink>}
         >
           <Components.CollectionsCard collection={testCollections[0]} big={true} url={"/rationality"}/>
           <Components.CollectionsCard collection={testCollections[1]} float={"left"} url={"/codex"}/>
@@ -91,7 +93,9 @@ const Home = (props, context) => {
           <Components.Section
             title="Recommended Sequences"
             titleLink="/library"
-            titleComponent= {<Link className="recommended-reading-library" to="/library">Sequence Library</Link>}
+            titleComponent= {<Components.SectionTitleLink to="/library">
+              Sequence Library
+            </Components.SectionTitleLink>}
           >
             <Components.SequencesGridWrapper
               terms={{view:"curatedSequences", limit:3}}
@@ -113,9 +117,9 @@ const Home = (props, context) => {
         title="Community"
         titleLink="/community"
         titleComponent={<div>
-          <Link className="events-near-you" to="/community">
+          <Components.SectionTitleLink className="events-near-you" to="/community">
             Find Events Nearby
-          </Link>
+          </Components.SectionTitleLink>
         </div>}
       >
         <Components.PostsList

--- a/packages/lesswrong/components/common/Section.jsx
+++ b/packages/lesswrong/components/common/Section.jsx
@@ -14,50 +14,57 @@ const styles = (theme) => ({
     marginBottom: theme.spacing.unit * 4,
   },
   sectionTitleContainer: {
-    textAlign: 'right',
-    display: 'inline',
+    [theme.breakpoints.up('md')]: {
+      textAlign: 'right',
+      display: 'inline',
+    }
   },
   sectionTitle: {
-    display: 'inline',
-    position: 'relative',
-    top: (theme.spacing.unit) + BORDER_TOP_WIDTH,
-    '&:before': {
-      top: ((theme.spacing.unit) - BORDER_TOP_WIDTH) * -1,
-      position: 'absolute',
-      width: '100%',
-      borderTopStyle: 'solid',
+    [theme.breakpoints.down('sm')]: {
       borderTopWidth: BORDER_TOP_WIDTH,
-      content: '""'
+      borderTopStyle: 'solid',
+      paddingTop: theme.spacing.unit
+    },
+    [theme.breakpoints.up('md')]: {
+      display: 'inline',
+      position: 'relative',
+      top: theme.spacing.unit + BORDER_TOP_WIDTH,
+      '&:before': {
+        top: (theme.spacing.unit - BORDER_TOP_WIDTH) * -1,
+        position: 'absolute',
+        width: '100%',
+        borderTopStyle: 'solid',
+        borderTopWidth: BORDER_TOP_WIDTH,
+        content: '""'
+      }
     }
   },
   sectionTitleTop: {
-    paddingBottom: theme.spacing.unit,
-    marginBottom: theme.spacing.unit
+    [theme.breakpoints.up('md')]: {
+      paddingBottom: theme.spacing.unit,
+      marginBottom: theme.spacing.unit
+    }
   },
-  sectionTitleBottom: {
-    // TODO: do we need this class?
-  },
-  sectionContent: {
-    // TODO: do we need this class?
-  }
+  // left to provide overrides
+  sectionTitleBottom: {},
+  sectionContent: {}
 })
 
 const Section = ({contentStyle, title, /*titleWidth = 220, contentWidth = 715,*/ titleLink, titleComponent, children, classes}) => {
 
   return (
     <Grid container className={classes.section}>
-      <Grid item md={3} className={classes.sectionTitleContainer}>
+      <Grid item xs={12} md={3} className={classes.sectionTitleContainer}>
         {title && <div className={classes.sectionTitleTop}>
           <Typography variant="display1" className={classes.sectionTitle}>
-            {!titleLink && <span>{title}</span>}
-            {titleLink && <Link to={titleLink}>{title}</Link>}
+            {!titleLink ? <span>{title}</span> : <Link to={titleLink}>{title}</Link>}
           </Typography>
         </div>}
         {titleComponent && <div className={classes.sectionTitleBottom}>
           {titleComponent}
         </div>}
       </Grid>
-      <Grid item md={9}>
+      <Grid item xs={12} md={9}>
         <div className={classes.sectionContent}>
           {children}
         </div>

--- a/packages/lesswrong/components/common/Section.jsx
+++ b/packages/lesswrong/components/common/Section.jsx
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 
 
-const borderTopWidth = 3
+const BORDER_TOP_WIDTH = 3
 
 const styles = (theme) => ({
   section: {
@@ -20,13 +20,13 @@ const styles = (theme) => ({
   sectionTitle: {
     display: 'inline',
     position: 'relative',
-    top: (theme.spacing.unit) + borderTopWidth,
+    top: (theme.spacing.unit) + BORDER_TOP_WIDTH,
     '&:before': {
-      top: ((theme.spacing.unit) - borderTopWidth) * -1,
+      top: ((theme.spacing.unit) - BORDER_TOP_WIDTH) * -1,
       position: 'absolute',
       width: '100%',
       borderTopStyle: 'solid',
-      borderTopWidth: borderTopWidth,
+      borderTopWidth: BORDER_TOP_WIDTH,
       content: '""'
     }
   },

--- a/packages/lesswrong/components/common/Section.jsx
+++ b/packages/lesswrong/components/common/Section.jsx
@@ -2,24 +2,68 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 import { Link } from 'react-router';
 import React from 'react';
 
-const Section = ({contentStyle, title, titleWidth = 220, contentWidth = 715, titleLink, titleComponent, children}) => {
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+
+
+const borderTopWidth = 3
+
+const styles = (theme) => ({
+  section: {
+    marginBottom: theme.spacing.unit * 4,
+  },
+  sectionTitleContainer: {
+    textAlign: 'right',
+    display: 'inline',
+  },
+  sectionTitle: {
+    display: 'inline',
+    position: 'relative',
+    top: (theme.spacing.unit) + borderTopWidth,
+    '&:before': {
+      top: ((theme.spacing.unit) - borderTopWidth) * -1,
+      position: 'absolute',
+      width: '100%',
+      borderTopStyle: 'solid',
+      borderTopWidth: borderTopWidth,
+      content: '""'
+    }
+  },
+  sectionTitleTop: {
+    paddingBottom: theme.spacing.unit,
+    marginBottom: theme.spacing.unit
+  },
+  sectionTitleBottom: {
+    // TODO: do we need this class?
+  },
+  sectionContent: {
+    // TODO: do we need this class?
+  }
+})
+
+const Section = ({contentStyle, title, /*titleWidth = 220, contentWidth = 715,*/ titleLink, titleComponent, children, classes}) => {
 
   return (
-    <div className="section" style={{width: `${titleWidth+contentWidth+5}px`, display: 'flex'}}>
-      <div className="section-title" style={{width: `${titleWidth}px`}}>
-        <div className="section-title-top">
-          {title && !titleLink && <h2>{title}</h2> }
-          {title && titleLink && <Link to={titleLink}><h2>{title}</h2></Link> }
+    <Grid container className={classes.section}>
+      <Grid item md={3} className={classes.sectionTitleContainer}>
+        {title && <div className={classes.sectionTitleTop}>
+          <Typography variant="display1" className={classes.sectionTitle}>
+            {!titleLink && <span>{title}</span>}
+            {titleLink && <Link to={titleLink}>{title}</Link>}
+          </Typography>
+        </div>}
+        {titleComponent && <div className={classes.sectionTitleBottom}>
+          {titleComponent}
+        </div>}
+      </Grid>
+      <Grid item md={9}>
+        <div className={classes.sectionContent}>
+          {children}
         </div>
-        <div className="section-title-bottom">
-          {titleComponent ? titleComponent : null}
-        </div>
-      </div>
-      <div className="section-content" style={{width: `${contentWidth}px`, ...contentStyle}}>
-        {children}
-      </div>
-    </div>
+      </Grid>
+    </Grid>
   )
 };
 
-registerComponent('Section', Section);
+registerComponent('Section', Section, withStyles(styles, { name: 'Section'}));

--- a/packages/lesswrong/components/common/SectionTitleLink.jsx
+++ b/packages/lesswrong/components/common/SectionTitleLink.jsx
@@ -10,7 +10,7 @@ const styles = (theme) => ({
       fontStyle: 'italic',
       fontSize: 16,
       color: theme.palette.grey[500],
-      '&:hover': {
+      '&:hover, &:active, &:focus': {
         color: theme.palette.grey[400],
       }
     }
@@ -27,8 +27,4 @@ const SectionTitleLink = (props) => {
   </Typography>
 }
 
-registerComponent(
-  'SectionTitleLink',
-  SectionTitleLink,
-  withStyles(styles, {name: 'SectionTitleLink'})
-)
+registerComponent( 'SectionTitleLink', SectionTitleLink, withStyles(styles, {name: 'SectionTitleLink'}))

--- a/packages/lesswrong/components/common/SectionTitleLink.jsx
+++ b/packages/lesswrong/components/common/SectionTitleLink.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Components, registerComponent } from 'meteor/vulcan:core';
+import { Link } from 'react-router';
+import { withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+const styles = (theme) => ({
+  sectionTitleLink: {
+    '& a': {
+      fontStyle: 'italic',
+      fontSize: 16,
+      color: theme.palette.grey[500],
+      '&:hover': {
+        color: theme.palette.grey[400],
+      }
+    }
+  }
+})
+
+const SectionTitleLink = (props) => {
+  const {children, classes} = props
+  const newProps = _.omit(props, ['classes', 'children'])
+  return <Typography component='span' variant='body1' className={classes.sectionTitleLink}>
+    <Link {...newProps}>
+      {children}
+    </Link>
+  </Typography>
+}
+
+registerComponent(
+  'SectionTitleLink',
+  SectionTitleLink,
+  withStyles(styles, {name: 'SectionTitleLink'})
+)

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -38,6 +38,7 @@ import '../components/common/Meta.jsx';
 import '../components/common/AllPosts.jsx';
 import '../components/common/AllComments.jsx';
 import '../components/common/Section.jsx';
+import '../components/common/SectionTitleLink.jsx';
 import '../components/common/VoteButton.jsx';
 import '../components/common/SearchBar.jsx';
 import '../components/common/DialogGroup.jsx';

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -56,6 +56,7 @@ const theme = createMuiTheme({
     },
     display1: {
       fontFamily: serifStack,
+      color: grey[800]
     },
     display3: {
       fontFamily: serifStack,


### PR DESCRIPTION
Work from hackathon. Styles the sidebar on the posts page, but SectionTitleLink is envisaged as the base for the filter links underneath the 'Recent Posts' component