### PR TITLE
Display logged-in user karma in the top right

### DIFF
--- a/packages/lesswrong/components/users/UsersMenu.jsx
+++ b/packages/lesswrong/components/users/UsersMenu.jsx
@@ -52,6 +52,7 @@ class UsersMenu extends PureComponent {
         <Button onClick={this.handleClick}>
           <span className={classes.userButton} style={{ color: color }}>
             {Users.getDisplayName(currentUser)}
+            {currentUser && currentUser.karma>0 && ` (${currentUser.karma})`}
           </span>
         </Button>
         <Popover

--- a/packages/lesswrong/components/users/UsersMenu.jsx
+++ b/packages/lesswrong/components/users/UsersMenu.jsx
@@ -19,6 +19,9 @@ const styles = theme => ({
     textTransform: 'none',
     fontSize: '16px',
     fontWeight: 400,
+  },
+  loggedInUserKarma: {
+    paddingLeft: '5px'
   }
 })
 
@@ -52,7 +55,7 @@ class UsersMenu extends PureComponent {
         <Button onClick={this.handleClick}>
           <span className={classes.userButton} style={{ color: color }}>
             {Users.getDisplayName(currentUser)}
-            {currentUser && currentUser.karma>0 && ` (${currentUser.karma})`}
+            {currentUser && currentUser.karma>0 && <span className={classes.loggedInUserKarma}>({currentUser.karma})</span>}
           </span>
         </Button>
         <Popover


### PR DESCRIPTION
This makes the logged in user's karma visible on the front page. This is closer to how old-LessWrong worked, and makes the site more skinner-boxy. Style-wise, it's just the karma number in parentheses after your username (exactly as it is on Hacker News).

Whether to do this, and how it should look, are policy questions. This PR is creating a default option that's not "karma is hidden unless you click through to your own user page".