### PR TITLE
Add tooltip for up-arrow on recent comments

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -8,6 +8,7 @@ import { Comments } from '../../../lib/collections/comments'
 import Users from 'meteor/vulcan:users';
 import classNames from 'classnames';
 import Icon from '@material-ui/core/Icon';
+import Tooltip from '@material-ui/core/Tooltip';
 import { shallowEqual, shallowEqualExcept } from '../../../lib/modules/utils/componentUtils';
 import { withStyles } from '@material-ui/core/styles';
 import { commentBodyStyles } from '../../../themes/stylePiping'
@@ -132,12 +133,14 @@ class CommentsItem extends Component {
           <div className="comments-item-body">
             <div className="comments-item-meta">
               {(comment.parentCommentId && (nestingLevel === 1)) &&
-                <Icon
-                  onClick={this.toggleShowParent}
-                  className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
-                >
-                  subdirectory_arrow_left
-                </Icon>}
+                <Tooltip title="Show previous comment">
+                  <Icon
+                    onClick={this.toggleShowParent}
+                    className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
+                  >
+                    subdirectory_arrow_left
+                  </Icon>
+                </Tooltip>}
               { postPage && <a className="comments-collapse" onClick={this.props.toggleCollapse}>
                 [<span>{this.props.collapsed ? "+" : "-"}</span>]
               </a>


### PR DESCRIPTION
Fixes #846.

![screenshot from 2018-11-23 21-49-40](https://user-images.githubusercontent.com/1735266/48965027-c6c1e300-ef69-11e8-9bab-eb476eac62e6.png)

