### PR TITLE
Do not use a default image for social media sharing. Fixes #870

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -1,0 +1,79 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
+import { registerComponent, Utils, getSetting, registerSetting, Head } from 'meteor/vulcan:lib';
+import { compose } from 'react-apollo';
+
+registerSetting('logoUrl', null, 'Absolute URL for the logo image');
+registerSetting('title', 'My App', 'App title');
+registerSetting('tagline', null, 'App tagline');
+registerSetting('description');
+registerSetting('siteImage', null, 'An image used to represent the site on social media');
+registerSetting('faviconUrl', '/img/favicon.ico', 'Favicon absolute URL');
+
+class HeadTags extends PureComponent {
+
+  render() {
+
+    const url = this.props.url || Utils.getSiteUrl();
+    const title = this.props.title || getSetting('title', 'My App');
+    const description = this.props.description || getSetting('tagline') || getSetting('description');
+
+    return (
+      <div>
+        <Helmet>
+
+          <title>{title}</title>
+
+          <meta charSet='utf-8'/>
+          <meta name='description' content={description}/>
+          <meta name='viewport' content='width=device-width, initial-scale=1'/>
+
+          {/* facebook */}
+          <meta property='og:type' content='article'/>
+          <meta property='og:url' content={url}/>
+          {this.props.image && <meta property='og:image' content={this.props.image}/>}
+          <meta property='og:title' content={title}/>
+          <meta property='og:description' content={description}/>
+
+          {/* twitter */}
+          <meta name='twitter:card' content='summary'/>
+          {this.props.image && <meta name='twitter:image:src' content={this.props.image}/>}
+          <meta name='twitter:title' content={title}/>
+          <meta name='twitter:description' content={description}/>
+
+          <link rel='canonical' href={url}/>
+          <link name='favicon' rel='shortcut icon' href={getSetting('faviconUrl', '/img/favicon.ico')}/>
+
+          {Head.meta.map((tag, index) => <meta key={index} {...tag}/>)}
+          {Head.link.map((tag, index) => <link key={index} {...tag}/>)}
+          {Head.script.map((tag, index) => <script key={index} {...tag}>{tag.contents}</script>)}
+
+        </Helmet>
+
+        {Head.components.map((componentOrArray, index) => {
+          let HeadComponent;
+          if (Array.isArray(componentOrArray)) {
+            const [component, ...hocs] = componentOrArray;
+            HeadComponent = compose(...hocs)(component);
+          } else {
+            HeadComponent = componentOrArray;
+          }
+          return <HeadComponent key={index} />
+        })}
+
+      </div>
+    );
+  }
+}
+
+HeadTags.propTypes = {
+  url: PropTypes.string,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  image: PropTypes.string,
+};
+
+registerComponent('HeadTags', HeadTags);
+
+export default HeadTags;

--- a/packages/lesswrong/components/common/Home.jsx
+++ b/packages/lesswrong/components/common/Home.jsx
@@ -1,4 +1,5 @@
 import { Components, registerComponent, withCurrentUser} from 'meteor/vulcan:core';
+import { getSetting } from 'meteor/vulcan:lib';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router';
@@ -83,6 +84,7 @@ const Home = (props, context) => {
 
   return (
     <div>
+      <Components.HeadTags image={getSetting('siteImage')} />
       { !currentUser ?
         <Components.Section
           contentStyle={{marginTop: '-20px'}}

--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -24,7 +24,6 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { postBodyStyles } from '../../themes/stylePiping'
 import classNames from 'classnames';
-// import Users from "meteor/vulcan:users";
 
 const styles = theme => ({
     header: {
@@ -281,7 +280,7 @@ class PostsPage extends Component {
 
       return (
         <Components.ErrorBoundary>
-          <Components.HeadTags url={Posts.getPageUrl(post, true)} title={post.title} image={post.thumbnailUrl} description={post.excerpt} />
+          <Components.HeadTags url={Posts.getPageUrl(post, true)} title={post.title} description={post.excerpt} />
           <div>
             <div className={classes.header}>
               <Typography variant="display3" className={classes.title}>

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -33,6 +33,7 @@ import '../components/Layout.jsx';
 import '../components/common/FlashMessages.jsx';
 import '../components/common/Header.jsx';
 import '../components/common/NavigationMenu.jsx';
+import '../components/common/HeadTags.jsx';
 import '../components/common/Home.jsx';
 import '../components/common/Meta.jsx';
 import '../components/common/AllComments.jsx';


### PR DESCRIPTION
The solution here:

* Create a copy of the HeadTags component.
* Remove the default image used for social media.
* Manually set the image for the homepate.
* All other pages do not have an image.

Testing:

* Use the facebook sharing debugger: https://developers.facebook.com/tools/debug/sharing/
* Verify that the homepage has the correct title, description, and has the same social media image
* Verify that posts have the correct title, description, but no social media image
* Verify that when testing with the facecbook sharing debugger, posts with images in them have that image used in the facebook preview.
