### PR TITLE
Switch views from $in:[false,null] to false

### DIFF
--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -160,7 +160,7 @@ function CommentsEditSoftDeleteCallback (comment, oldComment) {
 addCallback("comments.edit.async", CommentsEditSoftDeleteCallback);
 
 function ModerateCommentsPostUpdate (comment, oldComment) {
-  const comments = Comments.find({postId:comment.postId, deleted: {$in: [false,null]}}).fetch()
+  const comments = Comments.find({postId:comment.postId, deleted: false}).fetch()
 
   const lastComment = _.max(comments, (c) => c.postedAt)
   const lastCommentedAt = (lastComment && lastComment.postedAt) || Posts.findOne({_id:comment.postId}).postedAt

--- a/packages/lesswrong/lib/collections/comments/views.js
+++ b/packages/lesswrong/lib/collections/comments/views.js
@@ -10,7 +10,7 @@ Comments.addDefaultView(terms => {
   const alignmentForum = getSetting('AlignmentForum', false) ? {af: true} : {}
   return ({
     selector: {
-      $or: [{$and: [{deleted: true}, {deletedPublic: true}]}, {deleted: {$in: [false,null]}}],
+      $or: [{$and: [{deleted: true}, {deletedPublic: true}]}, {deleted: false}],
       hideAuthor: terms.userId ? {$in: [false,null]} : undefined,
       ...validFields,
       ...alignmentForum,
@@ -68,7 +68,7 @@ Comments.addView("postCommentsTop", function (terms) {
     selector: {
       postId: terms.postId,
       parentAnswerId: { $in: [false,null] },
-      answer: { $in: [false,null] },
+      answer: false,
     },
     options: {sort: {deleted: 1, baseScore: -1, postedAt: -1}},
 
@@ -81,7 +81,7 @@ Comments.addView("postCommentsOld", function (terms) {
     selector: {
       postId: terms.postId,
       parentAnswerId: { $in: [false,null] },
-      answer: { $in: [false,null] },
+      answer: false,
     },
     options: {sort: {deleted: 1, postedAt: 1}},
     parentAnswerId: { $in: [false,null] }
@@ -94,7 +94,7 @@ Comments.addView("postCommentsNew", function (terms) {
     selector: {
       postId: terms.postId,
       parentAnswerId: { $in: [false,null] },
-      answer: { $in: [false,null] },
+      answer: false,
     },
     options: {sort: {deleted: 1, postedAt: -1}}
   };
@@ -106,7 +106,7 @@ Comments.addView("postCommentsBest", function (terms) {
     selector: {
       postId: terms.postId,
       parentAnswerId: { $in: [false,null] },
-      answer: { $in: [false,null] },
+      answer: false,
     },
     options: {sort: {deleted: 1, baseScore: -1}, postedAt: -1}
   };
@@ -118,7 +118,7 @@ Comments.addView("postLWComments", function (terms) {
     selector: {
       postId: terms.postId,
       af: null,
-      answer: { $in: [false,null] },
+      answer: false,
       parentAnswerId: { $in: [false,null] }
     },
     options: {sort: {deleted: 1, baseScore: -1, postedAt: -1}}
@@ -127,14 +127,14 @@ Comments.addView("postLWComments", function (terms) {
 
 Comments.addView("allRecentComments", function (terms) {
   return {
-    selector: {deletedPublic: {$in: [false,null]}},
+    selector: {deletedPublic: false},
     options: {sort: {postedAt: -1}, limit: terms.limit || 5},
   };
 });
 
 Comments.addView("recentComments", function (terms) {
   return {
-    selector: { score:{$gt:0}, deletedPublic: {$in: [false,null]}},
+    selector: { score:{$gt:0}, deletedPublic: false},
     options: {sort: {postedAt: -1}, limit: terms.limit || 5},
   };
 });
@@ -146,7 +146,7 @@ Comments.addView("recentDiscussionThread", function (terms) {
     selector: {
       postId: terms.postId,
       score: {$gt:0},
-      deletedPublic: {$in: [false,null]},
+      deletedPublic: false,
       postedAt: {$gt: eighteenHoursAgo}
     },
     options: {sort: {postedAt: -1}, limit: terms.limit || 5}
@@ -160,7 +160,7 @@ Comments.addView("afRecentDiscussionThread", function (terms) {
     selector: {
       postId: terms.postId,
       score: {$gt:0},
-      deletedPublic: {$in: [false,null]},
+      deletedPublic: false,
       postedAt: {$gt: sevenDaysAgo},
       af: true,
     },
@@ -172,7 +172,7 @@ Comments.addView("postCommentsUnread", function (terms) {
   return {
     selector: {
       postId: terms.postId,
-      deleted: {$in: [false,null] },
+      deleted: false,
       score: {$gt: 0}
     },
     options: {sort: {postedAt: -1}, limit: terms.limit || 15},
@@ -189,7 +189,7 @@ Comments.addView("sunshineNewCommentsList", function (terms) {
         {baseScore: {$lte:0}}
       ],
       reviewedByUserId: {$exists:false},
-      deleted: {$in: [false,null]},
+      deleted: false,
       postedAt: {$gt: twoDaysAgo},
     },
     options: {sort: {postedAt: -1}, limit: terms.limit || 5},

--- a/packages/lesswrong/lib/collections/comments/views.js
+++ b/packages/lesswrong/lib/collections/comments/views.js
@@ -1,7 +1,7 @@
 import { getSetting } from 'meteor/vulcan:core'
 import { Comments } from './index';
 import moment from 'moment';
-import { ensureIndex } from '../../collectionUtils';
+import { ensureIndex,  combineIndexWithDefaultViewIndex} from '../../collectionUtils';
 
 // Auto-generated indexes from production
 
@@ -11,7 +11,7 @@ Comments.addDefaultView(terms => {
   return ({
     selector: {
       $or: [{$and: [{deleted: true}, {deletedPublic: true}]}, {deleted: false}],
-      hideAuthor: terms.userId ? {$in: [false,null]} : undefined,
+      hideAuthor: terms.userId ? false : undefined,
       ...validFields,
       ...alignmentForum,
     }
@@ -20,7 +20,11 @@ Comments.addDefaultView(terms => {
 
 export function augmentForDefaultView(indexFields)
 {
-  return {...indexFields, deleted:1, deletedPublic:1, hideAuthor:1, userId:1, af:1};
+  return combineIndexWithDefaultViewIndex({
+    viewFields: indexFields,
+    prefix: {deleted:1, deletedPublic:1},
+    suffix: {hideAuthor:1, userId:1, af:1},
+  });
 }
 
 // Most common case: want to get all the comments on a post, filter fields and

--- a/packages/lesswrong/lib/collections/notifications/views.js
+++ b/packages/lesswrong/lib/collections/notifications/views.js
@@ -20,7 +20,7 @@ Notifications.addView("userNotifications", (terms) => {
     selector: {
       userId: terms.userId,
       type: terms.type || null,
-      viewed: terms.viewed == null ? null : (terms.viewed || {$in: [false,null]})
+      viewed: terms.viewed == null ? null : (terms.viewed || false)
     }, //Ugly construction to deal with falsy viewed values and null != false in Mongo
     options: {sort: {createdAt: -1}}
   }

--- a/packages/lesswrong/lib/collections/posts/custom_fields.js
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.js
@@ -570,6 +570,7 @@ Posts.addField([
       insertableBy: ['admins'],
       control: 'checkbox',
       group: formGroups.moderationGroup,
+      ...schemaDefaultValue(false),
     }
   },
 
@@ -1027,7 +1028,7 @@ Posts.addField([
           if (document.question) {
 
             const answers = await Comments.find(
-              {answer:true, postId: document._id, deleted:{$in:[null, false]}},
+              {answer:true, postId: document._id, deleted:false},
               {sort:questionAnswersSort}
             ).fetch()
 
@@ -1058,7 +1059,7 @@ Posts.addField([
           }
           if (tocData) {
             const commentCount = await Comments.find(
-              {answer:{$in:[false, null]}, parentAnswerId:{$in:[undefined,null]}, postId: document._id }).count()
+              {answer:false, parentAnswerId:{$in:[undefined,null]}, postId: document._id }).count()
             tocData.sections.push({anchor:"comments", level:0, title:Posts.getCommentCountStr(document, commentCount)})
           }
           return tocData;

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -40,8 +40,8 @@ export function augmentForDefaultView(indexFields)
 {
   return combineIndexWithDefaultViewIndex({
     viewFields: indexFields,
-    prefix: {status:1},
-    suffix: { _id:1, isFuture:1, draft:1, meta:1, groupId:1, af:1, isEvent:1, unlisted:1, postedAt:1, baseScore:1 },
+    prefix: {status:1, isFuture:1, draft:1, meta:1, isEvent:1, unlisted:1 },
+    suffix: { _id:1, groupId:1, af:1, postedAt:1, baseScore:1 },
   });
 }
 

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -17,12 +17,12 @@ Posts.addDefaultView(terms => {
   let params = {
     selector: {
       status: Posts.config.STATUS_APPROVED,
-      draft: {$in: [false,null]},
-      isFuture: {$in: [false,null]}, // match both false and undefined
-      unlisted: {$in: [false,null]},
-      meta: {$in: [false,null]},
+      draft: false,
+      isFuture: false,
+      unlisted: false,
+      meta: false,
       groupId: {$exists: false},
-      isEvent: {$in: [false,null]},
+      isEvent: false,
       ...validFields,
       ...alignmentForum
     }
@@ -31,7 +31,7 @@ Posts.addDefaultView(terms => {
     params.selector.maxBaseScore = {$gte: parseInt(terms.karmaThreshold, 10)}
   }
   if (terms.userId) {
-    params.selector.hideAuthor = {$in: [false,null]}
+    params.selector.hideAuthor = false
   }
   return params;
 })
@@ -152,7 +152,7 @@ Posts.addView("old", terms => ({
 Posts.addView("daily", terms => ({
   selector: {
     baseScore: {$gt: terms.karmaThreshold || -100},
-    authorIsUnreviewed: {$in: [false,null]},
+    authorIsUnreviewed: false,
   },
   options: {
     sort: {score: -1}
@@ -168,7 +168,7 @@ ensureIndex(Posts,
 Posts.addView("frontpage", terms => ({
   selector: {
     frontpageDate: {$gt: new Date(0)},
-    authorIsUnreviewed: {$in: [false,null]},
+    authorIsUnreviewed: false,
   },
   options: {
     sort: {sticky: -1, score: -1}
@@ -222,7 +222,7 @@ Posts.addView("community", terms => ({
   selector: {
     frontpageDate: null,
     meta: null,
-    authorIsUnreviewed: {$in: [false,null]},
+    authorIsUnreviewed: false,
   },
   options: {
     sort: {sticky: -1, score: -1}
@@ -264,7 +264,7 @@ Posts.addView('rss', Posts.views['community-rss']); // default to 'community-rss
 Posts.addView("questions", terms => ({
   selector: {
     question: true,
-    authorIsUnreviewed: {$in: [false,null]},
+    authorIsUnreviewed: false,
   },
   options: {
     sort: {sticky: -1, score: -1}
@@ -300,8 +300,8 @@ Posts.addView("drafts", terms => {
     selector: {
       userId: terms.userId,
       draft: true,
-      deletedDraft: {$in: [false,null]},
-      hideAuthor: {$in: [false,null]},
+      deletedDraft: false,
+      hideAuthor: false,
       unlisted: null,
       meta: null,
     },
@@ -380,11 +380,11 @@ Posts.addView("recentDiscussionThreadsList", terms => {
   return {
     selector: {
       baseScore: {$gt:0},
-      hideFrontpageComments: {$in: [false,null]},
+      hideFrontpageComments: false,
       meta: null,
       groupId: null,
       isEvent: null,
-      authorIsUnreviewed: {$in: [false,null]},
+      authorIsUnreviewed: false,
     },
     options: {
       sort: {lastCommentedAt:-1},
@@ -557,7 +557,7 @@ Posts.addView("afRecentDiscussionThreadsList", terms => {
   return {
     selector: {
       baseScore: {$gt:0},
-      hideFrontpageComments: {$in: [false,null]},
+      hideFrontpageComments: false,
       af: true,
       meta: null,
       groupId: null,

--- a/packages/lesswrong/lib/collections/sequences/callbacks.js
+++ b/packages/lesswrong/lib/collections/sequences/callbacks.js
@@ -18,13 +18,13 @@ function UpdateUserSequenceCount (sequence) {
   if (sequence.userId) {
     const sequences = Sequences.find({
       userId: sequence.userId,
-      draft: {$in: [false,null]},
-      isDeleted: {$in: [false,null]}
+      draft: false,
+      isDeleted: false
     }).fetch()
     const drafts = Sequences.find({
       userId: sequence.userId,
       draft: true,
-      isDeleted: {$in: [false,null]}
+      isDeleted: false
     }).fetch()
     Users.update(sequence.userId, {$set: {
       'sequenceCount':sequences.length,

--- a/packages/lesswrong/lib/collections/sequences/views.js
+++ b/packages/lesswrong/lib/collections/sequences/views.js
@@ -6,7 +6,7 @@ Sequences.addDefaultView(terms => {
   const alignmentForum = getSetting('AlignmentForum', false) ? {af: true} : {}
   let params = {
     selector: {
-      hidden: {$in: [false,null]},
+      hidden: false,
       ...alignmentForum
     }
   }
@@ -22,8 +22,8 @@ Sequences.addView("userProfile", function (terms) {
   return {
     selector: {
       userId: terms.userId,
-      isDeleted: {$in: [false,null]},
-      draft: {$in: [false,null]},
+      isDeleted: false,
+      draft: false,
     },
     options: {
       sort: {
@@ -38,7 +38,7 @@ Sequences.addView("userProfileAll", function (terms) {
   return {
     selector: {
       userId: terms.userId,
-      isDeleted: {$in: [false,null]},
+      isDeleted: false,
     },
     options: {
       sort: {
@@ -54,9 +54,9 @@ Sequences.addView("curatedSequences", function (terms) {
     selector: {
       userId: terms.userId,
       curatedOrder: {$exists: true},
-      isDeleted: {$in: [false,null]},
+      isDeleted: false,
       gridImageId: {$ne: null },
-      draft: {$in: [false,null]},
+      draft: false,
     },
     options: {
       sort: {
@@ -75,8 +75,8 @@ Sequences.addView("communitySequences", function (terms) {
       curatedOrder: {$exists: false},
       gridImageId: {$ne: null },
       canonicalCollectionSlug: { $in: [null, ""] },
-      isDeleted: {$in: [false,null]},
-      draft: {$in: [false,null]},
+      isDeleted: false,
+      draft: false,
     },
     options: {
       sort: {

--- a/packages/lesswrong/lib/modules/alignment-forum/comments/callbacks.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/comments/callbacks.js
@@ -7,7 +7,7 @@ function recalculateAFCommentMetadata(postId) {
   const afComments = Comments.find({
     postId:postId,
     af: true,
-    deleted: {$in: [false,null]}
+    deleted: false
   }).fetch()
 
   const lastComment = _.max(afComments, function(c){return c.postedAt;})

--- a/packages/lesswrong/lib/modules/alignment-forum/comments/views.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/comments/views.js
@@ -5,7 +5,7 @@ import { augmentForDefaultView } from '../../../collections/comments/views';
 Comments.addView("alignmentSuggestedComments", function () {
   return {
     selector: {
-      af: {$in: [false,null]},
+      af: false,
       suggestForAlignmentUserIds: {$exists:true, $ne: []},
       reviewForAlignmentUserId: {$exists:false}
     },

--- a/packages/lesswrong/lib/modules/alignment-forum/posts/views.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/posts/views.js
@@ -5,7 +5,7 @@ import { augmentForDefaultView } from '../../../collections/posts/views';
 Posts.addView("alignmentSuggestedPosts", function () {
   return {
     selector: {
-      af: {$in: [false,null]},
+      af: false,
       suggestForAlignmentUserIds: {$exists:true, $ne: []},
       reviewForAlignmentUserId: {$exists:false}
     },


### PR DESCRIPTION
This is the followup to an earlier PR which gave boolean fields default values. It requires running the migration function from that PR (even if it was run after that earlier PR, because this one nonnullable-ifies another field).