### PR TITLE
LaTeX fixes

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -9,8 +9,10 @@ import withUser from '../common/withUser';
 import DraftJSEditor from '../async/EditorFormContainer'
 import classnames from 'classnames';
 
-const postEditorHeightPx = 250;
-const commentEditorHeightPx = 100;
+const postEditorHeight = 250;
+const commentEditorHeight = 100;
+const postEditorHeightRows = 15;
+const commentEditorHeightRows = 5;
 
 const styles = theme => ({
   postBodyStyles: {
@@ -27,21 +29,10 @@ const styles = theme => ({
   },
   
   postEditorHeight: {
-    minHeight: postEditorHeightPx,
+    minHeight: postEditorHeight,
   },
   commentEditorHeight: {
-    minHeight: commentEditorHeightPx,
-  },
-  
-  postEditorHeightMarkdown: {
-    "& textarea": {
-      minHeight: postEditorHeightPx,
-    }
-  },
-  commentEditorHeightMarkdown: {
-    "& textarea": {
-      minHeight: commentEditorHeightPx,
-    }
+    minHeight: commentEditorHeight,
   },
   
   errorTextColor: {
@@ -150,12 +141,13 @@ class EditorFormComponent extends Component {
       const name = (this.getCurrentEditorType() === "html") ? "htmlBody" : "body";
       
       return (
-        <div className={heightClass}>
+        <div>
           { editorWarning }
           <Components.MuiInput
             {...passedDownProps}
-            className={classnames(classes.markdownEditor, bodyStyles,
-              commentStyles ? classes.commentEditorHeightMarkdown : classes.postEditorHeightMarkdown)}
+            className={classnames(classes.markdownEditor, bodyStyles)}
+            rows={commentStyles ? commentEditorHeightRows : postEditorHeightRows}
+            rowsMax={99999}
             name={name}
           />
         </div>

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -7,36 +7,43 @@ import { editorStyles, postBodyStyles, commentBodyStyles } from '../../themes/st
 import Typography from '@material-ui/core/Typography';
 import withUser from '../common/withUser';
 import DraftJSEditor from '../async/EditorFormContainer'
+import classnames from 'classnames';
 
-const postEditorHeight = 250;
-const commentEditorHeight = 100;
+const postEditorHeightPx = 250;
+const commentEditorHeightPx = 100;
 
 const styles = theme => ({
-  postEditor: {
-    "&, & textarea": {
-      minHeight: postEditorHeight,
-      ...editorStyles(theme, postBodyStyles)
-    },
+  postBodyStyles: {
+    ...editorStyles(theme, postBodyStyles),
+    cursor: "text",
   },
-  commentEditor: {
-    "&, & textarea": {
-      minHeight: commentEditorHeight,
-      ...editorStyles(theme, commentBodyStyles)
-    },
+  
+  commentBodyStyles: {
+    ...editorStyles(theme, commentBodyStyles),
+    cursor: "text",
+    
+    margin: 0,
+    padding: 0,
   },
   
   postEditorHeight: {
-    minHeight: postEditorHeight,
-    cursor: "text"
+    minHeight: postEditorHeightPx,
   },
   commentEditorHeight: {
-    minHeight: commentEditorHeight,
-    cursor: "text"
+    minHeight: commentEditorHeightPx,
   },
   
-  markdownEditor: {
-    fontSize: '1.4rem',
+  postEditorHeightMarkdown: {
+    "& textarea": {
+      minHeight: postEditorHeightPx,
+    }
   },
+  commentEditorHeightMarkdown: {
+    "& textarea": {
+      minHeight: commentEditorHeightPx,
+    }
+  },
+  
   errorTextColor: {
     color: theme.palette.error.main
   }
@@ -121,33 +128,39 @@ class EditorFormComponent extends Component {
     // the draft-js editor; if we apply it to our wrapper div, it'll look right
     // but most of it won't be clickable.
     const heightClass = commentStyles ? classes.commentEditorHeight : classes.postEditorHeight;
+    const bodyStyles = commentStyles ? classes.commentBodyStyles : classes.postBodyStyles;
     
-    return (
-      <div className={commentStyles ? classes.commentEditor : classes.postEditor}>
-        {!editorOverride && formType !== "new" && document && document.lastEditedAs && document.lastEditedAs !== this.getUserDefaultEditor(currentUser) && this.renderEditorWarning()}
-        { this.getCurrentEditorType() === "markdown" &&
-            <Components.MuiInput
-              {...passedDownProps}
-              className={classes.markdownEditor}
-              name="body"
-            />
-        }
-        { this.getCurrentEditorType() === "html" &&
-            <Components.MuiInput
-              {...passedDownProps}
-              className={classes.markdownEditor}
-              name="htmlBody"
-            />
-        }
-        { this.getCurrentEditorType() === "draft-js" &&
-            <AsyncEditor
-              {...passedDownProps}
-              className={heightClass}
-            />
-        }
-      </div>
-
-    )
+    const editorWarning =
+      !editorOverride
+      && formType !== "new"
+      && document && document.lastEditedAs
+      && document.lastEditedAs !== this.getUserDefaultEditor(currentUser)
+      && this.renderEditorWarning()
+    
+    if (this.getCurrentEditorType() === "draft-js") {
+      return (
+        <div className={heightClass}>
+          { editorWarning }
+          <AsyncEditor
+            {...passedDownProps}
+            className={classnames(bodyStyles, heightClass)}
+          />
+        </div>);
+    } else {
+      const name = (this.getCurrentEditorType() === "html") ? "htmlBody" : "body";
+      
+      return (
+        <div className={heightClass}>
+          { editorWarning }
+          <Components.MuiInput
+            {...passedDownProps}
+            className={classnames(classes.markdownEditor, bodyStyles,
+              commentStyles ? classes.commentEditorHeightMarkdown : classes.postEditorHeightMarkdown)}
+            name={name}
+          />
+        </div>
+      );
+    }
   }
 }
 

--- a/packages/lesswrong/components/form-components/MuiInput.jsx
+++ b/packages/lesswrong/components/form-components/MuiInput.jsx
@@ -43,6 +43,7 @@ class MuiInput extends Component {
         onChange={this.onChange}
         multiline={this.props.multiLine}
         rows={this.props.rows}
+        rowsMax={this.props.rowsMax}
         placeholder={this.props.hintText || this.props.placeholder || this.props.label}
         fullWidth={this.props.fullWidth}
         disableUnderline={this.props.disableUnderline}

--- a/packages/lesswrong/styles/main.scss
+++ b/packages/lesswrong/styles/main.scss
@@ -134,9 +134,10 @@ div#mocha {
   z-index: 10000000;
 }
 
-// Maximum width for LaTeX, to prevent causing horizontal scroll or otherwise
-// breaking the layout.
-.mjx-chtml {
+// Maximum width for LaTeX blocks, to prevent causing horizontal scroll or
+// otherwise breaking the layout. We don't do this for inline styles, because
+// it messes up vertical alignment.
+.mjx-chtml.MJXc-display {
   overflow-x: auto;
   overflow-y: hidden;
   


### PR DESCRIPTION
Fixes the height of the LaTeX editor in DraftJS. Fixes vertical alignment of inline LaTeX elements, at the cost of them being able to overflow and make the whole page scroll.

Fixes #1168. Fixes #1166.