### PR TITLE
Add the minimum viable page footer (150px whitespace)

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -130,7 +130,7 @@ class Layout extends PureComponent {
                 <Components.SunshineSidebar />
               </Components.ErrorBoundary>
             </div>
-            {/* <Components.Footer />  Deactivated Footer, since we don't use one. Might want to add one later*/ }
+            <Components.Footer />
           </div>
           </DialogManager>
         </V0MuiThemeProvider>

--- a/packages/lesswrong/components/common/Footer.jsx
+++ b/packages/lesswrong/components/common/Footer.jsx
@@ -1,12 +1,19 @@
 import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
 
-const Footer = props => {
+const styles = theme => ({
+  root: {
+    height: 150,
+  }
+});
+
+const Footer = ({classes}) => {
   return (
-    <div className="footer"><a href="/about">Made with heart and brain for humanity</a></div>
+    <div className={classes.root} />
   )
 }
 
 Footer.displayName = "Footer";
 
-registerComponent('Footer', Footer);
+registerComponent('Footer', Footer, withStyles(styles, { name: "Footer" }));

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -49,6 +49,7 @@ import '../components/common/CloudinaryImage.jsx';
 import '../components/common/Logo.jsx';
 import '../components/common/SearchForm.jsx';
 import '../components/common/ContentItemBody.jsx';
+import '../components/common/Footer.jsx';
 
 // Outgoing RSS Feed builder
 import '../components/common/SubscribeWidget.jsx';


### PR DESCRIPTION
Fixes #1274. The purpose of this is to enable you to scroll a bit past the end, so you never have to read something jammed against the bottom of the screen.