### PR TITLE
Fix to description property for posts

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -275,7 +275,7 @@ class PostsPage extends Component {
       const htmlBody = {__html: post.htmlBody}
       let query = location && location.query
       const view = _.clone(router.location.query).view || Comments.getDefaultView(post, currentUser)
-      const description = post.plaintextExcerpt ? post.plaintextExcerpt : (post.body && post.body.substring(300))
+      const description = post.plaintextExcerpt ? post.plaintextExcerpt : (post.body && post.body.substring(0, 300))
       const commentTerms = _.isEmpty(query) ? {view: view, limit: 500} : {...query, limit:500}
 
       return (


### PR DESCRIPTION
Pretty obvious, substring(300) does not do the same as substring(0,300). 