### PR TITLE
Add and fix unit tests that weren't imported

### DIFF
--- a/packages/lesswrong/lib/modules/alignment-forum/users/tests.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/users/tests.js
@@ -14,7 +14,8 @@ describe('alignment updateUser – ', async () => {
     await userUpdateFieldFails({
       user:alignmentAdmin,
       document:user,
-      fieldName:'bio'
+      fieldName:'bio',
+      collectionType:'User'
     })
     assertIsPermissionsFlavoredError(graphQLerrors.getErrors());
   });

--- a/packages/lesswrong/testing/server.tests.js
+++ b/packages/lesswrong/testing/server.tests.js
@@ -12,3 +12,4 @@ import '../lib/collections/users/tests.js';
 import '../lib/collections/notifications/tests.js';
 
 import '../lib/modules/alignment-forum/posts/tests.js';
+import '../lib/modules/alignment-forum/users/tests.js';


### PR DESCRIPTION
One file of unit tests (lib/modules/alignment-forum/users/tests.js) wasn't being imported, and thus wasn't being run. Also, it wasn't passing (due to a minor problem with the test, not with the thing being tested). Fix both of those.