### PR TITLE
Assorted fixes

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -66,7 +66,7 @@ const Layout = ({currentUser, children, currentRoute, location, params, client, 
     
     const routeName = currentRoute.name
     const query = location && location.query
-    const { subtitleText = "" } = getHeaderSubtitleData(routeName, query, params, client) || {}
+    const { subtitleText = currentRoute.title || "" } = getHeaderSubtitleData(routeName, query, params, client) || {}
     const siteName = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
     const title = subtitleText ? `${subtitleText} - ${siteName}` : siteName;
 

--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -1,6 +1,7 @@
 import { Components, replaceComponent, getSetting } from 'meteor/vulcan:core';
 // import { InstantSearch} from 'react-instantsearch/dom';
 import React, { Component } from 'react';
+import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { withApollo } from 'react-apollo';
@@ -11,6 +12,7 @@ import Intercom from 'react-intercom';
 import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { customizeTheme } from '../lib/modules/utils/theme';
 import { withStyles, withTheme } from '@material-ui/core/styles';
+import getHeaderSubtitleData from '../lib/modules/utils/getHeaderSubtitleData';
 
 const intercomAppId = getSetting('intercomAppId', 'wtb8z7sj');
 
@@ -38,7 +40,7 @@ const styles = theme => ({
   }
 })
 
-const Layout = ({currentUser, children, currentRoute, params, client, classes, theme}, { userAgent }) => {
+const Layout = ({currentUser, children, currentRoute, location, params, client, classes, theme}, { userAgent }) => {
 
     const showIntercom = currentUser => {
       if (currentUser && !currentUser.hideIntercom) {
@@ -61,13 +63,19 @@ const Layout = ({currentUser, children, currentRoute, params, client, classes, t
         return null
       }
     }
+    
+    const routeName = currentRoute.name
+    const query = location && location.query
+    const { subtitleText = "" } = getHeaderSubtitleData(routeName, query, params, client) || {}
+    const siteName = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
+    const title = subtitleText ? `${subtitleText} - ${siteName}` : siteName;
 
     return <div className={classNames("wrapper", {'alignment-forum': getSetting('AlignmentForum', false)}) } id="wrapper">
       <V0MuiThemeProvider muiTheme={customizeTheme(currentRoute, userAgent, params, client.store)}>
         <div>
           <CssBaseline />
           <Helmet>
-            <title>{getSetting('forumSettings.tabTitle', 'LessWrong 2.0')}</title>
+            <title>{title}</title>
             <link name="material-icons" rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
             <link name="react-instantsearch" rel="stylesheet" type="text/css" href="https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css"/>
             <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"/>
@@ -108,4 +116,4 @@ Layout.contextTypes = {
 
 Layout.displayName = "Layout";
 
-replaceComponent('Layout', Layout, withApollo, withStyles(styles), withTheme());
+replaceComponent('Layout', Layout, withRouter, withApollo, withStyles(styles), withTheme());

--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -16,7 +16,8 @@ class HeadTags extends PureComponent {
   render() {
 
     const url = this.props.url || Utils.getSiteUrl();
-    const title = this.props.title || getSetting('title', 'My App');
+    const appTitle = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
+    const title = this.props.title ? `${this.props.title} - ${appTitle}` : appTitle;
     const description = this.props.description || getSetting('tagline') || getSetting('description');
 
     return (

--- a/packages/lesswrong/components/posts/PostsItem.jsx
+++ b/packages/lesswrong/components/posts/PostsItem.jsx
@@ -245,6 +245,7 @@ class PostsItem extends PureComponent {
         <Paper
           className={classNames(postClass, paperStyle)}
           elevation={0}
+          square={true}
         >
           <div
             className={classNames(classes.root, "posts-item-content", {"selected":this.state.showHighlight})}

--- a/packages/lesswrong/components/search/UsersAutoCompleteHit.jsx
+++ b/packages/lesswrong/components/search/UsersAutoCompleteHit.jsx
@@ -1,10 +1,17 @@
 import { Components, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import moment from 'moment';
+import { withStyles } from '@material-ui/core/styles';
 
-const UsersAutoCompleteHit = ({document, removeItem }) => {
+const styles = theme => ({
+  root: {
+    cursor: "pointer"
+  }
+});
+
+const UsersAutoCompleteHit = ({document, removeItem, classes}) => {
   if (document) {
-    return <div>
+    return <div className={classes.root}>
       <Components.MetaInfo>
         {document.displayName}
       </Components.MetaInfo>
@@ -19,4 +26,4 @@ const UsersAutoCompleteHit = ({document, removeItem }) => {
     return <Components.Loading />
   }
 };
-registerComponent('UsersAutoCompleteHit', UsersAutoCompleteHit);
+registerComponent('UsersAutoCompleteHit', UsersAutoCompleteHit, withStyles(styles));

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -38,6 +38,15 @@ class SequencesPage extends Component {
   showSequence = () => {
     this.setState({edit: false})
   }
+  
+  // Are sequences (as opposed to sequence-posts) a type
+  // of entity that people should be able to comment on?
+  // Maybe, at some point in the future? The current answer
+  // however is "no" (reflected in this function, and the
+  // comments widget being commented out below).
+  commentsEnabled = () => {
+    return false;
+  }
 
   render() {
     const { document, currentUser, loading, classes } = this.props;
@@ -80,9 +89,11 @@ class SequencesPage extends Component {
             <div className="sequences-date">
               {date}
             </div>
-            <div className="sequences-comment-count">
-              {document.commentCount || 0} comments
-            </div>
+            { this.commentsEnabled() && (
+              <div className="sequences-comment-count">
+                {document.commentCount || 0} comments
+              </div>)
+            }
             {document.userId ? <div className="sequences-author-top">
               by <Link className="sequences-author-top-name" to={Users.getProfileUrl(document.user)}>{document.user.displayName}</Link>
             </div> : null}

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -65,6 +65,7 @@ class SequencesPage extends Component {
       const canCreateChapter = Users.canDo(currentUser, 'chapters.new.all')
 
       return (<div className="sequences-page">
+        <Components.HeadTags url={Sequences.getPageUrl(document, true)} title={document.title}/>
         <div className="sequences-banner">
           <div className="sequences-banner-wrapper">
             <NoSSR>

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -101,7 +101,9 @@ class SequencesPage extends Component {
             {canEdit ? <a onClick={this.showEdit}>edit</a> : null}
           </div>}>
           <div className="sequences-description content-body">
-            {document.htmlDescription && <div className="content-body" dangerouslySetInnerHTML={{__html: document.htmlDescription}}/>}
+            <Typography variant="body2">
+              {document.htmlDescription && <div className="content-body" dangerouslySetInnerHTML={{__html: document.htmlDescription}}/>}
+            </Typography>
           </div>
         </Components.Section>
         <div className="sequences-chapters">

--- a/packages/lesswrong/lib/collections/sequences/helpers.js
+++ b/packages/lesswrong/lib/collections/sequences/helpers.js
@@ -1,0 +1,8 @@
+import Sequences from './collection.js';
+import { Utils } from 'meteor/vulcan:core';
+
+Sequences.getPageUrl = function(sequence, isAbsolute = false){
+  const prefix = isAbsolute ? Utils.getSiteUrl().slice(0,-1) : '';
+
+  return `${prefix}/s/${sequence._id}`;
+};

--- a/packages/lesswrong/lib/index.js
+++ b/packages/lesswrong/lib/index.js
@@ -73,6 +73,7 @@ import './collections/bans/admin.js';
 import Sequences from './collections/sequences/collection.js';
 import './collections/sequences/views.js';
 import './collections/sequences/utils.js';
+import './collections/sequences/helpers.js';
 
 import Chapters from './collections/chapters/collection.js';
 import Books from './collections/books/collection.js';

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -1,42 +1,42 @@
 import { addRoute, getSetting} from 'meteor/vulcan:core';
 
-addRoute({ name: 'inbox', path: '/inbox', componentName: 'InboxWrapper' });
-addRoute({ name: 'newPost', path: '/newPost', componentName: 'PostsNewForm' });
+addRoute({ name: 'inbox', path: '/inbox', componentName: 'InboxWrapper', title: "Inbox" });
+addRoute({ name: 'newPost', path: '/newPost', componentName: 'PostsNewForm', title: "New Post" });
 addRoute({ name: 'editPost', path: '/editPost', componentName: 'PostsEditForm' });
-addRoute({ name: 'recentComments', path: '/recentComments', componentName: 'RecentCommentsPage' });
+addRoute({ name: 'recentComments', path: '/recentComments', componentName: 'RecentCommentsPage', title: "Recent Comments" });
 
 // Sunshine Dashboard
-addRoute({ name: 'SunshineDashboard', path: '/sunshine', componentName: 'SunshineDashboard' });
+addRoute({ name: 'SunshineDashboard', path: '/sunshine', componentName: 'SunshineDashboard', title: "Sunshine Dashboard" });
 
 // Sequences
-addRoute({ name: 'sequencesHome', path: '/library', componentName: 'SequencesHome' });
+addRoute({ name: 'sequencesHome', path: '/library', componentName: 'SequencesHome', title: "The Library" });
 addRoute({ name: 'sequences.single.old', path: '/sequences/:_id', componentName: 'SequencesSingle' });
 addRoute({ name: 'sequences.single', path: '/s/:_id', componentName: 'SequencesSingle' });
 addRoute({ name: 'sequencesEdit', path: '/sequencesEdit/:_id', componentName: 'SequencesEditForm'});
-addRoute({ name: 'sequencesNew', path: '/sequencesNew', componentName: 'SequencesNewForm'});
+addRoute({ name: 'sequencesNew', path: '/sequencesNew', componentName: 'SequencesNewForm', title: "New Sequence" });
 addRoute({ name: 'sequencesPost', path: '/s/:sequenceId/p/:postId', componentName: 'SequencesPost'});
 
-addRoute({ name: 'chaptersEdit', path: '/chaptersEdit/:_id', componentName: 'ChaptersEditForm'});
+addRoute({ name: 'chaptersEdit', path: '/chaptersEdit/:_id', componentName: 'ChaptersEditForm', title: "Edit Chapter"});
 
 // Collections
 addRoute({ name: 'collections', path: '/collections/:_id', componentName: 'CollectionsSingle' });
-addRoute({ name: 'Sequences', path: '/sequences', componentName: 'CoreSequences'})
-addRoute({ name: 'Rationality', path: '/rationality', componentName: 'CoreSequences'})
+addRoute({ name: 'Sequences', path: '/sequences', componentName: 'CoreSequences', title: "Rationality: A-Z" })
+addRoute({ name: 'Rationality', path: '/rationality', componentName: 'CoreSequences', title: "Rationality: A-Z" })
 addRoute({ name: 'Rationality.posts.single', path: '/rationality/:slug', componentName: 'PostsSingleSlugWrapper'})
 
-addRoute({ name: 'HPMOR', path: '/hpmor', componentName: 'HPMOR'})
+addRoute({ name: 'HPMOR', path: '/hpmor', componentName: 'HPMOR', title: "Harry Potter and the Methods of Rationality" })
 addRoute({ name: 'HPMOR.posts.single', path: '/hpmor/:slug', componentName: 'PostsSingleSlugWrapper'})
 
-addRoute({ name: 'Codex', path: '/codex', componentName: 'Codex'})
+addRoute({ name: 'Codex', path: '/codex', componentName: 'Codex', title: "The Codex"})
 addRoute({ name: 'Codex.posts.single', path: '/codex/:slug', componentName: 'PostsSingleSlugWrapper'})
 
 
-addRoute({ name: 'Meta', path: '/meta', componentName: 'Meta'})
-addRoute({ name: 'EventsDaily', path: '/pastEvents', componentName: 'EventsDaily'})
+addRoute({ name: 'Meta', path: '/meta', componentName: 'Meta', title: "Meta"})
+addRoute({ name: 'EventsDaily', path: '/pastEvents', componentName: 'EventsDaily', title: "Past Events by Day"})
 addRoute({ name: 'FeaturedPosts', path: '/featured', componentName: 'FeaturedPostsPage'})
-addRoute({ name: 'AllComments', path: '/allComments', componentName: 'AllComments'})
-addRoute({ name: 'CommunityHome', path: '/community', componentName: 'CommunityHome'})
-addRoute({ name: 'MeetupsHome', path: '/meetups', componentName: 'CommunityHome'})
+addRoute({ name: 'AllComments', path: '/allComments', componentName: 'AllComments', title: "All Comments"})
+addRoute({ name: 'CommunityHome', path: '/community', componentName: 'CommunityHome', title: "Community"})
+addRoute({ name: 'MeetupsHome', path: '/meetups', componentName: 'CommunityHome', title: "Community"})
 
 //Route for testing the editor. Useful for debugging
 addRoute({ name: 'searchTest', path: '/searchTest', componentName: 'SearchBar'});
@@ -48,8 +48,8 @@ addRoute({name:'Localgroups.single',   path:'groups/:groupId', componentName: 'L
 addRoute({name:'events.single',   path:'events/:_id(/:slug)', componentName: 'PostsSingle'});
 addRoute({ name: 'groups.post', path: '/g/:groupId/p/:_id', componentName: 'PostsSingle'});
 
-addRoute({ name: 'admin', path: '/admin', componentName: 'AdminHome'});
-addRoute({ name: 'moderation', path: '/moderation', componentName: 'ModerationLog'});
+addRoute({ name: 'admin', path: '/admin', componentName: 'AdminHome', title: "Admin" });
+addRoute({ name: 'moderation', path: '/moderation', componentName: 'ModerationLog', title: "Moderation Log" });
 
 addRoute({name:'about',   path:'/about', componentName: 'PostsSingleRoute', _id:"ANDbEKqbdDuBCQAnM"});
 


### PR DESCRIPTION
Following the strategy of roaming around the site and code base looking for broken things that are quick to fix, and fixing them, without the overhead of going through the issue tracker or deciding whether they're worth it.

 * Don't show "0 comments" on sequences (which can't be commented on)
 * Remove accidentally-added rounding on PostsItem
 * Adds a bunch of missing page titles
 * Pointer style on users-search autocomplete
 * Typography of sequence descriptions
