### PR TITLE
TImezone handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "meteor-node-stubs": "^0.2.3",
     "mingo": "^2.2.0",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.21",
     "optics-agent": "^1.1.6",
     "pg": "^6.1.5",
     "pg-promise": "^5.6.7",

--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -1,6 +1,6 @@
 import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
 // import { InstantSearch} from 'react-instantsearch/dom';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
@@ -8,12 +8,14 @@ import { withApollo } from 'react-apollo';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import classNames from 'classnames'
 import Intercom from 'react-intercom';
+import moment from 'moment-timezone';
 
 import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { customizeTheme } from '../lib/modules/utils/theme';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import getHeaderSubtitleData from '../lib/modules/utils/getHeaderSubtitleData';
 import { UserContext } from './common/withUser';
+import { TimezoneContext } from './common/withTimezone';
 
 const intercomAppId = getSetting('intercomAppId', 'wtb8z7sj');
 
@@ -41,76 +43,100 @@ const styles = theme => ({
   }
 })
 
-const Layout = ({currentUser, children, currentRoute, location, params, client, classes, theme}, { userAgent }) => {
-
-  const showIntercom = currentUser => {
-    if (currentUser && !currentUser.hideIntercom) {
-      return <div id="intercome-outer-frame">
-        <Components.ErrorBoundary>
-          <Intercom
-            appID={intercomAppId}
-            user_id={currentUser._id}
-            email={currentUser.email}
-            name={currentUser.displayName}/>
-        </Components.ErrorBoundary>
-      </div>
-    } else if (!currentUser) {
-      return <div id="intercome-outer-frame">
-          <Components.ErrorBoundary>
-            <Intercom appID={intercomAppId}/>
-          </Components.ErrorBoundary>
-        </div>
-    } else {
-      return null
+class Layout extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      timezone: null
+    };
+  }
+  
+  componentDidMount() {
+    const newTimezone = moment.tz.guess();
+    if(this.state.timezone !== newTimezone) {
+      this.setState({
+        timezone: newTimezone
+      });
     }
   }
   
-  const routeName = currentRoute.name
-  const query = location && location.query
-  const { subtitleText = currentRoute.title || "" } = getHeaderSubtitleData(routeName, query, params, client) || {}
-  const siteName = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
-  const title = subtitleText ? `${subtitleText} - ${siteName}` : siteName;
+  render () {
+    const {currentUser, children, currentRoute, location, params, client, classes, theme} = this.props;
+    const {userAgent} = this.context;
 
-  return <UserContext.Provider value={currentUser}>
-    <div className={classNames("wrapper", {'alignment-forum': getSetting('AlignmentForum', false)}) } id="wrapper">
-      <V0MuiThemeProvider muiTheme={customizeTheme(currentRoute, userAgent, params, client.store)}>
-        <div>
-          <CssBaseline />
-          <Helmet>
-            <title>{title}</title>
-            <link name="material-icons" rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
-            <link name="react-instantsearch" rel="stylesheet" type="text/css" href="https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css"/>
-            <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"/>
-            { theme.typography.fontDownloads &&
-                theme.typography.fontDownloads.map(
-                  (url)=><link rel="stylesheet" key={`font-${url}`} href={url}/>
-                )
-            }
-            <meta httpEquiv="Accept-CH" content="DPR, Viewport-Width, Width"/>
-            <link rel="stylesheet" href="https://use.typekit.net/jvr1gjm.css"/>
-          </Helmet>
-          {/* Deactivating this component for now, since it's been causing a good amount of bugs. TODO: Fix this properly */}
-          {/* {currentUser ? <Components.UsersProfileCheck currentUser={currentUser} documentId={currentUser._id} /> : null} */}
-
-          {/* Sign up user for Intercom, if they do not yet have an account */}
-          {showIntercom(currentUser)}
-          <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
-          <Components.Header {...this.props}/>
-
-          <div className={classes.main}>
+    const showIntercom = currentUser => {
+      if (currentUser && !currentUser.hideIntercom) {
+        return <div id="intercome-outer-frame">
+          <Components.ErrorBoundary>
+            <Intercom
+              appID={intercomAppId}
+              user_id={currentUser._id}
+              email={currentUser.email}
+              name={currentUser.displayName}/>
+          </Components.ErrorBoundary>
+        </div>
+      } else if (!currentUser) {
+        return <div id="intercome-outer-frame">
             <Components.ErrorBoundary>
-              <Components.FlashMessages />
-            </Components.ErrorBoundary>
-            {children}
-            <Components.ErrorBoundary>
-              <Components.SunshineSidebar />
+              <Intercom appID={intercomAppId}/>
             </Components.ErrorBoundary>
           </div>
-          {/* <Components.Footer />  Deactivated Footer, since we don't use one. Might want to add one later*/ }
-        </div>
-      </V0MuiThemeProvider>
-    </div>
-  </UserContext.Provider>;
+      } else {
+        return null
+      }
+    }
+  
+    const routeName = currentRoute.name
+    const query = location && location.query
+    const { subtitleText = currentRoute.title || "" } = getHeaderSubtitleData(routeName, query, params, client) || {}
+    const siteName = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
+    const title = subtitleText ? `${subtitleText} - ${siteName}` : siteName;
+
+    return (
+      <UserContext.Provider value={currentUser}>
+      <TimezoneContext.Provider value={this.state.timezone}>
+      <div className={classNames("wrapper", {'alignment-forum': getSetting('AlignmentForum', false)}) } id="wrapper">
+        <V0MuiThemeProvider muiTheme={customizeTheme(currentRoute, userAgent, params, client.store)}>
+          <div>
+            <CssBaseline />
+            <Helmet>
+              <title>{title}</title>
+              <link name="material-icons" rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>
+              <link name="react-instantsearch" rel="stylesheet" type="text/css" href="https://unpkg.com/react-instantsearch-theme-algolia@4.0.0/style.min.css"/>
+              <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"/>
+              { theme.typography.fontDownloads &&
+                  theme.typography.fontDownloads.map(
+                    (url)=><link rel="stylesheet" key={`font-${url}`} href={url}/>
+                  )
+              }
+              <meta httpEquiv="Accept-CH" content="DPR, Viewport-Width, Width"/>
+              <link rel="stylesheet" href="https://use.typekit.net/jvr1gjm.css"/>
+            </Helmet>
+            {/* Deactivating this component for now, since it's been causing a good amount of bugs. TODO: Fix this properly */}
+            {/* {currentUser ? <Components.UsersProfileCheck currentUser={currentUser} documentId={currentUser._id} /> : null} */}
+  
+            {/* Sign up user for Intercom, if they do not yet have an account */}
+            {showIntercom(currentUser)}
+            <noscript className="noscript-warning"> This website requires javascript to properly function. Consider activating javascript to get access to all site functionality. </noscript>
+            <Components.Header {...this.props}/>
+  
+            <div className={classes.main}>
+              <Components.ErrorBoundary>
+                <Components.FlashMessages />
+              </Components.ErrorBoundary>
+              {children}
+              <Components.ErrorBoundary>
+                <Components.SunshineSidebar />
+              </Components.ErrorBoundary>
+            </div>
+            {/* <Components.Footer />  Deactivated Footer, since we don't use one. Might want to add one later*/ }
+          </div>
+        </V0MuiThemeProvider>
+      </div>
+      </TimezoneContext.Provider>
+      </UserContext.Provider>
+    )
+  }
 }
 
 Layout.contextTypes = {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.jsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent, withDocument } from 'meteor/vulcan:core';
 import React from 'react';
