### PR TITLE
Anchor styles

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem.jsx
+++ b/packages/lesswrong/components/posts/PostsItem.jsx
@@ -37,7 +37,7 @@ const styles = theme => ({
       backgroundColor: "rgba(0,0,0,.025) !important",
     },
     
-    "& a:hover, & a:active, & a:focus": {
+    "& a:hover, & a:active": {
       textDecoration: "none",
       color: "rgba(0,0,0,0.3)",
     },

--- a/packages/lesswrong/styles/_clear-style.scss
+++ b/packages/lesswrong/styles/_clear-style.scss
@@ -9,10 +9,6 @@ h1, h2, h3, h4 {
   font-weight:500;
 }
 
-a, a:hover, a:focus, a:active {
-  text-decoration: none;
-}
-
 textarea, textarea:focus, input, input:focus {
   border:none;
   outline:none;

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -18,9 +18,6 @@ $small-font: 1.1rem;
       overflow-wrap: break-word;
     }
   }
-  a {
-    font-weight: 400;
-  }
   .comments-item-meta {
     & > div {
       display: inline-block;

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -392,13 +392,6 @@ New CSS File
   padding:1em 0;
 }
 
-.comments-delete-modal-body {
-  padding-bottom: 10px !important;
-  p {
-    font-family: $comments-font !important;
-  }
-}
-
 .comments-delete-modal-textfield {
   margin-top: 10px;
 }

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -173,10 +173,6 @@ New CSS File
     font-size: $small-font;
     a {
       color: rgba(0,0,0,0.5);
-      .comments-item-permalink{
-          color: rgba(0,0,0,0.5);
-      }
-
     }
   }
   .comment-edit, .comment-delete {

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -250,16 +250,6 @@ New CSS File
   }
 }
 
-.comment-actions{
-  @include flex-center;
-  button{
-    margin-right: $hmargin;
-  }
-  a{
-    display: block;
-  }
-}
-
 .recent-comments-list {
   max-width: 700px;
   margin:-2px 10px;

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -194,7 +194,7 @@ New CSS File
     }
     color: rgba(0,0,0,0.3);
   }
