### PR TITLE
Excerpt/Highlight rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "speakingurl": "^9.0.0",
     "styled-components": "^3.3.3",
     "timber": "^3.1.3",
+    "truncatise": "0.0.7",
     "turndown": "^4.0.2",
     "underscore": "^1.9.1",
     "universal-cookie-express": "^2.2.0",

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -15,6 +15,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { commentBodyStyles } from '../../../themes/stylePiping'
 import withErrorBoundary from '../../common/withErrorBoundary'
 import withDialog from '../../common/withDialog'
+import { renderExcerpt } from '../../../lib/editor/ellipsize';
 
 const styles = theme => ({
   root: {
@@ -111,29 +112,6 @@ class CommentsItem extends Component {
     this.props.router.replace({...router.location, hash: "#" + comment._id})
     this.props.scrollIntoView(event);
     return false;
-  }
-
-  renderExcerpt() {
-    const { comment, classes } = this.props
-
-    if (comment.body) {
-      // Replace Markdown Links with just their display text
-      let bodyReplaceLinks = comment.body.replace(/(?:__|[*#])|\[(.*?)\]\(.*?\)/gm, '$1');
-
-      let commentExcerpt = bodyReplaceLinks.substring(0,300).split("\n\n");
-
-      const lastElement = commentExcerpt.slice(-1)[0];
-      commentExcerpt = commentExcerpt.slice(0, commentExcerpt.length - 1).map(
-        (text, i) => <p key={ comment._id + i}>{text}</p>);
-      return <div className={classNames("comments-item-text", "content-body", classes.commentStyling)}>
-        {commentExcerpt}
-        <p>{lastElement + "..."}
-          <a className="read-more" onClick={() => this.setState({expanded: true})}>(read more)</a>
-        </p>
-      </div>
-    } else {
-      return null
-    }
   }
 
   render() {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -141,12 +141,28 @@ class CommentsItem extends Component {
 
     const expanded = !(!this.state.expanded && comment.body && comment.body.length > 300) || this.props.expanded
 
-    const commentBody = this.props.collapsed ? "" : (
-      <div>
-        {this.state.showEdit ? this.renderEdit() : <Components.CommentBody comment={comment}/>}
-        {!comment.deleted && this.renderCommentBottom()}
-      </div>
-    )
+    let commentBody;
+    if (!postPage && !expanded) {
+      commentBody = renderExcerpt({
+        key: comment._id,
+        body: comment.body,
+        htmlBody: comment.htmlBody,
+        classes: classes,
+        onReadMore: () => this.setState({expanded: true}),
+      });
+    } else if (this.props.collapsed) {
+      commentBody = "";
+    } else {
+      commentBody = (
+        <div>
+          {this.state.showEdit
+            ? this.renderEdit()
+            : <Components.CommentBody comment={comment}/>}
+          {!comment.deleted
+            && this.renderCommentBottom()}
+        </div>
+      );
+    }
 
     if (comment && post) {
       return (
@@ -212,7 +228,7 @@ class CommentsItem extends Component {
               <Components.CommentsVote comment={comment} currentUser={currentUser} />
               {this.renderMenu()}
             </div>
-            { (!postPage && !expanded) ? this.renderExcerpt() : commentBody}
+            { commentBody }
           </div>
           {this.state.showReply && !this.props.collapsed ? this.renderReply() : null}
         </div>

--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -11,11 +11,11 @@ export const highlightFromMarkdown = (body, mdi) => {
 }
 
 export const highlightFromHTML = (html) => {
-  return truncatise(html, {
+  return Utils.sanitize(truncatise(html, {
     TruncateLength: highlightMaxChars,
     TruncateBy: "characters",
     Suffix: "... (Read More)",
-  });
+  }));
 };
 
 export const excerptFromHTML = (html) => {

--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import truncatise from 'truncatise';
+import { Utils } from 'meteor/vulcan:core';
+
+const highlightMaxChars = 2400;
+const excerptMaxChars = 300;
+
+export const highlightFromMarkdown = (body, mdi) => {
+  const htmlBody = mdi.render(body);
+  return highlightFromHTML(htmlBody);
+}
+
+export const highlightFromHTML = (html) => {
+  return truncatise(html, {
+    TruncateLength: highlightMaxChars,
+    TruncateBy: "characters",
+    Suffix: "... (Read More)",
+  });
+};
+
+export const excerptFromHTML = (html) => {
+  return Utils.sanitize(truncatise(html, {
+    TruncateLength: excerptMaxChars,
+    TruncateBy: "characters",
+    Suffix: '... <a className="read-more" href="#">(Read More)</a>',
+  }));
+};
+
+export const excerptFromMarkdown = (body, mdi) => {
+  const htmlBody = mdi.render(body);
+  return excerptFromHTML(htmlBody);
+}
+
+export const renderExcerpt = ({key, body, htmlBody, classes, onReadMore}) => {
+  if (!htmlBody)
+    return null;
+  
+  const truncatedBody = excerptFromHTML(htmlBody);
+  return <div
+    className={classes.commentStyling}
+    onClick={() => onReadMore()}
+    dangerouslySetInnerHTML={{__html: truncatedBody}}
+  />
+};

--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import truncatise from 'truncatise';
 import { Utils } from 'meteor/vulcan:core';
 

--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -25,24 +25,15 @@ function mjPagePromise(html, beforeSerializationCallback) {
   })
 }
 
-export const getExcerptFieldsFromMarkdown = (markdownBody, fieldName, mdi) => {
-  const wordCount = wordcountFromMarkdown(markdownBody)
+export const getExcerptFieldsFromMarkdown = (markdownBody, fieldName = "") => {
   const htmlBody = mdi.render(markdownBody);
-  const htmlHighlight = mdi.render(highlightFromHTML(htmlBody))
-  const excerpt = excerptFromHTML(htmlBody);
-  const plaintextExcerpt = htmlToText.fromString(excerpt);
-  return {
-    [`${fieldName}wordCount`]: wordCount,
-    [`${fieldName}htmlHighlight`]: htmlHighlight,
-    [`${fieldName}excerpt`]: excerpt,
-    [`${fieldName}plaintextExcerpt`]: plaintextExcerpt,
-  }
+  return getExcerptFieldsFromHTML(htmlBody, fieldName);
 }
 
-export const getExcerptFieldsFromHTML = (html, fieldName, mdi) => {
+export const getExcerptFieldsFromHTML = (html, fieldName = "") => {
   const markdownBody = htmlToMarkdown(html);
   const wordCount = wordcountFromMarkdown(markdownBody);
-  const htmlHighlight = mdi.render(highlightFromHTML(html));
+  const htmlHighlight = highlightFromHTML(html);
   const excerpt = excerptFromHTML(html);
   const plaintextExcerpt = htmlToText.fromString(excerpt);
   return {
@@ -66,7 +57,7 @@ const convertFromContent = (content, fieldName = "") => {
   return {
     [`${fieldName}htmlBody`]: htmlBody,
     [`${fieldName}body`]: body,
-    ...getExcerptFieldsFromHTML(htmlBody, fieldName, mdi),
+    ...getExcerptFieldsFromHTML(htmlBody, fieldName),
     [`${fieldName}lastEditedAs`]: 'draft-js'
   }
 }
@@ -86,7 +77,7 @@ const convertFromHTML = (html, sanitize, fieldName = "") => {
   return {
     [`${fieldName}htmlBody`]: htmlBody,
     [`${fieldName}body`]: body,
-    ...getExcerptFieldsFromHTML(html, fieldName, mdi),
+    ...getExcerptFieldsFromHTML(html, fieldName),
     [`${fieldName}lastEditedAs`]: "html",
   }
 }
@@ -95,7 +86,7 @@ const convertFromMarkdown = (body, fieldName = "") => {
   return {
     [`${fieldName}htmlBody`]: mdi.render(body),
     [`${fieldName}body`]: body,
-    ...getExcerptFieldsFromMarkdown(body, fieldName, mdi),
+    ...getExcerptFieldsFromMarkdown(body, fieldName),
     [`${fieldName}lastEditedAs`]: "markdown"
   }
 }


### PR DESCRIPTION
Rather than truncating Markdown to produce shortened post/comment excerpts, truncate HTML, using the `truncatise` library.