### PR TITLE
Eliminate all usages of Components.ShowIf

### DIFF
--- a/packages/lesswrong/components/admin/AdminDashboard.jsx
+++ b/packages/lesswrong/components/admin/AdminDashboard.jsx
@@ -52,9 +52,19 @@ const banColumns = [
 ]
 // columns={['_id', 'createdAt', 'expirationDate', 'type', 'user.username', 'ip']}
 
-const AdminHome = ({ currentUser }) =>
-  <div className="admin-home page">
-    <Components.ShowIf check={Users.isAdmin} document={currentUser} failureComponent={<p className="admin-home-message"><FormattedMessage id="app.noPermission" /></p>}>
+const AdminHome = ({ currentUser }) => {
+  if (!Users.isAdmin(currentUser)) {
+    return (
+      <div className="admin-home page">
+        <p className="admin-home-message">
+          <FormattedMessage id="app.noPermission" />
+        </p>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="admin-home page">
       <div>
         <h2>New IP Ban</h2>
         <Components.SmartForm
@@ -93,7 +103,8 @@ const AdminHome = ({ currentUser }) =>
           showEdit={true}
         />
       </div>
-    </Components.ShowIf>
-  </div>
+    </div>
+  );
+}
 
 registerComponent("AdminDashboard", AdminHome, withUser)

--- a/packages/lesswrong/components/comments/CommentsNewForm.jsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.jsx
@@ -6,6 +6,7 @@ import { FormattedMessage } from 'meteor/vulcan:i18n';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
+import withUser from '../common/withUser'
 
 const styles = theme => ({
   root: {
@@ -28,7 +29,7 @@ const styles = theme => ({
   }
 });
 
-const CommentsNewForm = ({prefilledProps = {}, postId, parentComment, parentCommentId, classes, successCallback, type, cancelCallback, alignmentForumPost}) => {
+const CommentsNewForm = ({prefilledProps = {}, postId, parentComment, parentCommentId, classes, successCallback, type, cancelCallback, alignmentForumPost, currentUser}) => {
   prefilledProps.postId = postId;
 
   if (parentComment) {
@@ -56,12 +57,8 @@ const CommentsNewForm = ({prefilledProps = {}, postId, parentComment, parentComm
     </div>
   }
 
-  return (
-    <Components.ShowIf
-      check={Comments.options.mutations.new.check}
-      document={prefilledProps}
-      failureComponent={<FormattedMessage id="users.cannot_comment"/>}
-    >
+  if (Comments.options.mutations.new.check(currentUser)) {
+    return (
       <div className={classes.root}>
         <Components.SmartForm
           collection={Comments}
@@ -75,9 +72,10 @@ const CommentsNewForm = ({prefilledProps = {}, postId, parentComment, parentComm
           alignmentForumPost={alignmentForumPost}
         />
       </div>
-    </Components.ShowIf>
-  )
-
+    );
+  } else {
+    return <FormattedMessage id="users.cannot_comment"/>;
+  }
 };
 
 const FormGroupComponent = (props) => {
@@ -116,4 +114,4 @@ CommentsNewForm.propTypes = {
   prefilledProps: PropTypes.object
 };
 
-registerComponent('CommentsNewForm', CommentsNewForm, withMessages, withStyles(styles));
+registerComponent('CommentsNewForm', CommentsNewForm, withUser, withMessages, withStyles(styles));

--- a/packages/lesswrong/components/posts/PostsNewForm.jsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.jsx
@@ -6,22 +6,24 @@ import { withRouter } from 'react-router';
 import Helmet from 'react-helmet';
 import withUser from '../common/withUser'
 
-const PostsNewForm = (props, context) => {
+const PostsNewForm = ({router, currentUser, flash}) => {
   const mapsAPIKey = getSetting('googleMaps.apiKey', null);
   const prefilledProps = {
-    isEvent: props.router.location.query && props.router.location.query.eventForm,
-    types: props.router.location.query && props.router.location.query.ssc ? ['SSC'] : [],
-    meta: props.router.location.query && !!props.router.location.query.meta,
+    isEvent: router.location.query && router.location.query.eventForm,
+    types: router.location.query && router.location.query.ssc ? ['SSC'] : [],
+    meta: router.location.query && !!router.location.query.meta,
     frontpageDate: getSetting("AlignmentForum", false) ? new Date() : null,
-    af: getSetting("AlignmentForum", false) || (props.router.location.query && !!props.router.location.query.af),
-    groupId: props.router.location.query && props.router.location.query.groupId,
-    moderationStyle: props.currentUser && props.currentUser.moderationStyle,
-    moderationGuidelinesHtmlBody: props.currentUser && props.currentUser.moderationGuidelinesHtmlBody,
+    af: getSetting("AlignmentForum", false) || (router.location.query && !!router.location.query.af),
+    groupId: router.location.query && router.location.query.groupId,
+    moderationStyle: currentUser && currentUser.moderationStyle,
+    moderationGuidelinesHtmlBody: currentUser && currentUser.moderationGuidelinesHtmlBody,
   }
-  return <Components.ShowIf
-    check={Posts.options.mutations.new.check}
-    failureComponent={<Components.AccountsLoginForm />}
-         >
+  
+  if (!Posts.options.mutations.new.check(currentUser)) {
+    return (<Components.AccountsLoginForm />);
+  }
+  
+  return (
     <div className="posts-new-form">
       {prefilledProps.isEvent && <Helmet><script src={`https://maps.googleapis.com/maps/api/js?key=${mapsAPIKey}&libraries=places`}/></Helmet>}
       <Components.SmartForm
@@ -29,15 +31,15 @@ const PostsNewForm = (props, context) => {
         mutationFragment={getFragment('PostsPage')}
         prefilledProps={prefilledProps}
         successCallback={post => {
-          props.router.push({pathname: Posts.getPageUrl(post)});
-          props.flash({ id: 'posts.created_message', properties: { title: post.title }, type: 'success'});
+          router.push({pathname: Posts.getPageUrl(post)});
+          flash({ id: 'posts.created_message', properties: { title: post.title }, type: 'success'});
         }}
-        eventForm={props.router.location.query && props.router.location.query.eventForm}
+        eventForm={router.location.query && router.location.query.eventForm}
         submitLabel="Publish"
         repeatErrors
       />
     </div>
-  </Components.ShowIf>
+  );
 }
 
 

--- a/packages/lesswrong/components/questions/NewAnswerForm.jsx
+++ b/packages/lesswrong/components/questions/NewAnswerForm.jsx
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
+import withUser from '../common/withUser'
 
 const styles = theme => ({
   answersForm: {
@@ -55,7 +56,7 @@ const FormGroupComponent = (props) => {
   </React.Fragment>
 }
 
-const NewAnswerForm = ({postId, classes}) => {
+const NewAnswerForm = ({postId, classes, currentUser}) => {
 
   const SubmitComponent = ({submitLabel = "Submit"}) => {
     return <div className={classes.submit}>
@@ -69,27 +70,26 @@ const NewAnswerForm = ({postId, classes}) => {
   }
 
   const prefilledProps = { postId: postId, answer: true }
-  const { SmartForm, ShowIf } = Components
+  const { SmartForm } = Components
+  
+  if (!Comments.options.mutations.new.check(currentUser)) {
+    return <FormattedMessage id="users.cannot_comment"/>;
+  }
+  
   return (
-    <ShowIf
-      check={Comments.options.mutations.new.check}
-      document={prefilledProps}
-      failureComponent={<FormattedMessage id="users.cannot_comment"/>}
-    >
-      <div className={classes.answersForm}>
-        <Typography variant="display1" className={classes.title}>
-          New Answer
-        </Typography>
-        <SmartForm
-          collection={Comments}
-          GroupComponent={FormGroupComponent}
-          SubmitComponent={SubmitComponent}
-          mutationFragment={getFragment('CommentsList')}
-          prefilledProps={prefilledProps}
-          layout="elementOnly"
-        />
-      </div>
-    </ShowIf>
+    <div className={classes.answersForm}>
+      <Typography variant="display1" className={classes.title}>
+        New Answer
+      </Typography>
+      <SmartForm
+        collection={Comments}
+        GroupComponent={FormGroupComponent}
+        SubmitComponent={SubmitComponent}
+        mutationFragment={getFragment('CommentsList')}
+        prefilledProps={prefilledProps}
+        layout="elementOnly"
+      />
+    </div>
   )
 };
 
@@ -99,4 +99,4 @@ NewAnswerForm.propTypes = {
   prefilledProps: PropTypes.object
 };
 
-registerComponent('NewAnswerForm', NewAnswerForm, withMessages, withStyles(styles, {name:"NewAnswerForm"}));
+registerComponent('NewAnswerForm', NewAnswerForm, withMessages, withUser, withStyles(styles, {name:"NewAnswerForm"}));

--- a/packages/lesswrong/components/sunshineDashboard/AdminHome.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AdminHome.jsx
@@ -143,81 +143,83 @@ class AdminHome extends PureComponent {
   }
 
   render() {
+    const { currentUser } = this.props;
+    
+    if (!Users.isAdmin(currentUser)) {
+      return (
+        <div className="admin-home page">
+          <p className="admin-home-message"><FormattedMessage id="app.noPermission" /></p>
+        </div>
+      );
+    }
+    
     return (
       <div className="admin-home page">
-        <Components.ShowIf
-          check={Users.isAdmin}
-          document={this.props.currentUser}
-          failureComponent={
-            <p className="admin-home-message"><FormattedMessage id="app.noPermission" /></p>
-          }
-        >
-          <div className="admin-home-layout">
-            <h2>Admin Console</h2>
-            <div>
-              <div className="admin-recent-logins">
-                <h3>Recent Logins</h3>
-                <Components.Datatable
-                  collection={LWEvents}
-                  columns={eventColumns}
-                  options={{
-                    fragmentName: 'lwEventsAdminPageFragment',
-                    terms: {view: 'adminView', name: 'login'},
-                    limit: 10,
-                  }}
-                />
-              </div>
-              <div className="admin-all-users">
-                <h3>All Users</h3>
-                <Select
-                  value={this.state.allUsersValue}
-                  onChange={(event) => {
-                    this.setState({allUsersValue: event.target.value});
-                  }}
-                >
-                  {adminViewsOfAllUsers.map((userView, i) =>
-                    <MenuItem key={i} value={i}>
-                      {userView.label}
-                    </MenuItem>
-                  )}
-                </Select>
-                <Components.Datatable
-                  collection={Users}
-                  columns={AdminColumns}
-                  options={{
-                    fragmentName: 'UsersAdmin',
-                    terms: {
-                      view: adminViewsOfAllUsers[this.state.allUsersValue].view,
-                      sort: adminViewsOfAllUsers[this.state.allUsersValue].sort,
-                    },
-                    limit: 20
-                  }}
-                  showEdit={true}
-                  showNew={false}
-                />
-              </div>
-              <div className="admin-new-ip-bans">
-                <h3>New IP Bans</h3>
-                <Components.SmartForm
-                  collection={Bans}
-                />
-              </div>
-              <div className="admin-current-ip-bans">
-                <h3>Current IP Bans</h3>
-                <Components.Datatable
-                  collection={Bans}
-                  columns={banColumns}
-                  options={{
-                    fragmentName: 'BansAdminPageFragment',
-                    terms: {},
-                    limit: 10,
-                  }}
-                  showEdit={true}
-                />
-              </div>
+        <div className="admin-home-layout">
+          <h2>Admin Console</h2>
+          <div>
+            <div className="admin-recent-logins">
+              <h3>Recent Logins</h3>
+              <Components.Datatable
+                collection={LWEvents}
+                columns={eventColumns}
+                options={{
+                  fragmentName: 'lwEventsAdminPageFragment',
+                  terms: {view: 'adminView', name: 'login'},
+                  limit: 10,
+                }}
+              />
+            </div>
+            <div className="admin-all-users">
+              <h3>All Users</h3>
+              <Select
+                value={this.state.allUsersValue}
+                onChange={(event) => {
+                  this.setState({allUsersValue: event.target.value});
+                }}
+              >
+                {adminViewsOfAllUsers.map((userView, i) =>
+                  <MenuItem key={i} value={i}>
+                    {userView.label}
+                  </MenuItem>
+                )}
+              </Select>
+              <Components.Datatable
+                collection={Users}
+                columns={AdminColumns}
+                options={{
+                  fragmentName: 'UsersAdmin',
+                  terms: {
+                    view: adminViewsOfAllUsers[this.state.allUsersValue].view,
+                    sort: adminViewsOfAllUsers[this.state.allUsersValue].sort,
+                  },
+                  limit: 20
+                }}
+                showEdit={true}
+                showNew={false}
+              />
+            </div>
+            <div className="admin-new-ip-bans">
+              <h3>New IP Bans</h3>
+              <Components.SmartForm
+                collection={Bans}
+              />
+            </div>
+            <div className="admin-current-ip-bans">
+              <h3>Current IP Bans</h3>
+              <Components.Datatable
+                collection={Bans}
+                columns={banColumns}
+                options={{
+                  fragmentName: 'BansAdminPageFragment',
+                  terms: {},
+                  limit: 10,
+                }}
+                showEdit={true}
+              />
             </div>
           </div>
-        </Components.ShowIf>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Vulcan's `Components.ShowIf` is problematic in two ways. First, it has a `withCurrentUser`, hence a GraphQL queries, hence it's slow (on the order of 6ms per component instance). And second, it's confusing, and (in most of our usages), slightly wrong--it gets the number of arguments wrong in many cases, calling things like `Users.isAdmin(currentUser, currentUser)`behind the scenes. This doesn't have real consequences in any of our usages (extra arguments are ignored), but it's a trap.

Remove all usages of `Components.ShowIf`.