### PR TITLE
Speed up client side JS: Fix shouldComponentUpdate on CommentsList

### DIFF
--- a/packages/lesswrong/components/comments/CommentsList.jsx
+++ b/packages/lesswrong/components/comments/CommentsList.jsx
@@ -24,10 +24,16 @@ class CommentsList extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     if(!shallowEqual(this.state, nextState))
       return true;
-    if(!shallowEqualExcept(this.props, nextProps, ["post","comments","editMutation"]))
+    
+    if(!shallowEqualExcept(this.props, nextProps,
+      ["post","comments","editMutation","updateComment"]))
+    {
       return true;
+    }
+    
     if(this.props.post==null || nextProps.post==null || this.props.post._id != nextProps.post._id)
       return true;
+    
     if(this.commentTreesDiffer(this.props.comments, nextProps.comments))
       return true;
     return false;

--- a/packages/lesswrong/lib/events/withNewEvents.jsx
+++ b/packages/lesswrong/lib/events/withNewEvents.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import uuid from 'uuid/v4';
 import { LWEvents } from '../collections/lwevents/collection.js';
+import { shallowEqual } from '../modules/utils/componentUtils';
 
 
 /*
@@ -19,6 +20,16 @@ function withNewEvents(WrappedComponent) {
       this.registerEvent = this.registerEvent.bind(this);
       this.closeEvent = this.closeEvent.bind(this);
     }
+    
+    // Don't update on changes to state.events (which is this component's
+    // only state), because that doesn't affect rendering at all and gets
+    // modified in mount events.
+    shouldComponentUpdate(nextProps, nextState) {
+      if (!shallowEqual(this.props, nextProps))
+        return true;
+      return false;
+    }
+    
     registerEvent(name, properties) {
       const newMutation = this.props.newMutation;
       const { userId, documentId, important, intercom, ...rest} = properties;
@@ -87,5 +98,4 @@ const newEventOptions = {
   fragmentName: 'newEventFragment',
 }
 
-// export default withNew(newEventOptions)(withEvents);
 export default withNewEvents;


### PR DESCRIPTION
The `shouldComponentUpdate` function on `commentsList` was broken by a Vulcan upgrade, which added an additional spurious prop to `withEdit` that we need to filter out. Fix that. Also avoid spurious updates to `withNewEvents`. Also, add a `shouldComponentUpdate` to `CommentsNode` so that if a comment updates without the whole `CommentsList` updating (usual case: clicking a vote button), only the changed comment has to rerender.

On posts with lots of comments (anything with >=500 will be the same), this takes ~1s off of load time (debug mode, MBP2015) and reduces vote-click time from ~1.0s to ~0.4s.

