### PR TITLE
Make everything serif (but this time I am serious)

### DIFF
--- a/packages/lesswrong/styles/main.scss
+++ b/packages/lesswrong/styles/main.scss
@@ -19,6 +19,36 @@
 @import "sunshine-sidebar";
 @import "alignment-forum";
 
+@font-face { font-family: "Valkyrie";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532699/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_t4_tab_regular.woff");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face { font-family: "Valkyrie";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532699/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_t4_tab_italic.woff");
+  font-weight: normal;
+  font-style: italic; }
+
+@font-face { font-family: "Valkyrie";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532699/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_t4_tab_bold_italic.woff");
+  font-weight: bold;
+  font-style: italic; }
+
+@font-face { font-family: "Valkyrie";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532699/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_t4_tab_bold.woff");
+  font-weight: bold;
+  font-style: normal; }
+
+@font-face { font-family: "Valkyrie Small Caps";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532699/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_c4_tab_regular.woff");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face { font-family: "Valkyrie Small Caps";
+  src: url("https://res.cloudinary.com/dq3pms5lt/raw/upload/v1543532698/Valkyrie%20Font/Tabular%20Numerals/WOFF/valkyrie_c4_tab_bold.woff");
+  font-weight: bold;
+  font-style: normal; }
+
 .upvoted .upvote{
   opacity: 0.3;
 }

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -3,6 +3,7 @@ import grey from '@material-ui/core/colors/grey';
 import deepOrange from '@material-ui/core/colors/deepOrange';
 
 const sansSerifStack = [
+  'Valkyrie',
   'Calibri',
   '"Gill Sans"',
   '"Gill Sans MT"',
@@ -20,6 +21,7 @@ const sansSerifStack = [
 ].join(',')
 
 const serifStack = [
+  'Valkyrie',
   'warnock-pro',
   'Palatino',
   '"Palatino Linotype"',


### PR DESCRIPTION
I went ahead and bought the Valkyrie font, which I think just actually works quite well for all of our text, basically out of the box. 

There are some small things we have to clean up (I noticed the Logo in the top-left being a bit misaligned), but I think this can be merged basically as is. 

I think we probably still want to have the discussion on whether to have comments in sans-serif because of various associations, but I do notice that I find the site a lot more coherent if everything is the same font. 