### PR TITLE
Fix crashes in Sequence navigation

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -19,10 +19,10 @@ class HeadTags extends PureComponent {
     const appTitle = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
     const title = this.props.title ? `${this.props.title} - ${appTitle}` : appTitle;
     const description = this.props.description || getSetting('tagline') || getSetting('description');
-
+    
     return (
       <div>
-        <Helmet>
+        <Helmet key={window.location.href}>
 
           <title>{title}</title>
 

--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { registerComponent, Utils, getSetting, registerSetting, Head } from 'meteor/vulcan:lib';
 import { compose } from 'react-apollo';
+import { withRouter } from 'react-router';
 
 registerSetting('logoUrl', null, 'Absolute URL for the logo image');
 registerSetting('title', 'My App', 'App title');
@@ -22,7 +23,7 @@ class HeadTags extends PureComponent {
     
     return (
       <div>
-        <Helmet key={window.location.href}>
+        <Helmet key={this.props.location.href}>
 
           <title>{title}</title>
 
@@ -75,6 +76,6 @@ HeadTags.propTypes = {
   image: PropTypes.string,
 };
 
-registerComponent('HeadTags', HeadTags);
+registerComponent('HeadTags', HeadTags, withRouter);
 
 export default HeadTags;

--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -23,7 +23,7 @@ class HeadTags extends PureComponent {
     
     return (
       <div>
-        <Helmet key={this.props.location.href}>
+        <Helmet key={this.props.location.pathname}>
 
           <title>{title}</title>
 


### PR DESCRIPTION
Works around a bug in react-helmet by giving `Helmet` a key that changes with every navigation, so that `Helmet.componentShouldUpdate` (which is crashy) doesn't get called. Fixes #865.