-import moment from 'moment';
 import { Comments } from '../../../lib/collections/comments';
 
 const CommentDeletedMetadata = ({document}) => {
@@ -15,7 +14,9 @@ const CommentDeletedMetadata = ({document}) => {
         }
         <span className="comments-item-deleted-info-meta">
           {deletedByUsername && <span> by {deletedByUsername}</span>}
-          {document.deletedDate && <span> {moment(new Date(document.deletedDate)).calendar()}</span>}
+          {document.deletedDate && <span>
+            <Components.CalendarDate date={document.deletedDate}/>
+          </span>}
         </span>
       </p>
     )

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -5,7 +5,6 @@ import { withRouter, Link } from 'react-router';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
 import { Posts } from "../../../lib/collections/posts";
 import { Comments } from '../../../lib/collections/comments'
-import moment from 'moment';
 import Users from 'meteor/vulcan:users';
 import classNames from 'classnames';
 import FontIcon from 'material-ui/FontIcon';
@@ -249,7 +248,7 @@ class CommentsItem extends Component {
       <div className="comments-item-bottom">
         { blockedReplies &&
           <div className="comment-blocked-replies">
-            A moderator has deactivated replies on this comment until {moment(new Date(comment.repliesBlockedUntil)).calendar()}
+            A moderator has deactivated replies on this comment until <Components.CalendarDate date={comment.repliesBlockedUntil}/>
           </div>
         }
         <div>

--- a/packages/lesswrong/components/comments/CommentsListSection.jsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.jsx
@@ -97,7 +97,7 @@ class CommentsListSection extends Component {
         className={this.props.classes.inline}
       >
         Highlighting new comments since <a className={classes.link} onClick={this.handleClick}>
-          {moment(highlightDate).calendar()}
+          <Components.CalendarDate date={highlightDate}/>
         </a>
         <Menu
           anchorEl={anchorEl}

--- a/packages/lesswrong/components/comments/LastVisitList.jsx
+++ b/packages/lesswrong/components/comments/LastVisitList.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Components, registerComponent, withList } from 'meteor/vulcan:core';
 import MenuItem from '@material-ui/core/MenuItem'
 import { LWEvents } from '../../lib/collections/lwevents/collection.js'
-import moment from 'moment';
 import withUser from '../common/withUser';
 
 class LastVisitList extends Component {
@@ -11,7 +10,7 @@ class LastVisitList extends Component {
     const { results, loading, clickCallback } = this.props
     if (!loading && results) {
       return (results.map((event) =>
-          <MenuItem key={event._id} dense onClick={() => clickCallback(event.createdAt)}>Visit at: {moment(event.createdAt).calendar().toString()} </MenuItem>
+          <MenuItem key={event._id} dense onClick={() => clickCallback(event.createdAt)}>Visit at: <Components.CalendarDate date={event.createdAt}/> </MenuItem>
         ))
     } else {
       return <Components.Loading />

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -1,6 +1,5 @@
 import { Components, getRawComponent, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import moment from 'moment';
 import { Posts } from '../../lib/collections/posts';
 import { Link } from 'react-router';
 import FontIcon from 'material-ui/FontIcon';
@@ -89,7 +88,7 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
                   <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
                     <div className="comments-item-origin">
                       <div className="comments-item-date">
-                        {moment(new Date(comment.postedAt)).fromNow()}
+                        <Components.FromNowDate date={comment.postedAt}/>
                         <FontIcon className="material-icons comments-item-permalink"> link </FontIcon>
                       </div>
                       { showTitle && comment.post && comment.post.title}

--- a/packages/lesswrong/components/common/CalendarDate.jsx
+++ b/packages/lesswrong/components/common/CalendarDate.jsx
@@ -1,0 +1,11 @@
+import { registerComponent } from 'meteor/vulcan:core';
+import React from 'react';
+import moment from 'moment-timezone';
+import Tooltip from '@material-ui/core/Tooltip';
+import withTimezone from '../common/withTimezone';
+
+const CalendarDate = ({date, timezone}) => {
+  return <span>{moment(new Date(date)).tz(timezone).calendar()}</span>
+};
+
+registerComponent('CalendarDate', CalendarDate, withTimezone);

--- a/packages/lesswrong/components/common/CalendarDate.jsx
+++ b/packages/lesswrong/components/common/CalendarDate.jsx
@@ -4,6 +4,9 @@ import moment from 'moment-timezone';
 import Tooltip from '@material-ui/core/Tooltip';
 import withTimezone from '../common/withTimezone';
 
+/// A date rendered with moment().calendar(). Includes a plethora of special
+/// cases like "Yesterday at 1:00 PM", "Last Tuesday at 1:00 PM". Turns into a
+/// more normal date (in locale format) if more than a week away.
 const CalendarDate = ({date, timezone}) => {
   return <span>{moment(new Date(date)).tz(timezone).calendar()}</span>
 };

--- a/packages/lesswrong/components/common/CalendarDate.jsx
+++ b/packages/lesswrong/components/common/CalendarDate.jsx
@@ -1,7 +1,6 @@
 import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import moment from 'moment-timezone';
-import Tooltip from '@material-ui/core/Tooltip';
 import withTimezone from '../common/withTimezone';
 
 /// A date rendered with moment().calendar(). Includes a plethora of special

--- a/packages/lesswrong/components/common/FromNowDate.jsx
+++ b/packages/lesswrong/components/common/FromNowDate.jsx
@@ -1,12 +1,13 @@
 import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import Tooltip from '@material-ui/core/Tooltip';
+import withTimezone from '../common/withTimezone';
 
-const FromNowDate = ({date}) => {
-  return <Tooltip title={moment(new Date(date)).format('LLL')}>
+const FromNowDate = ({date, timezone}) => {
+  return <Tooltip title={moment(new Date(date)).tz(timezone).format('LLL z')}>
       <span>{moment(new Date(date)).fromNow()}</span>
   </Tooltip>
 };
 
-registerComponent('FromNowDate', FromNowDate);
+registerComponent('FromNowDate', FromNowDate, withTimezone);

--- a/packages/lesswrong/components/common/SimpleDate.jsx
+++ b/packages/lesswrong/components/common/SimpleDate.jsx
@@ -4,12 +4,13 @@ import moment from 'moment-timezone';
 import Tooltip from '@material-ui/core/Tooltip';
 import withTimezone from '../common/withTimezone';
 
-/// A relative time/date, like "4d". Hover over for the actual (non-relative)
-/// date/time.
-const FromNowDate = ({date, timezone}) => {
+/// A simple date, with no special cases, like "Jan 1, 2020". Hover over to
+/// also see the time.
+const SimpleDate = ({date, timezone}) => {
   return <Tooltip title={moment(new Date(date)).tz(timezone).format('LLL z')}>
-      <span>{moment(new Date(date)).fromNow()}</span>
+      <span>{moment(new Date(date)).format("MMM DD, YYYY")}</span>
   </Tooltip>
 };
 
-registerComponent('FromNowDate', FromNowDate, withTimezone);
+registerComponent('SimpleDate', SimpleDate, withTimezone);
+

--- a/packages/lesswrong/components/common/withTimezone.jsx
+++ b/packages/lesswrong/components/common/withTimezone.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+
+export const TimezoneContext = React.createContext('timezone');
+
+// Higher-order component for providing the user's timezone. Provides two
+// props: timezone and timezoneIsKnown. If we know the user's timezone, then
+// timezone is that timezone (a string, for use with moment-timezone, such as
+// "America/New_York") and timezoneIsKnown is true; otherwise timezone is "GMT"
+// and timezoneIsKnown is false.
+export default function withTimezone(Component) {
+  return function WithTimezoneComponent(props) {
+    return (
+      <TimezoneContext.Consumer>
+        {timezone => <Component {...props}
+          timezone={timezone ? timezone : "GMT"}
+          timezoneIsKnown={!!timezone}
+        />}
+      </TimezoneContext.Consumer>
+    );
+  }
+}

--- a/packages/lesswrong/components/localGroups/EventTime.jsx
+++ b/packages/lesswrong/components/localGroups/EventTime.jsx
@@ -1,12 +1,13 @@
 import { Components, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import moment from 'moment';
+import withTimezone from '../common/withTimezone';
 
-const EventTime = ({post}) => {
-  const start = post.startTime;
-  const end = post.endTime;
+const EventTime = ({post, timezone}) => {
+  const start = post.startTime ? moment(post.startTime).tz(timezone) : null;
+  const end = post.endTime ? moment(post.endTime).tz(timezone) : null;
   
-  const timeFormat = 'h:mm A';
+  const timeFormat = 'h:mm A z';
   const dateFormat = 'MMMM Do YY, '+timeFormat
   const calendarFormat = {sameElse : dateFormat}
   
@@ -21,7 +22,7 @@ const EventTime = ({post}) => {
   // less sense, but users can enter silly things.)
   else if (!start || !end) {
     const eventTime = start ? start : end;
-    return moment(eventTime).calendar({}, calendarFormat)
+    return eventTime.calendar({}, calendarFormat)
   }
   // Both start end end time specified
   else {
@@ -29,19 +30,15 @@ const EventTime = ({post}) => {
     //   January 15 13:00-15:00
     // If they're on different dates, render it like:
     //   January 15 19:00 to January 16 12:00
-    if (moment(start).format("YYYY-MM-DD") === moment(end).format("YYYY-MM-DD")) {
-      return moment(start).format(dateFormat) + '-' + moment(end).format(timeFormat);
+    if (start.format("YYYY-MM-DD") === end.format("YYYY-MM-DD")) {
+      return start.format(dateFormat) + '-' + end.format(timeFormat);
     } else {
       return (<span>
-        <span>
-          From: {moment(start).calendar({}, calendarFormat)}
-        </span>
-        <span>
-          To: {moment(end).calendar({}, calendarFormat)}
-        </span>
+        {start.calendar({}, calendarFormat)}
+        to {end.calendar({}, calendarFormat)}
       </span>);
     }
   }
 };
 
-registerComponent('EventTime', EventTime);
+registerComponent('EventTime', EventTime, withTimezone);

--- a/packages/lesswrong/components/localGroups/EventTime.jsx
+++ b/packages/lesswrong/components/localGroups/EventTime.jsx
@@ -1,0 +1,47 @@
+import { Components, registerComponent } from 'meteor/vulcan:core';
+import React from 'react';
+import moment from 'moment';
+
+const EventTime = ({post}) => {
+  const start = post.startTime;
+  const end = post.endTime;
+  
+  const timeFormat = 'h:mm A';
+  const dateFormat = 'MMMM Do YY, '+timeFormat
+  const calendarFormat = {sameElse : dateFormat}
+  
+  // Neither start nor end time specified
+  if (!start && !end) {
+    return "TBD";
+  }
+  // Start time specified, end time missing. Use
+  // moment.calendar, which has a bunch of its own special
+  // cases like "tomorrow".
+  // (Or vise versa. Specifying end time without specifying start time makes
+  // less sense, but users can enter silly things.)
+  else if (!start || !end) {
+    const eventTime = start ? start : end;
+    return moment(eventTime).calendar({}, calendarFormat)
+  }
+  // Both start end end time specified
+  else {
+    // If the start and end time are on the same date, render it like:
+    //   January 15 13:00-15:00
+    // If they're on different dates, render it like:
+    //   January 15 19:00 to January 16 12:00
+    if (moment(start).format("YYYY-MM-DD") === moment(end).format("YYYY-MM-DD")) {
+      return moment(start).format(dateFormat) + '-' + moment(end).format(timeFormat);
+    } else {
+      return (<span>
+        <span>
+          From: {moment(start).calendar({}, calendarFormat)}
+        </span>
+        <span>
+          To: {moment(end).calendar({}, calendarFormat)}
+        </span>
+      </span>);
+    }
+  }
+};
+
+registerComponent('EventTime', EventTime);

--- a/packages/lesswrong/components/localGroups/EventTime.jsx
+++ b/packages/lesswrong/components/localGroups/EventTime.jsx
@@ -3,13 +3,34 @@ import React from 'react';
 import moment from 'moment';
 import withTimezone from '../common/withTimezone';
 
-const EventTime = ({post, timezone}) => {
+function getDateFormat(dense, isThisYear) {
+  if (dense) {
+    if (isThisYear) {
+      return 'DD MMM'; // 5 Jan
+    } else {
+      return 'DD MMM YYYY'; // 5 Jan 2020
+    }
+  } else {
+    return 'Do MMMM YYYY'; // 5th January 2020
+  }
+}
+
+const EventTime = ({post, timezone, dense}) => {
   const start = post.startTime ? moment(post.startTime).tz(timezone) : null;
   const end = post.endTime ? moment(post.endTime).tz(timezone) : null;
   
-  const timeFormat = 'h:mm A z';
-  const dateFormat = 'MMMM Do YY, '+timeFormat
-  const calendarFormat = {sameElse : dateFormat}
+  const isThisYear = moment(new Date()).format("YYYY") === moment(start).format("YYYY");
+  
+  // Date and time formats
+  const timeFormat = 'h:mm A z'; // 11:30 AM PDT
+  const dateFormat = getDateFormat(dense, isThisYear);
+  const dateAndTimeFormat = dateFormat+', '+timeFormat;
+  const calendarFormat = {sameElse : dateAndTimeFormat}
+  
+  // Alternate formats omitting the timezone, for the start time in a
+  // start-end range.
+  const startTimeFormat = 'h:mm A'; // 11:30 AM
+  const startCalendarFormat = {sameElse: dateFormat+', '+startTimeFormat};
   
   // Neither start nor end time specified
   if (!start && !end) {
@@ -27,14 +48,16 @@ const EventTime = ({post, timezone}) => {
   // Both start end end time specified
   else {
     // If the start and end time are on the same date, render it like:
-    //   January 15 13:00-15:00
+    //   January 15, 13:00-15:00 PDT
     // If they're on different dates, render it like:
-    //   January 15 19:00 to January 16 12:00
+    //   January 15, 19:00 to January 16 12:00 PDT
+    // In both cases we avoid duplicating the timezone.
     if (start.format("YYYY-MM-DD") === end.format("YYYY-MM-DD")) {
-      return start.format(dateFormat) + '-' + end.format(timeFormat);
+      return start.format(dateFormat) + ', ' +
+        start.format(startTimeFormat) + '-' + end.format(timeFormat);
     } else {
       return (<span>
-        {start.calendar({}, calendarFormat)}
+        {start.calendar({}, startCalendarFormat)}
         to {end.calendar({}, calendarFormat)}
       </span>);
     }

--- a/packages/lesswrong/components/messaging/InboxNavigation.jsx
+++ b/packages/lesswrong/components/messaging/InboxNavigation.jsx
@@ -8,7 +8,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { Components, registerComponent, withList } from 'meteor/vulcan:core';
-import moment from 'moment';
 import Conversations from '../../lib/collections/conversations/collection.js';
 import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router';
@@ -89,7 +88,7 @@ class InboxNavigation extends Component {
                 <Typography variant="body2" className={classes.conversationItem}>
                   { Conversations.getTitle(conversation, currentUser) }
                   <span className={classes.conversationItemLatestActivity}>
-                    {conversation.latestActivity && moment(new Date(conversation.latestActivity)).fromNow()}
+                    {conversation.latestActivity && <Components.FromNowDate date={conversation.latestActivity}/>}
                   </span>
                 </Typography>
             </Link>)

--- a/packages/lesswrong/components/messaging/MessageItem.jsx
+++ b/packages/lesswrong/components/messaging/MessageItem.jsx
@@ -11,7 +11,6 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import grey from '@material-ui/core/colors/grey';
 import classNames from 'classnames';
-import moment from 'moment';
 
 const styles = theme => ({
   message: {
@@ -50,7 +49,7 @@ class MessageItem extends Component {
   render() {
     const { currentUser, message, classes } = this.props;
 
-    const isCurrentUser = currentUser._id == message.user._id
+    const isCurrentUser = (currentUser && message && message.user) && currentUser._id == message.user._id
 
     if (message.htmlBody) {
       const htmlBody = {__html: message.htmlBody};
@@ -61,7 +60,9 @@ class MessageItem extends Component {
               {message.user && <span className={classes.usersName}>
                 <Components.UsersName user={message.user}/>
               </span>}
-              {message.createdAt && <span className={classes.createdAt}>{moment(message.createdAt).fromNow()}</span>}
+              {message.createdAt && <span className={classes.createdAt}>
+                <Components.FromNowDate date={message.createdAt}/>
+              </span>}
             </div>
             <div dangerouslySetInnerHTML={htmlBody} className={classes.messageBody}></div>
           </Typography>

--- a/packages/lesswrong/components/posts/EventsDaily.jsx
+++ b/packages/lesswrong/components/posts/EventsDaily.jsx
@@ -18,7 +18,8 @@ class EventsDaily extends Component {
     return <div className="posts-daily-wrapper">
       <Components.Section title="Past Events by Day">
         <div className="posts-daily-content-wrapper">
-          <Components.PostsDailyList title="Past Events by Day" terms={terms}/>
+          <Components.PostsDailyList title="Past Events by Day"
+            terms={terms} days={numberOfDays}/>
         </div>
       </Components.Section>
     </div>

--- a/packages/lesswrong/components/posts/PostsDaily.jsx
+++ b/packages/lesswrong/components/posts/PostsDaily.jsx
@@ -42,7 +42,8 @@ class PostsDaily extends Component {
     return <div className="posts-daily-wrapper">
       <Components.Section title="Posts by Day" titleComponent={this.renderTitle()}>
         <div className="posts-daily-content-wrapper">
-          <Components.PostsDailyList title="Posts by Day" terms={terms}/>
+          <Components.PostsDailyList title="Posts by Day"
+            terms={terms} days={numberOfDays}/>
         </div>
       </Components.Section>
     </div>

--- a/packages/lesswrong/components/posts/PostsDailyList.jsx
+++ b/packages/lesswrong/components/posts/PostsDailyList.jsx
@@ -113,8 +113,6 @@ class PostsDailyList extends PureComponent {
     const posts = this.props.results;
     const dates = this.getDateRange(this.state.afterLoaded, this.state.before, posts);
     
-    const postsByDate = this.groupByDate(posts);
-
     if (this.props.loading && (!posts || !posts.length)) {
       return <Components.PostsLoading />
     } else {

--- a/packages/lesswrong/components/posts/PostsDailyList.jsx
+++ b/packages/lesswrong/components/posts/PostsDailyList.jsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
 import { Posts } from '../../lib/collections/posts';
 import { withCurrentUser, withList, getSetting, Components, getRawComponent, registerComponent } from 'meteor/vulcan:core';
+import withTimezone from '../common/withTimezone';
 
 class PostsDailyList extends PureComponent {
 
@@ -16,37 +17,60 @@ class PostsDailyList extends PureComponent {
       daysLoaded: props.days,
       afterLoaded: props.terms.after,
       before: props.terms.before,
-      loading: true,
+      //loading: true,
     };
   }
 
   // intercept prop change and only show more days once data is done loading
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.networkStatus === 2) {
-      this.setState({loading: true});
+      //this.setState({loading: true});
     } else {
       this.setState((prevState, props) => ({
-        loading: false,
+        //loading: false,
         daysLoaded: prevState.days,
         afterLoaded: prevState.after,
       }));
     }
   }
 
-  // return date objects for all the dates in a range
-  getDateRange(after, before) {
-    const mAfter = moment.utc(after, 'YYYY-MM-DD').local();
-    const mBefore = moment.utc(before, 'YYYY-MM-DD').local();
+  // Return a date string for each date which should have a section. This
+  // includes all dates in the range, *except* that if the newest date has no
+  // posts, it's omitted. (Because the end of the range is some fraction of a
+  // day into the future, which would otherwise sometimes result in an awkward
+  // empty slot for tomorrow, depending on the current time of day.)
+  getDateRange(after, before, posts) {
+    const mAfter = moment.utc(after, 'YYYY-MM-DD');
+    const mBefore = moment.utc(before, 'YYYY-MM-DD');
     const daysCount = mBefore.diff(mAfter, 'days') + 1;
     const range = _.range(daysCount).map(
-      i => moment.utc(before, 'YYYY-MM-DD').local().subtract(i, 'days').startOf('day')
+      i => moment.utc(before, 'YYYY-MM-DD').subtract(i, 'days')
+        .tz(this.props.timezone)
+        .format('YYYY-MM-DD')
     );
-    return range;
+    
+    if(this.getDatePosts(posts, range[0]).length == 0) {
+      return _.rest(range);
+    } else {
+      return range;
+    }
   }
 
   getDatePosts(posts, date) {
     const { timeField } = this.props.terms
-    return _.filter(posts, post => moment(new Date(timeField ? post[timeField] : post.postedAt)).startOf('day').isSame(date, 'day'));
+    return _.filter(posts, post =>
+      moment(new Date(timeField ? post[timeField] : post.postedAt))
+        .tz(this.props.timezone)
+        .format('YYYY-MM-DD') === date);
+  }
+  
+  groupByDate(posts) {
+    const { timeField } = this.props.terms
+    
+    return _.groupBy(posts, post =>
+      moment(new Date(timeField ? post[timeField] : post.postedAt))
+        .tz(this.props.timezone)
+        .format('YYYY-MM-DD'));
   }
 
   // variant 1: reload everything each time (works with polling)
@@ -87,7 +111,9 @@ class PostsDailyList extends PureComponent {
 
   render() {
     const posts = this.props.results;
-    const dates = this.getDateRange(this.state.afterLoaded, this.state.before);
+    const dates = this.getDateRange(this.state.afterLoaded, this.state.before, posts);
+    
+    const postsByDate = this.groupByDate(posts);
 
     if (this.props.loading && (!posts || !posts.length)) {
       return <Components.PostsLoading />
@@ -95,8 +121,15 @@ class PostsDailyList extends PureComponent {
       return (
         <div className="posts-daily">
           {/* <Components.PostsListHeader /> */}
-          {dates.map((date, index) => <Components.PostsDay key={index} number={index} date={date} posts={this.getDatePosts(posts, date)} networkStatus={this.props.networkStatus} currentUser={this.props.currentUser} />)}
-          {this.state.loading? <Components.PostsLoading /> : <a className="posts-load-more posts-load-more-days" onClick={this.loadMoreDays}><FormattedMessage id="posts.load_more_days"/></a>}
+          {dates.map((date, index) =>
+            <Components.PostsDay key={index} number={index}
+              date={moment(date)}
+              posts={this.getDatePosts(posts, date)}
+              networkStatus={this.props.networkStatus}
+              currentUser={this.props.currentUser}
+            />
+          )}
+          {this.props.loadingMore ? <Components.PostsLoading /> : <a className="posts-load-more posts-load-more-days" onClick={this.loadMoreDays}><FormattedMessage id="posts.load_more_days"/></a>}
         </div>
       )
     }
@@ -122,4 +155,4 @@ const options = {
   ssr: true,
 };
 
-registerComponent('PostsDailyList', PostsDailyList, withCurrentUser, [withList, options]);
+registerComponent('PostsDailyList', PostsDailyList, withCurrentUser, [withList, options], withTimezone);

--- a/packages/lesswrong/components/posts/PostsItemMeta.jsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.jsx
@@ -26,7 +26,7 @@ const PostsItemMeta = ({currentUser, post}) => {
         {parseInt(post.wordCount/300) || 1 } min read
       </C.MetaInfo>}
       { post.isEvent && post.startTime && <C.MetaInfo>
-        <Components.CalendarDate date={post.startTime}/>
+        <C.EventTime post={post}/>
       </C.MetaInfo>}
       { post.isEvent && post.location && <C.MetaInfo>
         {post.location}

--- a/packages/lesswrong/components/posts/PostsItemMeta.jsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.jsx
@@ -26,7 +26,7 @@ const PostsItemMeta = ({currentUser, post}) => {
         {parseInt(post.wordCount/300) || 1 } min read
       </C.MetaInfo>}
       { post.isEvent && post.startTime && <C.MetaInfo>
-        <C.EventTime post={post}/>
+        <C.EventTime post={post} dense={true} />
       </C.MetaInfo>}
       { post.isEvent && post.location && <C.MetaInfo>
         {post.location}

--- a/packages/lesswrong/components/posts/PostsItemMeta.jsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.jsx
@@ -2,7 +2,6 @@ import { Components as C, registerComponent, getSetting } from 'meteor/vulcan:co
 import { Posts } from '../../lib/collections/posts';
 import React from 'react';
 import withUser from '../common/withUser';
-import moment from 'moment';
 
 const PostsItemMeta = ({currentUser, post}) => {
   const baseScore = getSetting('AlignmentForum', false) ? post.afBaseScore : post.baseScore
@@ -27,7 +26,7 @@ const PostsItemMeta = ({currentUser, post}) => {
         {parseInt(post.wordCount/300) || 1 } min read
       </C.MetaInfo>}
       { post.isEvent && post.startTime && <C.MetaInfo>
-        {moment(post.startTime).calendar()}
+        <Components.CalendarDate date={post.startTime}/>
       </C.MetaInfo>}
       { post.isEvent && post.location && <C.MetaInfo>
         {post.location}

--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -18,7 +18,6 @@ import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import { Posts } from '../../lib/collections/posts';
 import { Comments } from '../../lib/collections/comments'
-import moment from 'moment';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { postBodyStyles } from '../../themes/stylePiping'
@@ -210,7 +209,7 @@ class PostsPage extends Component {
       </div>
     } else {
       return <div className={classes.subtitle}>
-        {moment(post.postedAt).format('MMM D, YYYY')}
+        <Components.SimpleDate date={post.postedAt}/>
       </div>
     }
   }

--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -99,12 +99,6 @@ const styles = theme => ({
       lineHeight: 1.25,
       fontWeight: 600,
     },
-    eventTimeStart: {
-      display: "inline-block",
-    },
-    eventTimeEnd: {
-      display: "inline-block",
-    },
     
     eventLocation: {
       fontSize: "14px",
@@ -212,52 +206,12 @@ class PostsPage extends Component {
     const { classes } = this.props
     if (post.isEvent) {
       return <div className={classes.eventTimes}>
-        {this.renderEventTimes(post.startTime, post.endTime)}
+        <Components.EventTime post={post}/>
       </div>
     } else {
       return <div className={classes.subtitle}>
         {moment(post.postedAt).format('MMM D, YYYY')}
       </div>
-    }
-  }
-  
-  renderEventTimes = (start, end) => {
-    const classes = this.props.classes;
-    const timeFormat = 'h:mm A';
-    const dateFormat = 'MMMM Do YY, '+timeFormat
-    const calendarFormat = {sameElse : dateFormat}
-    
-    // Neither start nor end time specified
-    if (!start && !end) {
-      return "TBD";
-    }
-    // Start time specified, end time missing. Use
-    // moment.calendar, which has a bunch of its own special
-    // cases like "tomorrow".
-    // (Or vise versa. Specifying end time without specifying start time makes
-    // less sense, but users can enter silly things.)
-    else if (!start || !end) {
-      const eventTime = start ? start : end;
-      return moment(eventTime).calendar({}, calendarFormat)
-    }
-    // Both start end end time specified
-    else {
-      // If the start and end time are on the same date, render it like:
-      //   January 15 13:00-15:00
-      // If they're on different dates, render it like:
-      //   January 15 19:00 to January 16 12:00
-      if (moment(start).format("YYYY-MM-DD") === moment(end).format("YYYY-MM-DD")) {
-        return moment(start).format(dateFormat) + '-' + moment(end).format(timeFormat);
-      } else {
-        return (<span>
-          <span className={classes.eventTimeStart}>
-            From: {moment(start).calendar({}, calendarFormat)}
-          </span>
-          <span className={classes.eventTimeEnd}>
-            To: {moment(end).calendar({}, calendarFormat)}
-          </span>
-        </span>);
-      }
     }
   }
 

--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -206,7 +206,7 @@ class PostsPage extends Component {
     const { classes } = this.props
     if (post.isEvent) {
       return <div className={classes.eventTimes}>
-        <Components.EventTime post={post}/>
+        <Components.EventTime post={post} dense={false} />
       </div>
     } else {
       return <div className={classes.subtitle}>

--- a/packages/lesswrong/components/search/CommentsSearchHit.jsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.jsx
@@ -1,5 +1,4 @@
 import { Components, registerComponent} from 'meteor/vulcan:core';
-import moment from 'moment';
 import { Link } from 'react-router';
 import { Snippet } from 'react-instantsearch/dom';
 import { withStyles } from '@material-ui/core/styles';
@@ -27,7 +26,7 @@ const CommentsSearchHit = ({hit, clickAction, classes}) => {
         <Components.MetaInfo>{hit.authorDisplayName}</Components.MetaInfo>
         <Components.MetaInfo>{hit.baseScore} points </Components.MetaInfo>
         <Components.MetaInfo>
-          {moment(new Date(hit.postedAt)).fromNow()}
+          <Components.FromNowDate date={hit.postedAt}/>
         </Components.MetaInfo>
       </div>
       <div className={classes.snippet}>

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.jsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Components, registerComponent} from 'meteor/vulcan:core';
 import { Posts } from '../../lib/collections/posts';
-import moment from 'moment';
 import { Link, withRouter } from 'react-router';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -33,7 +32,9 @@ const PostsListEditorSearchHit = ({hit, clickAction, router, classes}) => {
       <Components.MetaInfo>
         {hit.baseScore} points
       </Components.MetaInfo>
-      {hit.postedAt && <Components.MetaInfo> {moment(new Date(hit.postedAt)).fromNow()} </Components.MetaInfo>}
+      {hit.postedAt && <Components.MetaInfo>
+        <Components.FromNowDate date={hit.postedAt}/>
+      </Components.MetaInfo>}
       <Link to={Posts.getLink(hit)} target={Posts.getLinkTarget(hit)} className={classes.postLink}>
         (Link)
       </Link>

--- a/packages/lesswrong/components/search/PostsSearchHit.jsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Components, registerComponent} from 'meteor/vulcan:core';
 import { Posts } from '../../lib/collections/posts';
-import moment from 'moment';
 import { Link, withRouter } from 'react-router';
 import { Snippet} from 'react-instantsearch/dom';
 import { withStyles } from '@material-ui/core/styles';
@@ -37,7 +36,9 @@ const PostsSearchHit = ({hit, clickAction, router, classes}) => {
         <Components.MetaInfo>
           {hit.baseScore} points
         </Components.MetaInfo>
-        {hit.postedAt && <Components.MetaInfo> {moment(new Date(hit.postedAt)).fromNow()} </Components.MetaInfo>}
+        {hit.postedAt && <Components.MetaInfo>
+          <Components.FromNowDate date={hit.postedAt}/>
+        </Components.MetaInfo>}
         <div><Snippet attributeName="body" hit={hit} tagName="mark" /></div>
     </Link>
   </div>

--- a/packages/lesswrong/components/search/SequencesSearchHit.jsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.jsx
@@ -1,5 +1,4 @@
 import { Components, registerComponent} from 'meteor/vulcan:core';
-import moment from 'moment';
 import { Link } from 'react-router';
 
 import React, { PureComponent } from 'react';
@@ -15,7 +14,9 @@ const SequencesSearchHit = ({hit, clickAction}) => {
           <div className="sequences-item-meta">
             <div className="sequences-item-author">{hit.authorDisplayName}</div>
             <div className="sequences-item-karma">{hit.karma} points </div>
-            <div className="sequences-item-created-date"> {moment(new Date(hit.createdAt)).fromNow()}</div>
+            <div className="sequences-item-created-date">
+              <Components.FromNowDate date={hit.createdAt}/>
+            </div>
           </div>
         </div>
       </Link>

--- a/packages/lesswrong/components/search/UsersAutoCompleteHit.jsx
+++ b/packages/lesswrong/components/search/UsersAutoCompleteHit.jsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import moment from 'moment';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
@@ -19,7 +18,7 @@ const UsersAutoCompleteHit = ({document, removeItem, classes}) => {
         {document.karma} points
       </Components.MetaInfo>
       <Components.MetaInfo>
-        {moment(new Date(document.createdAt)).fromNow()}
+        <Components.FromNowDate date={document.createdAt}/>
       </Components.MetaInfo>
     </div>
   } else {

--- a/packages/lesswrong/components/search/UsersSearchHit.jsx
+++ b/packages/lesswrong/components/search/UsersSearchHit.jsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent} from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
-import moment from 'moment';
 import { Link } from 'react-router';
 import React, { PureComponent } from 'react';
 import { withStyles } from '@material-ui/core/styles';
@@ -19,7 +18,7 @@ const isLeftClick = (event) => {
 const UsersSearchHit = ({hit, clickAction, classes}) => <div className={classes.root}>
   <Link to={Users.getProfileUrl(hit)} onClick={(event) => isLeftClick(event) && clickAction()}>
     <Components.MetaInfo>
-      {moment(new Date(hit.createdAt)).fromNow()}
+      <Components.FromNowDate date={hit.createdAt}/>
     </Components.MetaInfo>
     <Components.MetaInfo>
       {hit.displayName}

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -6,7 +6,6 @@ import {
 } from 'meteor/vulcan:core';
 import PropTypes from 'prop-types';
 import Sequences from '../../lib/collections/sequences/collection.js';
-import moment from 'moment';
 import NoSSR from 'react-no-ssr';
 import { Link } from 'react-router';
 import Users from 'meteor/vulcan:users';
@@ -63,7 +62,6 @@ class SequencesPage extends Component {
         successCallback={this.showSequence}
         cancelCallback={this.showSequence} />
     } else {
-      const date = moment(new Date(document.createdAt)).format('MMM DD, YYYY');
       const canEdit = Users.canDo(currentUser, 'sequences.edit.all') || (Users.canDo(currentUser, 'sequences.edit.own') && Users.owns(currentUser, document))
       const canCreateChapter = Users.canDo(currentUser, 'chapters.new.all')
 
@@ -90,7 +88,9 @@ class SequencesPage extends Component {
         </div>
         <Components.Section titleComponent={
           <div className="sequences-meta">
-            <Typography variant="subheading"><strong>{date}</strong></Typography>
+            <Typography variant="subheading"><strong>
+              <Components.SimpleDate date={document.createdAt}/>
+            </strong></Typography>
             { this.commentsEnabled() && (
               <div className="sequences-comment-count">
                 {document.commentCount || 0} comments

--- a/packages/lesswrong/components/sunshineDashboard/AdminHome.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AdminHome.jsx
@@ -4,7 +4,6 @@ import { Bans } from '../../lib/collections/bans';
 import { LWEvents } from '../../lib/collections/lwevents';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
 import Users from 'meteor/vulcan:users';
-import moment from 'moment';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 import withUser from '../common/withUser';
@@ -20,7 +19,7 @@ const UserIPsDisplay = ({column, document}) => {
 }
 
 const DateDisplay = ({column, document}) => {
-  return <div>{document[column.name] && moment(document[column.name]).fromNow()}</div>
+  return <div>{document[column.name] && <Components.FromNowDate date={document[column.name]}/>}</div>
 }
 
 const EventPropertiesDisplay = ({column, document}) => {

--- a/packages/lesswrong/components/sunshineDashboard/ModerationLog.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationLog.jsx
@@ -3,11 +3,10 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 import { Posts } from '../../lib/collections/posts';
 import { Comments } from '../../lib/collections/comments'
 import Users from 'meteor/vulcan:users';
-import moment from 'moment';
 import { Link } from 'react-router'
 
 const DateDisplay = ({column, document}) => {
-  return <div>{document[column.name] && moment(document[column.name]).fromNow()}</div>
+  return <div>{document[column.name] && <Components.FromNowDate date={document[column.name]}/>}</div>
 }
 
 const PostDisplay = ({column, document}) => {

--- a/packages/lesswrong/components/sunshineDashboard/SuggestAlignmentItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SuggestAlignmentItem.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { Posts } from '../../lib/collections/posts';
 import Users from 'meteor/vulcan:users';
 import { Link } from 'react-router'
-import moment from 'moment';
 import Typography from '@material-ui/core/Typography';
 import withUser from '../common/withUser';
 import withHover from '../common/withHover'
@@ -68,7 +67,7 @@ class SuggestAlignmentItem extends Component {
             </Link>
           </Components.SidebarInfo>
           {post.postedAt && <Components.SidebarInfo>
-            {moment(new Date(post.postedAt)).fromNow()}
+            <Components.FromNowDate date={post.postedAt}/>
           </Components.SidebarInfo>}
         </div>
         <Components.SidebarInfo>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItemOverview.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItemOverview.jsx
@@ -4,7 +4,6 @@ import { Posts } from '../../lib/collections/posts';
 import Users from 'meteor/vulcan:users';
 import { Link } from 'react-router'
 import FontIcon from 'material-ui/FontIcon';
-import moment from 'moment';
 import withUser from '../common/withUser';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -42,7 +41,7 @@ class SunshineCommentsItemOverview extends Component {
           </Components.SidebarInfo>
           <Components.SidebarInfo>
             <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
-              {moment(new Date(comment.postedAt)).fromNow()}
+              <Components.FromNowDate date={comment.postedAt}/>
               <FontIcon className="material-icons comments-item-permalink"> link </FontIcon>
             </Link>
           </Components.SidebarInfo>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { Posts } from '../../lib/collections/posts';
 import Users from 'meteor/vulcan:users';
 import { Link } from 'react-router'
-import moment from 'moment';
 import Typography from '@material-ui/core/Typography';
 import withUser from '../common/withUser';
 import withHover from '../common/withHover'
@@ -87,7 +86,7 @@ class SunshineCuratedSuggestionsItem extends Component {
             </Link>
           </Components.SidebarInfo>
           {post.postedAt && <Components.SidebarInfo>
-            {moment(new Date(post.postedAt)).fromNow()}
+            <Components.FromNowDate date={post.postedAt}/>
           </Components.SidebarInfo>}
         </div>
         <Components.SidebarInfo>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
@@ -71,7 +71,7 @@ class SunshineNewUsersItem extends Component {
               { user.email }
             </C.MetaInfo>
             <C.MetaInfo>
-              { moment(new Date(user.createdAt)).fromNow() }
+              <C.FromNowDate date={user.createdAt}/>
             </C.MetaInfo>
           </div>
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedCommentsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedCommentsItem.jsx
@@ -2,7 +2,6 @@ import { Components, registerComponent, withEdit } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import { Comments } from '../../lib/collections/comments';
 import { Link } from 'react-router'
-import moment from 'moment';
 import Typography from '@material-ui/core/Typography';
 import { Posts } from '../../lib/collections/posts';
 import withHover from '../common/withHover'
@@ -69,7 +68,7 @@ class SunshineReportedCommentsItem extends Component {
             </Components.SidebarHoverOver>
             <Components.SunshineCommentsItemOverview comment={comment}/>
             <Components.SidebarInfo>
-              <em>"{ report.description }"</em> – {report.user.displayName}, { moment(new Date(report.createdAt)).fromNow() }
+              <em>"{ report.description }"</em> – {report.user.displayName}, <Components.FromNowDate date={report.createdAt}/>
             </Components.SidebarInfo>
             {hover && <Components.SidebarActionMenu>
               <Components.SidebarAction title="Mark as Reviewed" onClick={this.handleReview}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportsItem.jsx
@@ -4,7 +4,6 @@ import { Comments } from '../../lib/collections/comments';
 import Users from 'meteor/vulcan:users';
 import { Link } from 'react-router'
 import FontIcon from 'material-ui/FontIcon';
-import moment from 'moment';
 import Typography from '@material-ui/core/Typography';
 import { Posts } from '../../lib/collections/posts';
 import withUser from '../common/withUser';
@@ -74,7 +73,7 @@ class SunshineReportsItem extends Component {
 
               <Typography variant="caption">
                 <div>
-                  Reported by {report.user.displayName} { moment(new Date(report.createdAt)).fromNow() }
+                  Reported by {report.user.displayName} <Components.FromNowDate date={report.createdAt}/>
                 </div>
                 <div>"{ report.description }"</div>
               </Typography>

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -26,6 +26,7 @@ import '../components/notifications/SubscribeTo.jsx';
 
 import '../components/Layout.jsx';
 
+import '../components/common/CalendarDate.jsx';
 import '../components/common/FromNowDate.jsx';
 import '../components/common/FlashMessages.jsx';
 import '../components/common/Header.jsx';

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -28,6 +28,7 @@ import '../components/Layout.jsx';
 
 import '../components/common/CalendarDate.jsx';
 import '../components/common/FromNowDate.jsx';
+import '../components/common/SimpleDate.jsx';
 import '../components/common/FlashMessages.jsx';
 import '../components/common/Header.jsx';
 import '../components/common/NavigationMenu.jsx';

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -116,6 +116,7 @@ import '../components/localGroups/CommunityHome.jsx';
 import '../components/localGroups/CommunityMap.jsx';
 import '../components/localGroups/CommunityMapFilter.jsx';
 import '../components/localGroups/CommunityMapWrapper.jsx';
+import '../components/localGroups/EventTime.jsx';
 import '../components/localGroups/LocalGroupMarker.jsx';
 import '../components/localGroups/LocalEventMarker.jsx';
 import '../components/localGroups/LocalGroupPage.jsx';

--- a/packages/lesswrong/server/posts/cron.js
+++ b/packages/lesswrong/server/posts/cron.js
@@ -1,5 +1,4 @@
 import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
-// import moment from 'moment';
 import { Posts } from '../../lib/collections/posts';
 
 SyncedCron.options = {

--- a/packages/lesswrong/server/rss-integration/cron.js
+++ b/packages/lesswrong/server/rss-integration/cron.js
@@ -1,5 +1,4 @@
 import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
-// import moment from 'moment';
 import RSSFeeds from '../../lib/collections/rssfeeds/collection.js';
 import { newMutation, editMutation } from 'meteor/vulcan:core';
 import { Posts } from '../../lib/collections/posts';

--- a/packages/lesswrong/server/scripts/debuggingScripts.js
+++ b/packages/lesswrong/server/scripts/debuggingScripts.js
@@ -3,6 +3,7 @@ import { Posts } from '../../lib/collections/posts';
 import Users from 'meteor/vulcan:users';
 import { createDummyMessage, createDummyConversation, createDummyPost, createDummyComment } from '../../testing/utils.js';
 import { performSubscriptionAction } from '../../lib/subscriptions/mutations.js';
+import moment from 'moment';
 
 Vulcan.populateNotifications = async ({username,
   messageNotifications = 3,
@@ -237,7 +238,8 @@ Vulcan.createBulkyTestPost = async ({
   commentParagraphCount = 2,
   commentParagraphLength = 800,
   numRootComments = 100,
-  commentDepth = 1 }) =>
+  commentDepth = 1,
+  backDate = null}) =>
 {
   var user;
   if(username)
@@ -249,10 +251,15 @@ Vulcan.createBulkyTestPost = async ({
   const body = "<p>This is a programmatically generated test post.</p>" +
     makeLoremIpsumBody(postParagraphCount, postParagraphLength);
 
-  const post = await createDummyPost(user, {
+  let dummyPostFields = {
     title: postTitle,
     body: body
-  })
+  };
+  if (backDate) {
+    dummyPostFields.createdAt = backDate;
+    dummyPostFields.postedAt = backDate;
+  }
+  const post = await createDummyPost(user, dummyPostFields)
 
   // Create some comments
   for(var ii=0; ii<numRootComments; ii++)
@@ -274,4 +281,24 @@ Vulcan.createBulkyTestPost = async ({
       parentCommentId = childComment._id
     }
   }
+}
+
+// Create a set of test posts that are back-dated, one per hour for the past
+// ten days. Primarily for testing time-zone handling on /daily.
+Vulcan.createBackdatedPosts = async () =>
+{
+  //eslint-disable-next-line no-console
+  console.log("Creating back-dated test post set");
+  
+  for(let i=0; i<24*10; i++) {
+    const backdateTime = moment().subtract(i, 'hours').toDate();
+    await Vulcan.createBulkyTestPost({
+      postTitle: "Test post backdated by "+i+" hours",
+      numRootComments: 0,
+      backDate: backdateTime,
+    });
+  }
+  
+  //eslint-disable-next-line no-console
+  console.log("Done");
 }


### PR DESCRIPTION
 * New dependency on `moment-timezone` library (from the same folks as `moment`, which we were already using)
 * Added `withTimezone` higher-order component
 * Server renders are always GMT; client then switches it to local time with a proper state change
 * Time zones are displayed explicitly in lots of places, especially events
 * Long tail of date and time displays now passes through a few components, which are timezone aware

Fixes #1064. Fixes #956.