### PR TITLE
RSS: Use a more-readable format for timestamps

### DIFF
--- a/packages/lesswrong/server/rss.js
+++ b/packages/lesswrong/server/rss.js
@@ -4,6 +4,7 @@ import { rssTermsToUrl } from '../lib/modules/rss_urls.js';
 import { Comments } from '../lib/collections/comments';
 import { Utils, getSetting, registerSetting } from 'meteor/vulcan:core';
 import { Picker } from 'meteor/meteorhacks:picker';
+import moment from 'moment-timezone';
 
 // LESSWRONG - this import wasn't needed until fixing author below.
 import Users from 'meteor/vulcan:users';
@@ -60,11 +61,13 @@ export const servePostRSS = (terms, url) => {
     let date = (viewDate > thresholdDate) ? viewDate : thresholdDate;
 
     const postLink = `<a href="${Posts.getPageUrl(post, true)}#comments">Discuss</a>`;
+    const formattedTime = moment(post.postedAt).tz(moment.tz.guess()).format('LLL z');
     const feedItem = {
       title: post.title,
       // LESSWRONG - this was added to handle karmaThresholds
       // description: `${post.htmlBody || ""}<br/><br/>${postLink}`,
-      description: `Published on ${post.postedAt}<br/><br/>${post.htmlBody || ""}<br/><br/>${postLink}`,
+
+      description: `Published on ${formattedTime}<br/><br/>${post.htmlBody || ""}<br/><br/>${postLink}`,
       // LESSWRONG - changed how author is set for RSS because
       // LessWrong posts don't reliably have post.author defined.
       //author: post.author,


### PR DESCRIPTION
The new format matches that of the tooltip that's displayed when you over the date on the post page. I think the time zone will usually be UTC for cloud RSS readers, though that's already the case.

Before: Published on Thu Nov 29 2018 09:32:54 GMT-0800 (PST)
After: Published on November 29, 2018 9:32 AM PST

I wonder whether there's a better way of getting the time zone in there.