-  a:hover, a:active, a:focus {
+  a:hover, a:active {
     text-decoration: none;
     color: rgba(0,0,0,0.3) !important;
     .comments-item-permalink {

--- a/packages/lesswrong/styles/_global.scss
+++ b/packages/lesswrong/styles/_global.scss
@@ -22,6 +22,10 @@ h1 {
 }
 
 // Global link styling
+a {
+  text-decoration: none;
+}
+
 a:hover, a:active, a:focus {
   text-decoration: none;
   opacity: 0.5;

--- a/packages/lesswrong/styles/_global.scss
+++ b/packages/lesswrong/styles/_global.scss
@@ -1,9 +1,4 @@
 
-a{
-  cursor: pointer;
-  color: inherit;
-}
-
 .message.error {
   color: $red;
 }
@@ -23,6 +18,8 @@ h1 {
 
 // Global link styling
 a {
+  cursor: pointer;
+  color: inherit;
   text-decoration: none;
 }
 

--- a/packages/lesswrong/styles/_global.scss
+++ b/packages/lesswrong/styles/_global.scss
@@ -26,7 +26,7 @@ a {
   text-decoration: none;
 }
 
-a:hover, a:active, a:focus {
+a:hover, a:active {
   text-decoration: none;
   opacity: 0.5;
 }

--- a/packages/lesswrong/styles/_localgroups.scss
+++ b/packages/lesswrong/styles/_localgroups.scss
@@ -167,7 +167,7 @@ $lw-green: #588f27;
       padding-left:0;
   }
 
-  a:hover, a:visited, a:focus {
+  a:hover, a:focus {
     text-decoration:none;
   }
   a:hover {

--- a/packages/lesswrong/styles/_localgroups.scss
+++ b/packages/lesswrong/styles/_localgroups.scss
@@ -167,10 +167,8 @@ $lw-green: #588f27;
       padding-left:0;
   }
 
-  a:hover, a:focus {
-    text-decoration:none;
-  }
   a:hover {
+    text-decoration:none;
     color:rgba(0,0,0,.4);
   }
 }

--- a/packages/lesswrong/styles/_posts.scss
+++ b/packages/lesswrong/styles/_posts.scss
@@ -362,10 +362,6 @@ svg.drag-handle {
     line-height: 24px;
     color: rgba(0,0,0,0.5);
     margin-top: -10p;
-
-    a {
-      text-decoration: none;
-    }
 }
 
 .sequences-navigation-top, .posts-page-group-details {

--- a/packages/lesswrong/styles/_posts.scss
+++ b/packages/lesswrong/styles/_posts.scss
@@ -27,9 +27,6 @@
     a {
       color: rgba(0,0,0,0.6);
     }
-    a:visited {
-      color: inherit;
-    }
     a:hover {
       text-decoration: none;
     }

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -16,7 +16,7 @@
     justify-content: center;
   }
 
-  a:hover, a:active, a:focus {
+  a:hover, a:active {
     text-decoration: none;
     color: rgba(0,0,0,0.87);
   }
@@ -138,7 +138,7 @@
     color: rgba(0,0,0,0.5);
     font-size: 20px;
 
-    a:hover, a:focus, a:active {
+    a:hover, a:active {
       text-decoration: none;
       color: rgba(0,0,0,0.3);
     }

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -527,7 +527,7 @@
 
   &:hover, &:visited, &:focus {
     text-decoration: none;
-    a, a:hover, a:visited, h3, p, span, div {
+    a, a:hover, h3, p, span, div {
       text-decoration: none;
       color:rgba(0,0,0,.5);
     }

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -84,9 +84,6 @@
       margin-top: 3px;
       color: rgba(0,0,0,0.5);
 
-      a {
-        transition: inherit;
-      }
       &:hover {
         color: rgba(0,0,0,0.3);
         a {
@@ -205,9 +202,6 @@
   div {
     display: inline-block;
     margin-right: 5px;
-  }
-  .sequences-item-user a {
-    color: rgba(0,0,0,0.5);
   }
 }
 

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -124,7 +124,7 @@ const createLWTheme = (theme) => {
         padding: '1rem',
         whiteSpace: 'pre-wrap',
         margin: "1em 0",
-        '& a, & a:hover, & a:focus, & a:active': {
+        '& a, & a:hover, & a:active': {
           ...linkStyle({
             theme,
             underlinePosition: (typography.codeblock && typography.codeblock.linkUnderlinePosition) || "97%",

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -124,7 +124,7 @@ const createLWTheme = (theme) => {
         padding: '1rem',
         whiteSpace: 'pre-wrap',
         margin: "1em 0",
-        '& a, & a:visited, & a:hover, & a:focus, & a:active': {
+        '& a, & a:hover, & a:focus, & a:active': {
           ...linkStyle({
             theme,
             underlinePosition: (typography.codeblock && typography.codeblock.linkUnderlinePosition) || "97%",

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -75,7 +75,7 @@ export const postBodyStyles = (theme, fontSize) => {
     '& img': {
       maxWidth: "100%"
     },
-    '& a, & a:hover, & a:focus, & a:active, & a:visited': {
+    '& a, & a:hover, & a:focus, & a:active': {
       ...linkStyle({
         theme: theme,
         underlinePosition: (
@@ -126,12 +126,12 @@ export const commentBodyStyles = theme => {
       content: '"spoiler (hover/select to reveal)"',
       color: 'white',
     },
-    '& a, & a:hover, & a:focus, & a:active, & a:visited': {
+    '& a, & a:hover, & a:focus, & a:active': {
       backgroundImage: "none",
       textShadow: "none",
       textDecoration: "none",
     },
-    '& pre code a, & pre code a:hover, & pre code a:focus, & pre code a:active, & pre code a:visited': {
+    '& pre code a, & pre code a:hover, & pre code a:focus, & pre code a:active': {
       backgroundImage: "none",
       textShadow: "none",
       textDecoration: "none",

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -75,7 +75,7 @@ export const postBodyStyles = (theme, fontSize) => {
     '& img': {
       maxWidth: "100%"
     },
-    '& a, & a:hover, & a:focus, & a:active': {
+    '& a, & a:hover, & a:active': {
       ...linkStyle({
         theme: theme,
         underlinePosition: (
@@ -126,12 +126,12 @@ export const commentBodyStyles = theme => {
       content: '"spoiler (hover/select to reveal)"',
       color: 'white',
     },
-    '& a, & a:hover, & a:focus, & a:active': {
+    '& a, & a:hover, & a:active': {
       backgroundImage: "none",
       textShadow: "none",
       textDecoration: "none",
     },
-    '& pre code a, & pre code a:hover, & pre code a:focus, & pre code a:active': {
+    '& pre code a, & pre code a:hover, & pre code a:active': {
       backgroundImage: "none",
       textShadow: "none",
       textDecoration: "none",


### PR DESCRIPTION
Cleans up a lot of (but not all of) the weird CSS we have surrounding <a> tags. Fixes #1317, by no longer styling a:focus.