### PR TITLE
Fix weird email bug?!?

### DIFF
--- a/packages/lesswrong/lib/modules/callbacks.js
+++ b/packages/lesswrong/lib/modules/callbacks.js
@@ -234,13 +234,18 @@ function findUsersToEmail(filter) {
   let usersMatchingFilter = Users.find(filter, {fields: {_id:1, email:1, emails:1}}).fetch();
 
   let usersToEmail = usersMatchingFilter.filter(u => {
-    let primaryAddress = u.email;
-    for(let i=0; i<u.emails.length; i++)
-    {
-      if(u.emails[i].address === primaryAddress && u.emails[i].verified)
-        return true;
+    if (u.email && u.emails && u.emails.length) {
+      let primaryAddress = u.email;
+
+      for(let i=0; i<u.emails.length; i++)
+      {
+        if(u.emails[i].address === primaryAddress && u.emails[i].verified)
+          return true;
+      }
+      return false;
+    } else {
+      return true
     }
-    return false;
   });
   return usersToEmail
 }


### PR DESCRIPTION
We are currently getting this error in the logs: 

Oct 23 08:05:11pm info Exception in defer callback: TypeError: Cannot read property 'length' of undefined at usersMatchingFilter.filter.u (packages/lesswrong/lib/modules/callbacks.js:238:29) at Array.filter (<anonymous>) at findUsersToEmail (packages/lesswrong/lib/modules/callbacks.js:236:42) at PostsCurateNotification (packages/lesswrong/lib/modules/callbacks.js:250:24) at packages/vulcan:lib/lib/modules/callbacks.js:179:18 at Array.forEach (<anonymous>) at packages/vulcan:lib/lib/modules/

I have no idea how that state could come to be, but this adds some defensive programming to avoid that.