### PR TITLE
Support /favicon.ico path

### DIFF
--- a/packages/lesswrong/server/legacy-redirects/routes.js
+++ b/packages/lesswrong/server/legacy-redirects/routes.js
@@ -266,3 +266,9 @@ Picker.route('/item', (params, req, res, next) => {
     res.end("Please provide a URL");
   }
 });
+
+// Secondary way of specifying favicon for browser or RSS readers that don't
+// support using a meta tag (the preferred approach).
+Picker.route('/favicon.ico', (params, req, res, next) => {
+  makeRedirect(res, getSetting('faviconUrl'));
+});


### PR DESCRIPTION
This is an untested fix for LessWrong2#846. It seems not ideal that the new route is in the legacy-routes file.