### PR TITLE
Add full name field for alignment forum import

### DIFF
--- a/packages/lesswrong/components/users/UsersName.jsx
+++ b/packages/lesswrong/components/users/UsersName.jsx
@@ -1,10 +1,14 @@
-import { registerComponent } from 'meteor/vulcan:core';
+import { registerComponent, getSetting } from 'meteor/vulcan:core';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Users from 'meteor/vulcan:users';
 import { Link } from 'react-router';
 
-const UsersName = ({user}) => <Link className="users-name" to={Users.getProfileUrl(user)}>{Users.getDisplayName(user)}</Link>
+
+
+const UsersName = ({user}) => <Link className="users-name" to={Users.getProfileUrl(user)}>
+  {getSetting('AlignmentForum', false) ? (user.fullName || Users.getDisplayName(user)) : Users.getDisplayName(user)}
+</Link>
 
 UsersName.propTypes = {
   user: PropTypes.object.isRequired,

--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -770,4 +770,15 @@ Users.addField([
       canRead: ['guests'],
     }
   },
+
+  // Full Name field to display full name for alignment forum users
+  {
+    fieldName: 'fullName',
+    fieldSchema: {
+      type: String,
+      optional: true,
+      canRead: ['guests'],
+      canUpdate: [Users.owns, 'sunshineRegiment']
+    }
+  }
 ]);

--- a/packages/lesswrong/lib/modules/fragments.js
+++ b/packages/lesswrong/lib/modules/fragments.js
@@ -482,6 +482,7 @@ registerFragment(`
     slug
     username
     displayName
+    fullName
     emailHash
     karma
     afKarma


### PR DESCRIPTION
These changes make it so that when a full-name field is provided, it's displayed instead of the usual name on alignment forum (though the profile links and everything still go to the same place).