### PR TITLE
Temporarily revert removal of cloudinary-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bowser": "^1.9.4",
     "chalk": "^2.4.1",
     "classnames": "^2.2.6",
+    "cloudinary-react": "^1.0.4",
     "compression": "^1.7.3",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",

--- a/packages/lesswrong/components/common/CloudinaryImage.jsx
+++ b/packages/lesswrong/components/common/CloudinaryImage.jsx
@@ -1,7 +1,8 @@
 import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
 import React from 'react';
+import { Image } from 'cloudinary-react';
 
-function cloudinaryPropsToStr(props) {
+/*function cloudinaryPropsToStr(props) {
   let sb = [];
   for(let k in props)
     sb.push(k+'_'+props[k]);
@@ -36,6 +37,22 @@ const CloudinaryImage = (props, context) => {
     sizes="100vw"
     src={imageUrl}
     {...sizeProps}
+  />
+};*/
+
+const CloudinaryImage = (props, context) => {
+  const cloudinaryCloudName = getSetting('cloudinary.cloudName', 'lesswrong-2-0')
+  
+  return <Image
+    publicId={props.publicId}
+    cloudName={cloudinaryCloudName}
+    quality="auto"
+    responsive={true}
+    width={props.width || "auto"}
+    height={props.height || "auto"}
+    dpr="auto"
+    crop="fill"
+    gravity="custom"
   />
 };
 


### PR DESCRIPTION
Having killed cloudinary-react meant losing some fancy size-detection stuff on sequences pages, which was fairly important. We can probably get that without the library (and get isomorphic SSR while we're at it), but the first attempt didn't do it, so revert temporarily until we figure that out.