### PR TITLE
Hopefully fix CircleCI tests after Meteor upgrade

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -70,7 +70,6 @@ oauth@1.2.3
 oauth2@1.2.1-rc171.11
 ordered-dict@1.1.0
 percolatestudio:synced-cron@1.1.0
-practicalmeteor:mocha-core@1.0.1
 promise@0.11.1
 random@1.1.0
 rate-limit@1.0.9

--- a/packages/lesswrong/package.js
+++ b/packages/lesswrong/package.js
@@ -40,7 +40,7 @@ Package.onTest(function(api) {
     'vulcan:voting',
     'practicalmeteor:sinon',
     'coffeescript',
-    'practicalmeteor:mocha',
+    'meteortesting:mocha',
   ]);
   // Entry points for tests
   api.mainModule('./testing/client.tests.js', 'client');


### PR DESCRIPTION
Fix our ability to run CircleCI tests. Hopefully. Whether this PR is done is, funnily enough, indicated by CircleCI.