### PR TITLE
Fix Daily page jank

### DIFF
--- a/packages/example-forum/lib/components/posts/PostsDailyList.jsx
+++ b/packages/example-forum/lib/components/posts/PostsDailyList.jsx
@@ -89,13 +89,17 @@ class PostsDailyList extends PureComponent {
     const posts = this.props.results;
     const dates = this.getDateRange(this.state.afterLoaded, this.state.before);
 
-    return (
-      <div className="posts-daily">
-        {/* <Components.PostsListHeader /> */}
-        {dates.map((date, index) => <Components.PostsDay key={index} number={index} date={date} posts={this.getDatePosts(posts, date)} networkStatus={this.props.networkStatus} currentUser={this.props.currentUser} />)}
-        {this.state.loading? <Components.PostsLoading /> : <a className="posts-load-more posts-load-more-days" onClick={this.loadMoreDays}><FormattedMessage id="posts.load_more_days"/></a>}
-      </div>
-    )
+    if (this.props.loading && (!posts || !posts.length)) {
+      return <Components.PostsLoading />
+    } else {
+      return (
+        <div className="posts-daily">
+          {/* <Components.PostsListHeader /> */}
+          {dates.map((date, index) => <Components.PostsDay key={index} number={index} date={date} posts={this.getDatePosts(posts, date)} networkStatus={this.props.networkStatus} currentUser={this.props.currentUser} />)}
+          {this.state.loading? <Components.PostsLoading /> : <a className="posts-load-more posts-load-more-days" onClick={this.loadMoreDays}><FormattedMessage id="posts.load_more_days"/></a>}
+        </div>
+      )
+    }
   }
 }
 
@@ -115,6 +119,7 @@ const options = {
   queryName: 'postsDailyListQuery',
   fragmentName: 'PostsList',
   limit: 0,
+  ssr: true,
 };
 
 registerComponent('PostsDailyList', PostsDailyList, withCurrentUser, [withList, options]);

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -2,7 +2,7 @@ import { addRoute, getSetting} from 'meteor/vulcan:core';
 
 // example-forum routes
 addRoute([
-  {name:'posts.daily',      path:'daily',                 componentName: 'PostsDaily'},
+  {name:'posts.daily',      path:'daily',                 componentName: 'PostsDaily', title: "Posts by Day" },
   {name:'users.single',     path:'users/:slug',           componentName: 'UsersSingle'},
   {name:'users.account',    path:'account',               componentName: 'UsersAccount'},
   {name:'users.edit',       path:'users/:slug/edit',      componentName: 'UsersAccount'},


### PR DESCRIPTION
Set page title. Enable SSR. When navigating (so SSR is unavailable), show a single loading indicator instead of a bunch of "No posts on <Date>" rows.