### PR TITLE
Editor publish label

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.jsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Components, registerComponent, getFragment, withMessages, getSetting } from 'meteor/vulcan:core';
+import { Components, registerComponent, getFragment, withMessages, getSetting, withDocument } from 'meteor/vulcan:core';
 import { intlShape } from 'meteor/vulcan:i18n';
 import { Posts } from '../../lib/collections/posts';
 import { withRouter } from 'react-router'
@@ -10,15 +10,15 @@ import withUser from '../common/withUser';
 class PostsEditForm extends PureComponent {
 
   render() {
-    const postId = this.props.location.query.postId;
-    const eventForm = this.props.router.location.query && this.props.router.location.query.eventForm;
+    const { documentId, document, eventForm } = this.props;
     const mapsAPIKey = getSetting('googleMaps.apiKey', null);
+    
     return (
       <div className="posts-edit-form">
         {eventForm && <Helmet><script src={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&libraries=places`}/></Helmet>}
         <Components.SmartForm
           collection={Posts}
-          documentId={postId}
+          documentId={documentId}
           mutationFragment={getFragment('LWPostsPage')}
           successCallback={post => {
             this.props.flash({ id: 'posts.edit_success', properties: { title: post.title }, type: 'success'});
@@ -37,7 +37,7 @@ class PostsEditForm extends PureComponent {
             // this.context.events.track("post deleted", {_id: documentId});
           }}
           showRemove={true}
-          submitLabel="Save"
+          submitLabel={document.draft ? "Publish" : "Publish Changes"}
           repeatErrors
         />
       </div>
@@ -55,4 +55,13 @@ PostsEditForm.contextTypes = {
   intl: intlShape
 }
 
-registerComponent('PostsEditForm', PostsEditForm, withMessages, withRouter, withUser);
+const documentQuery = {
+  collection: Posts,
+  queryName: 'PostsEditFormQuery',
+  fragmentName: 'LWPostsPage',
+  ssr: true
+};
+
+registerComponent('PostsEditForm', PostsEditForm,
+  [withDocument, documentQuery],
+  withMessages, withRouter, withUser);

--- a/packages/lesswrong/components/posts/PostsEditForm.jsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.jsx
@@ -1,21 +1,19 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Components, registerComponent, getFragment, withMessages, getSetting, withDocument } from 'meteor/vulcan:core';
+import { Components, registerComponent, getFragment, withMessages, withDocument } from 'meteor/vulcan:core';
 import { intlShape } from 'meteor/vulcan:i18n';
 import { Posts } from '../../lib/collections/posts';
 import { withRouter } from 'react-router'
-import Helmet from 'react-helmet';
 import withUser from '../common/withUser';
 
 class PostsEditForm extends PureComponent {
 
   render() {
     const { documentId, document, eventForm } = this.props;
-    const mapsAPIKey = getSetting('googleMaps.apiKey', null);
+    const isDraft = document && document.draft;
     
     return (
       <div className="posts-edit-form">
-        {eventForm && <Helmet><script src={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&libraries=places`}/></Helmet>}
         <Components.SmartForm
           collection={Posts}
           documentId={documentId}
@@ -37,7 +35,7 @@ class PostsEditForm extends PureComponent {
             // this.context.events.track("post deleted", {_id: documentId});
           }}
           showRemove={true}
-          submitLabel={document.draft ? "Publish" : "Publish Changes"}
+          submitLabel={isDraft ? "Publish" : "Publish Changes"}
           repeatErrors
         />
       </div>

--- a/packages/lesswrong/components/posts/PostsEditPage.jsx
+++ b/packages/lesswrong/components/posts/PostsEditPage.jsx
@@ -1,0 +1,21 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
+import { withRouter } from 'react-router'
+import Helmet from 'react-helmet';
+
+class PostsEditPage extends PureComponent {
+
+  render() {
+    const postId = this.props.location.query.postId;
+    const eventForm = this.props.router.location.query && this.props.router.location.query.eventForm;
+    const mapsAPIKey = getSetting('googleMaps.apiKey', null);
+    
+    return <div>
+      {eventForm && <Helmet><script src={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&libraries=places`}/></Helmet>}
+      <Components.PostsEditForm documentId={postId} eventForm={eventForm}/>
+    </div>
+  }
+}
+
+registerComponent('PostsEditPage', PostsEditPage, withRouter);

--- a/packages/lesswrong/components/posts/PostsNewForm.jsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.jsx
@@ -30,6 +30,7 @@ const PostsNewForm = (props, context) => {
           props.flash({ id: 'posts.created_message', properties: { title: post.title }, type: 'success'});
         }}
         eventForm={props.router.location.query && props.router.location.query.eventForm}
+        submitLabel="Publish"
         repeatErrors
       />
     </div>

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -102,6 +102,7 @@ import '../components/posts/PostsLoadMore.jsx';
 import '../components/posts/PostsCommentsThread.jsx';
 import '../components/posts/PostsNewForm.jsx';
 import '../components/posts/PostsEditForm.jsx';
+import '../components/posts/PostsEditPage.jsx';
 import '../components/posts/PostsListHeader.jsx';
 import '../components/posts/FeaturedPostsPage.jsx';
 import '../components/posts/PostsGroupDetails.jsx';

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -12,7 +12,7 @@ addRoute([
 addRoute({ name: 'login', path: '/login', componentName: 'LoginPage', title: "Login" });
 addRoute({ name: 'inbox', path: '/inbox', componentName: 'InboxWrapper', title: "Inbox" });
 addRoute({ name: 'newPost', path: '/newPost', componentName: 'PostsNewForm', title: "New Post" });
-addRoute({ name: 'editPost', path: '/editPost', componentName: 'PostsEditForm' });
+addRoute({ name: 'editPost', path: '/editPost', componentName: 'PostsEditPage' });
 addRoute({ name: 'recentComments', path: '/recentComments', componentName: 'RecentCommentsPage', title: "Recent Comments" });
 
 // Sequences


### PR DESCRIPTION
(Best viewed as squashed.)

Changes the post edit form submit button label to say "Publish" or "Publish Changes" (rather than "Save" in both cases) depending on whether it's a draft.