### PR TITLE
Server-side render notifications

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.jsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.jsx
@@ -151,6 +151,7 @@ const options = {
   pollInterval: 0,
   limit: 20,
   enableTotal: false,
+  ssr: true,
 };
 
 

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.jsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.jsx
@@ -71,7 +71,8 @@ const options = {
   pollInterval: 0,
   limit: 20,
   enableTotal: false,
-  fetchPolicy: 'cache-and-network'
+  fetchPolicy: 'cache-and-network',
+  ssr: true,
 };
 
 registerComponent('NotificationsMenuButton', NotificationsMenuButton, [withList, options], withUser, withStyles(styles, { name: "NotificationsMenuButton" }))


### PR DESCRIPTION
Previously we didn't server-side render notifications, initially because everything was client-side only by default, and then because we thought there might be performance problems. This activates SSR for the notification bell, and the performance seems fine. (No slow queries, client-side scripts spend ~25ms on the notifications area during front page load.)