### PR TITLE
Add `withDialog` HoC and use it

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -16,6 +16,7 @@ import { withStyles, withTheme } from '@material-ui/core/styles';
 import getHeaderSubtitleData from '../lib/modules/utils/getHeaderSubtitleData';
 import { UserContext } from './common/withUser';
 import { TimezoneContext } from './common/withTimezone';
+import { DialogManager } from './common/withDialog';
 
 const intercomAppId = getSetting('intercomAppId', 'wtb8z7sj');
 
@@ -97,6 +98,7 @@ class Layout extends PureComponent {
       <TimezoneContext.Provider value={this.state.timezone}>
       <div className={classNames("wrapper", {'alignment-forum': getSetting('AlignmentForum', false)}) } id="wrapper">
         <V0MuiThemeProvider muiTheme={customizeTheme(currentRoute, userAgent, params, client.store)}>
+          <DialogManager>
           <div>
             <CssBaseline />
             <Helmet>
@@ -131,6 +133,7 @@ class Layout extends PureComponent {
             </div>
             {/* <Components.Footer />  Deactivated Footer, since we don't use one. Might want to add one later*/ }
           </div>
+          </DialogManager>
         </V0MuiThemeProvider>
       </div>
       </TimezoneContext.Provider>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -60,15 +60,15 @@ class CommentsItem extends Component {
 
   showReport = (event) => {
     const { openDialog, comment, currentUser } = this.props;
-    openDialog(
-      "ReportForm",
-      {
+    openDialog({
+      componentName: "ReportForm",
+      componentProps: {
         commentId: comment._id,
         postId: comment.postId,
         link: "/posts/" + comment.postId + "/a/" + comment._id,
         userId: currentUser._id,
       }
-    );
+    });
   }
 
   showReply = (event) => {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -59,15 +59,15 @@ class CommentsItem extends Component {
   }
 
   showReport = (event) => {
-    const { openDialog, closeDialog, comment, currentUser } = this.props;
+    const { openDialog, comment, currentUser } = this.props;
     openDialog(
-      <Components.ReportForm
-        commentId={comment._id}
-        postId={comment.postId}
-        link={"/posts/" + comment.postId + "/a/" + comment._id}
-        userId={currentUser._id}
-        onRequestClose={closeDialog}
-      />
+      "ReportForm",
+      {
+        commentId: comment._id,
+        postId: comment.postId,
+        link: "/posts/" + comment.postId + "/a/" + comment._id,
+        userId: currentUser._id,
+      }
     );
   }
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -14,6 +14,7 @@ import { shallowEqual, shallowEqualExcept } from '../../../lib/modules/utils/com
 import { withStyles } from '@material-ui/core/styles';
 import { commentBodyStyles } from '../../../themes/stylePiping'
 import withErrorBoundary from '../../common/withErrorBoundary'
+import withDialog from '../../common/withDialog'
 
 const styles = theme => ({
   root: {
@@ -45,7 +46,6 @@ class CommentsItem extends Component {
     this.state = {
       showReply: false,
       showEdit: false,
-      showReport: false,
       showParent: false
     };
   }
@@ -59,8 +59,16 @@ class CommentsItem extends Component {
   }
 
   showReport = (event) => {
-    event.preventDefault();
-    this.setState({showReport: true});
+    const { openDialog, closeDialog, comment, currentUser } = this.props;
+    openDialog(
+      <Components.ReportForm
+        commentId={comment._id}
+        postId={comment.postId}
+        link={"/posts/" + comment.postId + "/a/" + comment._id}
+        userId={currentUser._id}
+        onRequestClose={closeDialog}
+      />
+    );
   }
 
   showReply = (event) => {
@@ -276,15 +284,6 @@ class CommentsItem extends Component {
                   />
                 ]}
               />}
-              { this.state.showReport &&
-                <Components.ReportForm
-                  commentId={comment._id}
-                  postId={comment.postId}
-                  link={"/posts/" + comment.postId + "/a/" + comment._id}
-                  userId={currentUser._id}
-                  open={true}
-                />
-              }
             </Components.CommentsMenu>
         </span>
       )
@@ -386,6 +385,7 @@ CommentsItem.propTypes = {
 registerComponent('CommentsItem', CommentsItem,
   withRouter, withMessages,
   withStyles(styles, { name: "CommentsItem" }),
+  withDialog,
   withErrorBoundary
 );
 export default CommentsItem;

--- a/packages/lesswrong/components/common/withDialog.jsx
+++ b/packages/lesswrong/components/common/withDialog.jsx
@@ -1,0 +1,56 @@
+import React, { PureComponent } from 'react';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+
+export const OpenDialogContext = React.createContext('openDialog');
+
+export class DialogManager extends PureComponent {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      currentDialog: null,
+    };
+  }
+  
+  closeDialog() {
+    this.setState({
+      currentDialog: null
+    });
+  }
+  
+  render() {
+    const { children } = this.props;
+    
+    return (
+      <OpenDialogContext.Provider value={{
+        openDialog: (dialog) => this.setState({ currentDialog: dialog }),
+        closeDialog: () => this.closeDialog()
+      }}>
+        {children}
+        
+        {this.state.currentDialog &&
+          <ClickAwayListener onClickAway={() => this.closeDialog()}>
+            {this.state.currentDialog}
+          </ClickAwayListener>
+        }
+      </OpenDialogContext.Provider>
+    );
+  }
+}
+
+// Higher-order component for managing dialogs.
+export default function withDialog(Component) {
+  return function WithDialogComponent(props) {
+    return (
+      <OpenDialogContext.Consumer>
+        {dialogFns =>
+          <Component {...props}
+            openDialog={dialogFns.openDialog}
+            closeDialog={dialogFns.closeDialog}
+          />
+        }
+      </OpenDialogContext.Consumer>
+    );
+  }
+}
+

--- a/packages/lesswrong/components/common/withDialog.jsx
+++ b/packages/lesswrong/components/common/withDialog.jsx
@@ -5,14 +5,10 @@ import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 export const OpenDialogContext = React.createContext('openDialog');
 
 export class DialogManager extends PureComponent {
-  constructor(props) {
-    super(props);
-    
-    this.state = {
-      currentDialog: null,
-      componentProps: null
-    };
-  }
+  state = {
+    currentDialog: null,
+    componentProps: null
+  };
   
   closeDialog = () => {
     this.setState({
@@ -27,11 +23,11 @@ export class DialogManager extends PureComponent {
     
     return (
       <OpenDialogContext.Provider value={{
-        openDialog: (componentName, componentProps) => this.setState({
+        openDialog: ({componentName, componentProps}) => this.setState({
           componentName: componentName,
           componentProps: componentProps
         }),
-        closeDialog: () => this.closeDialog()
+        closeDialog: this.closeDialog
       }}>
         {children}
         

--- a/packages/lesswrong/components/common/withDialog.jsx
+++ b/packages/lesswrong/components/common/withDialog.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { Components } from 'meteor/vulcan:core';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 
 export const OpenDialogContext = React.createContext('openDialog');
@@ -9,28 +10,37 @@ export class DialogManager extends PureComponent {
     
     this.state = {
       currentDialog: null,
+      componentProps: null
     };
   }
   
-  closeDialog() {
+  closeDialog = () => {
     this.setState({
-      currentDialog: null
+      componentName: null,
+      componentProps: null
     });
   }
   
   render() {
     const { children } = this.props;
+    const ModalComponent = Components[this.state.componentName];
     
     return (
       <OpenDialogContext.Provider value={{
-        openDialog: (dialog) => this.setState({ currentDialog: dialog }),
+        openDialog: (componentName, componentProps) => this.setState({
+          componentName: componentName,
+          componentProps: componentProps
+        }),
         closeDialog: () => this.closeDialog()
       }}>
         {children}
         
-        {this.state.currentDialog &&
+        {this.state.componentName &&
           <ClickAwayListener onClickAway={() => this.closeDialog()}>
-            {this.state.currentDialog}
+            <ModalComponent
+              {...this.state.componentProps}
+              onRequestClose={this.closeDialog}
+            />
           </ClickAwayListener>
         }
       </OpenDialogContext.Provider>

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
@@ -1,26 +1,17 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Components, registerComponent, getFragment } from 'meteor/vulcan:core';
 import Reports from '../../lib/collections/reports/collection.js'
 import Dialog from 'material-ui/Dialog';
 
-class ReportForm extends Component {
-
-  constructor(props) {
-    super(props);
-  }
-
-  handleClose = () => {
-    this.props.onRequestClose();
-  };
-
+class ReportForm extends PureComponent {
   render() {
     return (
       <Dialog
         title={this.props.title}
         modal={false}
         open={true}
-        onRequestClose={this.handleClose}
+        onRequestClose={this.props.onRequestClose}
       >
         <Components.SmartForm
           collection={Reports}
@@ -31,7 +22,7 @@ class ReportForm extends Component {
             commentId: this.props.commentId,
             link: this.props.link
           }}
-          successCallback={this.handleClose}
+          successCallback={this.props.onRequestClose}
         />
       </Dialog>
     )

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
@@ -8,48 +8,44 @@ class ReportForm extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {
-      open: props.open,
-    };
   }
 
-  handleOpen = () => {
-    this.setState({open: true});
-  };
-
   handleClose = () => {
-    this.setState({open: false});
+    this.props.onRequestClose();
   };
 
   render() {
     return (
-        <Dialog
-          title={this.props.title}
-          modal={false}
-          open={this.state.open}
-          onRequestClose={this.handleClose}
-        >
-          <Components.SmartForm
-            collection={Reports}
-            mutationFragment={getFragment('unclaimedReportsList')}
-            prefilledProps={{
-              userId: this.props.userId,
-              postId: this.props.postId,
-              commentId: this.props.commentId,
-              link: this.props.link
-            }}
-            successCallback={this.handleClose}
-          />
-        </Dialog>
-      )
+      <Dialog
+        title={this.props.title}
+        modal={false}
+        open={true}
+        onRequestClose={this.handleClose}
+      >
+        <Components.SmartForm
+          collection={Reports}
+          mutationFragment={getFragment('unclaimedReportsList')}
+          prefilledProps={{
+            userId: this.props.userId,
+            postId: this.props.postId,
+            commentId: this.props.commentId,
+            link: this.props.link
+          }}
+          successCallback={this.handleClose}
+        />
+      </Dialog>
+    )
   }
 }
 
 ReportForm.propTypes = {
-    userId: PropTypes.string.isRequired,
-    documentId: PropTypes.string.isRequired,
-    documentType: PropTypes.string.isRequired,
-    link: PropTypes.string.isRequired
+  userId: PropTypes.string.isRequired,
+  link: PropTypes.string.isRequired,
+  onRequestClose: PropTypes.func,
+  title: PropTypes.string,
+  postId: PropTypes.string,
+  commentId: PropTypes.string,
+  link: PropTypes.string,
 }
 
 registerComponent('ReportForm', ReportForm);

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.jsx
@@ -45,7 +45,6 @@ ReportForm.propTypes = {
   title: PropTypes.string,
   postId: PropTypes.string,
   commentId: PropTypes.string,
-  link: PropTypes.string,
 }
 
 registerComponent('ReportForm', ReportForm);


### PR DESCRIPTION
A prototype in response to the architecture discussion we were having earlier. This adds a `withDialog` HoC, providing `openDialog` and `closeDialog` properties. Once a dialog is created, the component that created it can detach from the React tree, without affecting the dialog.