### PR TITLE
Legacy route fixes

### DIFF
--- a/packages/lesswrong/server/legacy-redirects/routes.js
+++ b/packages/lesswrong/server/legacy-redirects/routes.js
@@ -2,8 +2,21 @@ import { Picker } from 'meteor/meteorhacks:picker';
 import { Posts, Comments } from 'meteor/example-forum';
 import Users from 'meteor/vulcan:users';
 
-// All legacy URLs either do not contain /lw/, start with /lw/, or start with
-//   /r/[section]/lw/, where section is one of {all,discussion,lesswrong}
+// Some legacy routes have an optional subreddit prefix, which is either
+// omitted, is /r/all, /r/discussion, or /r/lesswrong. The is followed by
+// /lw/postid possibly followed by a slug, comment ID, filter settings, or other
+// things, some of which is supported and some of which isn't.
+// 
+// If a route has this optional prefix, use `subredditPrefixRoute` to represent
+// that part. It contains two optional parameters, constrained to be `r` and
+// a subreddit name, respectively (the subreddits being lesswrong, discussion,
+// and all). Since old-LW made all post IDs non-overlapping, we just ignore
+// which subreddit was specified.
+// 
+// (In old LW, the set of possible subreddits may also have included user
+// account names, for things in users' draft folders. We don't support getting
+// old drafts via legacy routes; I'm not sure whether we support getting them
+// through other UI).
 const subredditPrefixRoute = "/:section(r)?/:subreddit(all|discussion|lesswrong)?";
 
 function findPostByLegacyId(legacyId) {

--- a/packages/lesswrong/server/legacy-redirects/routes.js
+++ b/packages/lesswrong/server/legacy-redirects/routes.js
@@ -4,7 +4,7 @@ import Users from 'meteor/vulcan:users';
 
 // All legacy URLs either do not contain /lw/, start with /lw/, or start with
 //   /r/[section]/lw/, where section is one of {all,discussion,lesswrong}
-const subredditPrefixRoute = "/:section?/:subreddit?";
+const subredditPrefixRoute = "/:section(r)?/:subreddit(all|discussion|lesswrong)?";
 
 function findPostByLegacyId(legacyId) {
   const parsedId = parseInt(legacyId, 36);

--- a/packages/lesswrong/server/legacy-redirects/routes.js
+++ b/packages/lesswrong/server/legacy-redirects/routes.js
@@ -4,6 +4,7 @@ import Users from 'meteor/vulcan:users';
 
 // All legacy URLs either do not contain /lw/, start with /lw/, or start with
 //   /r/[section]/lw/, where section is one of {all,discussion,lesswrong}
+const subredditPrefixRoute = "/:section?/:subreddit?";
 
 function findPostByLegacyId(legacyId) {
   const parsedId = parseInt(legacyId, 36);
@@ -26,7 +27,7 @@ function makeRedirect(res, destination) {
 
 
 // Route for old post links
-Picker.route('/:section?/:subreddit?/lw/:id/:slug?', (params, req, res, next) => {
+Picker.route(subredditPrefixRoute+'/lw/:id/:slug?', (params, req, res, next) => {
   if(params.id){
 
     try {
@@ -53,7 +54,7 @@ Picker.route('/:section?/:subreddit?/lw/:id/:slug?', (params, req, res, next) =>
 });
 
 // Route for old comment links
-Picker.route('/:section?/:subreddit?/lw/:id/:slug/:commentId', (params, req, res, next) => {
+Picker.route(subredditPrefixRoute+'/lw/:id/:slug/:commentId', (params, req, res, next) => {
   if(params.id){
 
     try {
@@ -156,7 +157,7 @@ Picker.route('/static/imported/:year/:month/:day/:imageName', (params, req, res,
 // Legacy RSS Routes
 
 // Route for old comment rss feeds
-Picker.route('/:section?/:subreddit?/lw/:id/:slug/:commentId/.rss', (params, req, res, next) => {
+Picker.route(subredditPrefixRoute+'/lw/:id/:slug/:commentId/.rss', (params, req, res, next) => {
   if(params.id){
     try {
       const post = findPostByLegacyId(params.id);

--- a/packages/lesswrong/server/legacy-redirects/routes.js
+++ b/packages/lesswrong/server/legacy-redirects/routes.js
@@ -187,6 +187,11 @@ Picker.route('comments/.rss', (params, req, res, next) => {
   res.end();
 });
 
+Picker.route('/rss/comments.xml', (params, req, res, next) => {
+  res.writeHead(301, {'Location': '/feed.xml?type=comments'})
+  res.end();
+});
+
 // Route for old general RSS (all posts)
 Picker.route('/:section?/:subreddit?/:new?/.rss', (params, req, res, next) => {
   res.writeHead(301, {'Location': '/feed.xml'})


### PR DESCRIPTION
Add a legacy route for `/rss/comments.xml`. Refactor the legacy routes file. Fix the legacy route for the post "Reversed Stupidity is Not Intelligence", which had the very unfortunate property that its ID in base36 was `lw` and this messed up URL parsing (#807 ).