### PR TITLE
Fix sizing problems with CloudinaryImage

### DIFF
--- a/packages/lesswrong/components/common/CloudinaryImage.jsx
+++ b/packages/lesswrong/components/common/CloudinaryImage.jsx
@@ -17,20 +17,25 @@ const CloudinaryImage = (props, context) => {
     g: "custom",
     q: "auto",
   };
-  let imageStyle = {};
   
+  let sizeProps = {};
   if(props.width) {
     cloudinaryProps.w = props.width;
+    if(parseInt(props.width))
+      sizeProps.width = props.width+"px";
   }
   if(props.height) {
     cloudinaryProps.h = props.height;
+    if(parseInt(props.height))
+      sizeProps.height = props.height+"px";
   }
   
   const imageUrl = `http://res.cloudinary.com/${cloudinaryCloudName}/image/upload/${cloudinaryPropsToStr(cloudinaryProps)}/${props.publicId}`;
   
   return <img
+    sizes="100vw"
     src={imageUrl}
-    style={imageStyle}
+    {...sizeProps}
   />
 };
 


### PR DESCRIPTION
This fixes the egregious styling problems introduced by the Cloudinary sizing refactor (images not staying inside their bounds), which was caused by accidentally replacing the `width` and `height` attributes on images with `width` and `height` attributes in CSS on the `style` attribute, which has higher precedence than regular CSS does.

There is still a significant glitch remaining, which is that the header images on sequences (eg `https://www.lesswrong.com/s/HXkpm9b8o964jbQ89`) should crop according to the browser width, but instead it's doing an aspect-ratio-changing scale. We could probably fix this using Cloudinary's client-hints support, as described [here](https://cloudinary.com/documentation/image_transformation_reference#width_parameter), but this isn't currently working; this may be related to the note on the docs that says `(Note: For customers with a custom domain name: Contact us to setup this feature).`