### PR TITLE
Fix links when you click on filters on the front page map

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.jsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.jsx
@@ -31,7 +31,7 @@ class CommunityMapFilter extends Component {
       newFilters = [...this.state.filters, filter];
     }
     this.setState({filters: newFilters});
-    router.replace({...router.location, query: {filters: newFilters}})
+    router.replace({...router.location, pathname: "/community", query: {filters: newFilters}})
   }
 
   render() {


### PR DESCRIPTION
This is not an ideal fix, and this is not the only bug related to those filters, but it's probably good enough for now.

(If you go to a specific-group page, and try using the filters, the currently-deployed version mangles the URI in a weird way. But that page shouldn't have the filters in the first place.)