### PR TITLE
Adjust sequences form field visibility

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/schema.js
+++ b/packages/lesswrong/lib/collections/sequences/schema.js
@@ -1,5 +1,4 @@
 import { Components } from 'meteor/vulcan:core';
-import Users from 'meteor/vulcan:users';
 import { generateIdResolverSingle } from '../../modules/utils/schemaUtils'
 
 const schema = {

--- a/packages/lesswrong/lib/collections/sequences/schema.js
+++ b/packages/lesswrong/lib/collections/sequences/schema.js
@@ -27,7 +27,7 @@ const schema = {
     viewableBy: ['guests'],
     insertableBy: ['members'],
     editableBy: ['admin'],
-    hidden: Users.canDo('sequences.edit.all'),
+    hidden:  true,
     resolveAs: {
       fieldName: 'user',
       type: 'User',
@@ -172,6 +172,7 @@ const schema = {
     viewableBy: ['guests'],
     editableBy: ['members'],
     insertableBy: ['members'],
+    hidden: true,
     control: "checkbox"
   },
 


### PR DESCRIPTION
Hides unintended sequences fields which showed `userId` fields to non-admin users