### PR TITLE
Use the newly added `preload` option on `withList`.

### DIFF
--- a/packages/lesswrong/components/localGroups/LocalGroupsList.jsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsList.jsx
@@ -19,6 +19,7 @@ const options = {
   fragmentName: 'localGroupsHomeFragment',
   totalResolver: false,
   enableCache: true,
+  preload: 10,
 }
 
 registerComponent('LocalGroupsList', LocalGroupsList, [withList, options])

--- a/packages/lesswrong/components/messaging/InboxNavigation.jsx
+++ b/packages/lesswrong/components/messaging/InboxNavigation.jsx
@@ -106,6 +106,7 @@ const conversationOptions = {
   queryName: 'conversationsListQuery',
   fragmentName: 'conversationsListFragment',
   limit: 20,
+  preload: 20,
   totalResolver: false,
 };
 

--- a/packages/lesswrong/components/notifications/NotificationsFullscreenList.jsx
+++ b/packages/lesswrong/components/notifications/NotificationsFullscreenList.jsx
@@ -33,6 +33,7 @@ const options = {
   queryName: 'notificationsFullScreenQuery',
   fragmentName: 'NotificationsList',
   limit: 30,
+  preload: 30,
   totalResolver: false,
 };
 

--- a/packages/lesswrong/components/notifications/NotificationsList.jsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.jsx
@@ -34,6 +34,7 @@ const options = {
   queryName: 'notificationsListQuery',
   fragmentName: 'NotificationsList',
   limit: 20,
+  preload: 20,
   totalResolver: false
 };
 

--- a/packages/lesswrong/components/notifications/NotificationsMenu.jsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.jsx
@@ -122,6 +122,7 @@ const options = {
   fragmentName: 'NotificationsList',
   pollInterval: 0,
   limit: 20,
+  preload: 20,
   totalResolver: false,
 };
 

--- a/packages/lesswrong/components/posts/PostsList.jsx
+++ b/packages/lesswrong/components/posts/PostsList.jsx
@@ -75,7 +75,8 @@ const options = {
   totalResolver: false,
   enableCache: true,
   fetchPolicy: 'cache-and-network',
-  ssr: true
+  ssr: true,
+  preload: 10
 };
 
 registerComponent('PostsList', PostsList, withCurrentUser, [withList, options]);

--- a/packages/lesswrong/components/sequences/ChaptersList.jsx
+++ b/packages/lesswrong/components/sequences/ChaptersList.jsx
@@ -19,6 +19,7 @@ const options = {
   fragmentName: 'ChaptersFragment',
   totalResolver: false,
   enableCache: true,
+  preload: 10,
 }
 
 registerComponent('ChaptersList', ChaptersList, [withList, options])

--- a/packages/lesswrong/components/sequences/SequencesGrid.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.jsx
@@ -22,6 +22,7 @@ const options = {
   fragmentName: 'SequencesPageFragment',
   totalResolver: false,
   enableCache: true,
+  preload: 10,
 }
 
 

--- a/packages/lesswrong/components/sequences/SequencesGridWrapper.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGridWrapper.jsx
@@ -43,7 +43,8 @@ const options = {
   queryName: "SequencesGridWrapperQuery",
   fragmentName: 'SequencesPageFragment',
   totalResolver: true,
-  ssr: true
+  ssr: true,
+  preload: 10
 }
 
 

--- a/packages/lesswrong/components/users/UsersPostsList.jsx
+++ b/packages/lesswrong/components/users/UsersPostsList.jsx
@@ -58,7 +58,9 @@ const options = {
   queryName: 'usersPostsListQuery',
   fragmentName: 'PostsList',
   totalResolver: true,
-  enableCache: true
+  enableCache: true,
+  limit: 20,
+  preload: 20
 };
 
 registerComponent('UsersPostsList', UsersPostsList, withCurrentUser, [withList, options]);


### PR DESCRIPTION
In https://github.com/LessWrong2/Vulcan/pull/14 I added a `preload` option to `withList` which makes `withList` load more results than it needs, so that clicking Load More is instantaneous. This adds usages of that option to LW.

We probably want to hold off on merging this one until we've also migrated to Node 8.12, because this results in larger GraphQL queries to the server, which can cause performance problems on Node 8.11.