### PR TITLE
Log node version during startup (to check if we're still on 8.11)

### DIFF
--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -51,3 +51,6 @@ import './lib/events/server.js';
 
 import './lib/modules/indexes.js';
 import './lib/modules/connection_logs.js';
+
+//eslint-disable-next-line no-console
+console.log("Starting LessWrong server. Versions: "+JSON.stringify(process.versions));


### PR DESCRIPTION
Based on slow GraphQL query times we've been seeing on Galaxy, I suspect that, although upgrading Meteor got us upgraded to node 8.12 on our local installs, Galaxy may still be giving us Node 8.11. Log `process.versions` during server startup so we can check.