### PR TITLE
Add indicators for LaTeX horizontal scroll

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.jsx
@@ -16,7 +16,7 @@ const CommentBody = ({comment, classes}) => {
   const htmlBody = {__html: comment.htmlBody};
   return (
     <div className={classes.commentStyling}>
-      {!comment.deleted && <div className="comment-body" dangerouslySetInnerHTML={htmlBody}></div>}
+      {!comment.deleted && <Components.ContentItemBody className="comment-body" dangerouslySetInnerHTML={htmlBody}/>}
       {comment.deleted && <div className="comment-body"><Components.CommentDeletedMetadata documentId={comment._id}/></div>}
     </div>
   )

--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -54,6 +54,8 @@ class CommentsNode extends PureComponent {
   }
 
   scrollIntoView = (event) => {
+    // TODO: This is a legacy React API; migrate to the new type of refs.
+    // https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
     //eslint-disable-next-line react/no-string-refs
     this.refs.comment.scrollIntoView({behavior: "smooth", block: "center", inline: "nearest"});
     this.setState({finishedScroll: true});

--- a/packages/lesswrong/components/common/ContentItemBody.jsx
+++ b/packages/lesswrong/components/common/ContentItemBody.jsx
@@ -3,6 +3,9 @@ import { registerComponent } from 'meteor/vulcan:core';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 
+const scrollIndicatorColor = "#ddd";
+const scrollIndicatorHoverColor = "#888";
+
 const styles = theme => ({
   scrollIndicatorWrapper: {
     display: "block",
@@ -20,6 +23,7 @@ const styles = theme => ({
     position: "absolute",
     top: "50%",
     marginTop: -28,
+    cursor: "pointer",
     
     // Scroll arrows use the CSS Triangle hack - see
     // https://css-tricks.com/snippets/css/css-triangle/ for a full explanation
@@ -29,12 +33,20 @@ const styles = theme => ({
   
   scrollIndicatorLeft: {
     left: 0,
-    borderRight: "10px solid #ddd",
+    borderRight: "10px solid "+scrollIndicatorColor,
+    
+    "&:hover": {
+      borderRight: "10px solid "+scrollIndicatorHoverColor,
+    },
   },
   
   scrollIndicatorRight: {
     right: 0,
-    borderLeft: "10px solid #ddd",
+    borderLeft: "10px solid "+scrollIndicatorColor,
+    
+    "&:hover": {
+      borderLeft: "10px solid "+scrollIndicatorHoverColor,
+    },
   },
   
   scrollableLaTeX: {
@@ -43,10 +55,16 @@ const styles = theme => ({
     // target.
     // !important to take precedence over .mjx-chtml
     marginTop: "-1em !important",
-    marginBottom: "-1em !important",
     
     paddingTop: "2em !important",
     paddingBottom: "2em !important",
+    
+    // Hide the scrollbar (on browsers that support it) because our scroll
+    // indicator is better
+    "-ms-overflow-style": "-ms-autohiding-scrollbar",
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
   }
 });
 
@@ -148,6 +166,13 @@ class ContentItemBody extends Component {
         classes.scrollIndicator, classes.scrollIndicatorRight,
         { [classes.hidden]: block.scrollLeft+block.clientWidth+1 > block.scrollWidth });
     }
+    
+    scrollIndicatorLeft.onclick = (ev) => {
+      block.scrollLeft = Math.max(block.scrollLeft-block.clientWidth, 0);
+    };
+    scrollIndicatorRight.onclick = (ev) => {
+      block.scrollLeft += Math.min(block.scrollLeft+block.clientWidth, block.scrollWidth-block.clientWidth);
+    };
     
     updateScrollIndicatorClasses();
     block.onscroll = (ev) => updateScrollIndicatorClasses();

--- a/packages/lesswrong/components/common/ContentItemBody.jsx
+++ b/packages/lesswrong/components/common/ContentItemBody.jsx
@@ -1,0 +1,159 @@
+import React, { Component } from 'react';
+import { registerComponent } from 'meteor/vulcan:core';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+  scrollIndicatorWrapper: {
+    display: "block",
+    position: "relative",
+    
+    paddingLeft: 13,
+    paddingRight: 13,
+  },
+  
+  hidden: {
+    display: "none !important",
+  },
+  
+  scrollIndicator: {
+    position: "absolute",
+    top: "50%",
+    marginTop: -28,
+    
+    // Scroll arrows use the CSS Triangle hack - see
+    // https://css-tricks.com/snippets/css/css-triangle/ for a full explanation
+    borderTop: "20px solid transparent",
+    borderBottom: "20px solid transparent",
+  },
+  
+  scrollIndicatorLeft: {
+    left: 0,
+    borderRight: "10px solid #ddd",
+  },
+  
+  scrollIndicatorRight: {
+    right: 0,
+    borderLeft: "10px solid #ddd",
+  },
+  
+  scrollableLaTeX: {
+    // Cancel out the margin created by the block elements above and below,
+    // so that we can convert them into padding and get a larger touch
+    // target.
+    // !important to take precedence over .mjx-chtml
+    marginTop: "-1em !important",
+    marginBottom: "-1em !important",
+    
+    paddingTop: "2em !important",
+    paddingBottom: "2em !important",
+  }
+});
+
+// The body of a post/comment/etc, created by taking server-side-processed HTML
+// out of the result of a GraphQL query and adding some decoration to it. In
+// particular, if this is the client-side render, adds scroll indicators to
+// horizontally-scrolling LaTeX blocks.
+//
+// This doesn't apply styling (other than for the decorators it adds) because
+// it's shared between entity types, which have styling that differs.
+class ContentItemBody extends Component {
+  constructor(props) {
+    super(props);
+    this.bodyRef = React.createRef();
+  }
+  
+  render() {
+    return <div
+      className={this.props.className}
+      ref={this.bodyRef}
+      dangerouslySetInnerHTML={this.props.dangerouslySetInnerHTML}
+    />
+  }
+  
+  componentDidMount() {
+    this.markScrollableLaTeX();
+  }
+  
+  // Find LaTeX elements inside the body, check whether they're wide enough to
+  // need horizontal scroll, and if so, give them
+  // `classes.hasHorizontalScroll`. 1They will have a scrollbar regardless;
+  // this gives them additional styling which makes the scrollability
+  // obvious, if your browser hides scrollbars like Mac does and most
+  // mobile browsers do).
+  // This is client-only because it requires measuring widths.
+  markScrollableLaTeX = () => {
+    const { classes } = this.props;
+    
+    if(!Meteor.isServer && this.bodyRef && this.bodyRef.current) {
+      let latexBlocks = this.bodyRef.current.getElementsByClassName("mjx-chtml");
+      for(let i=0; i<latexBlocks.length; i++) {
+        let latexBlock = latexBlocks[i];
+        latexBlock.className += " " + classes.scrollableLaTeX;
+        if(latexBlock.scrollWidth > latexBlock.clientWidth) {
+          this.addHorizontalScrollIndicators(latexBlock);
+        }
+      }
+    }
+  }
+  
+  // Given an HTML block element which has horizontal scroll, give it scroll
+  // indicators: left and right arrows that tell you scrolling is possible.
+  // That is, wrap it in this DOM structure and replce it in-place in the
+  // browser DOM:
+  //
+  //   <div class={classes.scrollIndicatorWrapper}>
+  //     <div class={classes.scrollIndicator,classes.scrollIndicatorLeft}/>
+  //     {block}
+  //     <div class={classes.scrollIndicator,classes.scrollIndicatorRight}/>
+  //   </div>
+  //
+  // Instead of doing it with React, we do it with legacy DOM APIs, because
+  // this needs to work when we take some raw non-REACT HTML from the database,
+  // rather than working in a normal React-component-tree context.
+  //
+  // Attaches a handler to `block.onscrol` which shows and hides the scroll
+  // indicators when it's scrolled all the way.
+  addHorizontalScrollIndicators = (block) => {
+    const { classes } = this.props;
+    
+    // If already wrapped, don't re-wrap (so this is idempotent).
+    if (block.parentElement && block.parentElement.className === classes.scrollIndicatorWrapper)
+      return;
+    
+    const scrollIndicatorWrapper = document.createElement("div");
+    scrollIndicatorWrapper.className = classes.scrollIndicatorWrapper;
+    
+    const scrollIndicatorLeft = document.createElement("div");
+    scrollIndicatorWrapper.append(scrollIndicatorLeft);
+    
+    block.parentElement.insertBefore(scrollIndicatorWrapper, block);
+    block.remove();
+    scrollIndicatorWrapper.append(block);
+    
+    const scrollIndicatorRight = document.createElement("div");
+    scrollIndicatorWrapper.append(scrollIndicatorRight);
+    
+    // Update scroll indicator classes, either for the first time (when newly
+    // constructed) or when we've scrolled. We apply `classes.hidden` when the
+    // scroll position is within 1px (exclusive) of an edge, rather than when
+    // it's exactly at an edge, because in at least one tested browser (Chrome
+    // on Windows) scrolling actually stopped a fraction of a pixel short of
+    // where `scrollWidth` said it would.
+    const updateScrollIndicatorClasses = () => {
+      scrollIndicatorLeft.className = classNames(
+        classes.scrollIndicator, classes.scrollIndicatorLeft,
+        { [classes.hidden]: block.scrollLeft < 1 });
+      scrollIndicatorRight.className = classNames(
+        classes.scrollIndicator, classes.scrollIndicatorRight,
+        { [classes.hidden]: block.scrollLeft+block.clientWidth+1 > block.scrollWidth });
+    }
+    
+    updateScrollIndicatorClasses();
+    block.onscroll = (ev) => updateScrollIndicatorClasses();
+  };
+}
+
+registerComponent('ContentItemBody', ContentItemBody,
+  withStyles(styles, { name: "ContentItemBody" })
+);

--- a/packages/lesswrong/components/posts/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage.jsx
@@ -290,7 +290,9 @@ class PostsPage extends Component {
               </Components.ErrorBoundary>
               <div className={classes.postContent}>
                 <Components.LinkPostMessage post={post} />
-                { post.htmlBody && <div dangerouslySetInnerHTML={{__html: post.htmlBody}}/> }
+                { post.htmlBody && <Components.ContentItemBody
+                    dangerouslySetInnerHTML={{__html: post.htmlBody}}
+                 /> }
               </div>
             </div>
             <div className={classes.postFooter}>

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -48,6 +48,7 @@ import '../components/common/ErrorBoundary.jsx';
 import '../components/common/CloudinaryImage.jsx';
 import '../components/common/Logo.jsx';
 import '../components/common/SearchForm.jsx';
+import '../components/common/ContentItemBody.jsx';
 
 // Outgoing RSS Feed builder
 import '../components/common/SubscribeWidget.jsx';


### PR DESCRIPTION
This patch makes it so that if a LaTeX block in a post or comment is wide enough to need a horizontal scrollbar, it gets expanded to a larger touch target and gets an indicator on the left/right sides to show that it's scrollable.