### PR TITLE
Sorting Posts (UserProfile + AllPosts)

### DIFF
--- a/packages/lesswrong/components/common/Home.jsx
+++ b/packages/lesswrong/components/common/Home.jsx
@@ -56,7 +56,7 @@ const Home = (props, context) => {
         </Components.Section>}
       <Components.Section title={recentPostsTitle}
         titleComponent= {<div className="recent-posts-title-component">
-          <Components.PostsViews />
+          <Components.HomePostsViews />
         </div>}
         subscribeLinks={<Components.SubscribeWidget view={recentPostsTerms.view} />}
       >

--- a/packages/lesswrong/components/common/Meta.jsx
+++ b/packages/lesswrong/components/common/Meta.jsx
@@ -5,7 +5,7 @@ import withUser from '../common/withUser';
 
 const Meta = ({location, currentUser}, context) => {
   const query = location ? location.query : {};
-  const recentPostsTerms = { view: 'magicalSorting', limit: 10, ...query, meta: true, forum: true }
+  const recentPostsTerms = { view: 'magic', limit: 10, ...query, meta: true, forum: true }
   return (
     <div className="home">
       <Components.Section title="Recent Meta Posts"

--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -7,7 +7,6 @@ const styles = theme => ({
   titleSettings: {
     marginTop: 10,
     width: 150,
-
     [theme.breakpoints.up('md')]: {
       float: "right"
     }
@@ -35,21 +34,28 @@ class AllPostsPage extends Component {
 
   renderTitle = () => {
     const { classes } = this.props;
-    return <div className={classes.titleSettings}>
-      <Checkbox
-        classes={{root: classes.checkbox, checked: classes.checkboxChecked}}
-        checked={this.state.hideLowKarma}
-        onChange={(event, checked) => this.setState({hideLowKarma: checked})}
-      />
-      <span className={classes.checkboxLabel}>
-        Hide Low Karma
-      </span>
+    return <div>
+      <Components.PostsViews defaultView="community" hideDaily={true}/>
+      <div className={classes.titleSettings}>
+        <Checkbox
+          classes={{root: classes.checkbox, checked: classes.checkboxChecked}}
+          checked={this.state.hideLowKarma}
+          onChange={(event, checked) => this.setState({hideLowKarma: checked})}
+        />
+        <span className={classes.checkboxLabel}>
+          Hide Low Karma
+        </span>
+      </div>
     </div>
   }
 
   render() {
+
+    const query = _.clone(this.props.router.location.query || {});
+
     const terms = {
       view:"new",
+      ...query,
       karmaThreshold: this.state.hideLowKarma ? -10 : -100,
       limit:100
     }

--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -2,50 +2,69 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import { withStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = theme => ({
   titleSettings: {
-    marginTop: 10,
-    width: 150,
+    width: "100%",
+    fontStyle: "italic",
+    cursor: "pointer",
+    opacity: .8,
     [theme.breakpoints.up('md')]: {
       float: "right"
+    },
+    '&:hover': {
+      opacity:1,
+    },
+    '& svg': {
+      width: ".8em",
+      marginTop: -4,
+      marginRight: 3
     }
   },
   checkbox: {
-    padding: 0
+    padding: 0,
   },
   checkboxChecked: {
     // Tone down the material-UI default color to the shade old-material-UI was
     // using, since the new, darker green doesn't fit the deemphasized position
     // this element is in.
     "& svg": {
-      color: "rgba(100, 169, 105, 0.7)"
+      color: "rgba(100, 169, 105, 0.7)",
     }
   },
   checkboxLabel: {
     ...theme.typography.subheading,
     marginLeft: 5
   },
+  divider: {
+    margin:"10px 0 12px 82%",
+    borderBottom: "solid 1px rgba(0,0,0,.15)"
+  }
 });
 
 class AllPostsPage extends Component {
 
-  state = { hideLowKarma: true }
+  state = { lowKarma: false }
 
   renderTitle = () => {
     const { classes } = this.props;
+    const { lowKarma } = this.state
+    const { PostsViews } = Components
     return <div>
-      <Components.PostsViews defaultView="community" hideDaily={true}/>
-      <div className={classes.titleSettings}>
-        <Checkbox
-          classes={{root: classes.checkbox, checked: classes.checkboxChecked}}
-          checked={this.state.hideLowKarma}
-          onChange={(event, checked) => this.setState({hideLowKarma: checked})}
-        />
-        <span className={classes.checkboxLabel}>
-          Hide Low Karma
-        </span>
-      </div>
+      <PostsViews />
+      <div className={classes.divider} />
+      <Tooltip title="Show low karma posts" placement="right">
+        <div className={classes.titleSettings} onClick={(event) => this.setState({lowKarma: !lowKarma})}>
+          <Checkbox
+            classes={{root: classes.checkbox, checked: classes.checkboxChecked}}
+            checked={lowKarma}
+          />
+          <span className={classes.checkboxLabel}>
+            Low Karma
+          </span>
+        </div>
+      </Tooltip>
     </div>
   }
 
@@ -56,7 +75,7 @@ class AllPostsPage extends Component {
     const terms = {
       view:"new",
       ...query,
-      karmaThreshold: this.state.hideLowKarma ? -10 : -100,
+      karmaThreshold: this.state.lowKarma ? -100 : -10,
       limit:100
     }
 

--- a/packages/lesswrong/components/posts/HomePostsViews.jsx
+++ b/packages/lesswrong/components/posts/HomePostsViews.jsx
@@ -1,0 +1,173 @@
+import { Components, registerComponent, withEdit } from 'meteor/vulcan:core';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { intlShape } from 'meteor/vulcan:i18n';
+import { withRouter, Link } from 'react-router'
+import Icon from '@material-ui/core/Icon';
+import { withStyles } from '@material-ui/core/styles';
+import classnames from 'classnames';
+import Users from 'meteor/vulcan:users';
+import postViewSections from '../../lib/sections.js'
+import withUser from '../common/withUser';
+
+const defaultViews = ["curated", "frontpage"];
+const defaultExpandedViews = ["community"];
+
+const styles = theme => ({
+  categoryIcon: {
+    position: "relative",
+    fontSize: "14px",
+    color: "white",
+    verticalAlign: "middle",
+    bottom: 1,
+    marginRight: 2
+  },
+
+  helpIcon: {
+    position: "relative",
+    fontSize: "14px",
+    color: "white",
+    top: 2,
+    marginRight: 1,
+  },
+});
+
+
+class HomePostsViews extends Component {
+  constructor(props) {
+    super(props);
+    const expandedViews = this.props.expandedViews || defaultExpandedViews;
+    const currentView = this.getCurrentView();
+    this.state = {
+      expanded: !!expandedViews.includes(currentView),
+    }
+  }
+
+  handleChange = (view, event) => {
+    const { router } = this.props;
+    const query = { ...router.location.query, view };
+    const location = { pathname: router.location.pathname, query };
+    router.replace(location);
+    this.setState({ view });
+    if (this.props.currentUser && router.location.pathname === "/") {
+      this.props.editMutation({
+        documentId: this.props.currentUser._id,
+        set: {currentFrontpageFilter: view},
+        unset: {}
+      })
+    }
+  }
+
+  getCurrentView = () => {
+    const props = this.props;
+    return _.clone(props.router.location.query).view || props.defaultView || (props.currentUser && props.currentUser.currentFrontpageFilter) || (this.props.currentUser ? "frontpage" : "curated");
+  }
+
+  renderMenu = (viewData, view) => {
+    const { classes } = this.props;
+    return (
+      <div className="view-chip-menu-wrapper">
+        <div className="view-chip-menu">
+          <div className="view-chip-menu-item description">
+            {viewData.categoryIcon && <Icon className={classnames("material-icons", classes.categoryIcon)}>
+              {viewData.categoryIcon}
+            </Icon>}
+            {viewData.description}
+          </div>
+          { viewData.includes && <div className="view-chip-menu-item includes">{viewData.includes}</div>}
+          { viewData.learnMoreLink && <div className="view-chip-menu-item learn-more">
+            <Link to={viewData.learnMoreLink}>
+              <Icon className={classnames("material-icons", classes.helpIcon)}>help</Icon>
+              <span style={{color:"white"}}> Learn More</span>
+            </Link>
+          </div>}
+        </div>
+      </div>
+    )
+  }
+
+  render() {
+    const props = this.props;
+    const views = props.views || defaultViews;
+    let expandedViews = props.expandedViews || defaultExpandedViews;
+    const currentView = this.getCurrentView();
+    // const adminViews = ["pending", "rejected", "scheduled", "all_drafts"];
+    //
+    // if (Users.canDo(this.props.currentUser, "posts.edit.all")) {
+    //   expandedViews = expandedViews.concat(adminViews);
+    // }
+
+    return (
+      <div className="posts-views">
+        {views.map(view => (
+          <div key={view} className={classnames("posts-view-button", {"posts-views-button-active": view === currentView, "posts-views-button-inactive": view !== currentView})}>
+
+            <span className="view-chip" onClick={() => this.handleChange(view)}>
+              <Components.SectionSubtitle className={view === currentView ? "posts-views-chip-active" : "posts-views-chip-inactive"}>
+                {postViewSections[view].label}
+                { this.renderMenu(postViewSections[view], view)}
+              </Components.SectionSubtitle>
+            </span>
+          </div>
+        ))}
+        {(this.state.expanded || this.props.currentUser) ?
+          <span>
+            {expandedViews.map(view => (
+              <div
+                key={view}
+                className={classnames(
+                    "posts-view-button",
+                  {"posts-views-button-active": view === currentView, "posts-views-button-inactive": view !== currentView}
+                )}
+              >
+                <span className="view-chip" onClick={() => this.handleChange(view)} >
+                  <Components.SectionSubtitle className={view === currentView ? "posts-views-chip-active" : "posts-views-chip-inactive"}>
+                    {postViewSections[view].label}
+                    { this.renderMenu(postViewSections[view])}
+                  </Components.SectionSubtitle>
+                </span>
+              </div>
+            ))}
+            {!props.hideDaily && <div className="posts-view-button"><span className="view-chip">
+              <Components.SectionSubtitle className={"posts-views-chip-inactive"}>
+                <Link to="/meta">Meta</Link> { this.renderMenu(postViewSections["meta"])}
+              </Components.SectionSubtitle></span>
+            </div>}
+            {!props.hideDaily && <span className="view-chip">
+              <Components.SectionSubtitle className={"posts-views-chip-inactive"}>
+                <Link to="/daily">Daily</Link> { this.renderMenu(postViewSections["daily"])}
+              </Components.SectionSubtitle>
+            </span>}
+          </span> : <span>
+            <div className="view-chip more"
+              onClick={() => this.setState({expanded: true})}>
+              ...
+              { this.renderMenu(postViewSections["more"])}
+            </div>
+          </span>
+        }
+        <br/>
+      </div>
+    )
+  }
+}
+
+HomePostsViews.propTypes = {
+  currentUser: PropTypes.object,
+  defaultView: PropTypes.string
+};
+
+HomePostsViews.contextTypes = {
+  currentRoute: PropTypes.object,
+  intl: intlShape
+};
+
+HomePostsViews.displayName = "HomePostsViews";
+
+const withEditOptions = {
+  collection: Users,
+  fragmentName: 'UsersCurrent',
+};
+
+registerComponent('HomePostsViews', HomePostsViews, withRouter, withUser, [withEdit, withEditOptions],
+  withStyles(styles, { name: "HomePostsViews" }));

--- a/packages/lesswrong/components/posts/PostsList.jsx
+++ b/packages/lesswrong/components/posts/PostsList.jsx
@@ -5,10 +5,17 @@ import { Posts } from '../../lib/collections/posts';
 import { FormattedMessage, intlShape } from 'meteor/vulcan:i18n';
 import classNames from 'classnames';
 import withUser from '../common/withUser';
+import { withStyles } from '@material-ui/core/styles'
 
 const Error = ({error}) => <div>
   <FormattedMessage id={error.id} values={{value: error.value}}/>{error.message}
 </div>;
+
+const styles = theme => ({
+  loading: {
+    opacity: .4,
+  }
+})
 
 const PostsList = ({
   className,
@@ -23,6 +30,7 @@ const PostsList = ({
   networkStatus,
   currentUser,
   error,
+  classes,
   terms}) => {
 
   // TODO-Q: Is there a composable way to check whether this is the second
@@ -32,6 +40,9 @@ const PostsList = ({
   //         Alternatively, is there a better way of checking that this is
   //         in fact the best way of checking loading status?
   const loadingMore = networkStatus === 2 || networkStatus === 1;
+
+  const { Loading } = Components
+
   const renderContent = () => {
     if (results && results.length) {
       return <div>
@@ -49,7 +60,8 @@ const PostsList = ({
     }
   }
   return (
-    <div className={classNames(className, 'posts-list')}>
+    <div className={classNames(className, 'posts-list', {[classes.loading]: loading})}>
+      {loading && <Loading/> }
       {showHeader ? <Components.PostsListHeader/> : null}
       {error ? <Error error={Utils.decodeIntlError(error)} /> : null }
       <div className="posts-list-content">
@@ -86,4 +98,4 @@ const options = {
   ssr: true
 };
 
-registerComponent('PostsList', PostsList, withUser, [withList, options]);
+registerComponent('PostsList', PostsList, withUser, [withList, options], withStyles(styles, {name:"PostsList"}));

--- a/packages/lesswrong/components/posts/PostsViews.jsx
+++ b/packages/lesswrong/components/posts/PostsViews.jsx
@@ -15,15 +15,15 @@ const styles = theme => ({
     fontWeight: 600,
   },
   filter: {
-    cursor: "pointer",
     color: theme.palette.grey[400],
-    '&:hover': {
-      opacity:.7
-    }
   },
   selected: {
     color: theme.palette.grey[800],
   },
+  divider: {
+    margin: "10px 0 10px 80%",
+    borderBottom: "solid 1px rgba(0,0,0,.2)"
+  }
 })
 
 class PostsViews extends Component {
@@ -33,7 +33,7 @@ class PostsViews extends Component {
     this.state = {
       anchorEl: null,
       view: query && query.view || "new",
-      filter: query && query.filter
+      filter: query && query.filter || "all"
     }
   }
 
@@ -61,7 +61,7 @@ class PostsViews extends Component {
       ...currentQuery,
       view: view || this.state.view,
       postId: post ? post._id : undefined,
-      filter: filter || this.state.filter
+      filter: filter || this.state.filter || "all",
     }
     router.replace({...router.location, query: query})
   };
@@ -74,7 +74,9 @@ class PostsViews extends Component {
     const { currentUser, router, classes } = this.props
     const { anchorEl, filter } = this.state
 
-    let views = ['magic', 'new', 'old', 'top', 'unread'];
+    const { SectionSubtitle } = Components
+
+    let views = ['magic', 'new', 'old', 'top', 'recentComments'];
     const adminViews = [
       // 'pending', 'rejected', 'scheduled'
     ];
@@ -87,37 +89,39 @@ class PostsViews extends Component {
 
     return (
       <div>
-        sorted by <a className={classes.view} onClick={this.handleSortClick}>{ currentView }</a>
-        <Menu
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={this.handleClose}
-        >
-          {views.map(view => {
-            return(
-              <MenuItem key={view} onClick={() => this.handleViewClick(view)}>
-                { view }
-              </MenuItem>)})}
-        </Menu>
-        <div> —–––— </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="all"})} onClick={()=>this.setFilter("all")}>
-          All
-        </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="curated"})} onClick={()=>this.setFilter("curated")}>
+        <SectionSubtitle>
+          sorted by <a className={classes.view} onClick={this.handleSortClick}>{ currentView }</a>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={this.handleClose}
+          >
+            {views.map(view => {
+              return(
+                <MenuItem key={view} onClick={() => this.handleViewClick(view)}>
+                  { view }
+                </MenuItem>)})}
+          </Menu>
+        </SectionSubtitle>
+        <div className={classes.divider}/>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="curated"})} onClick={()=>this.setFilter("curated")}>
           Curated
-        </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="frontpage"})} onClick={()=>this.setFilter("frontpage")}>
+        </SectionSubtitle>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="frontpage"})} onClick={()=>this.setFilter("frontpage")}>
           Frontpage
-        </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="questions"})} onClick={()=>this.setFilter("questions")}>
+        </SectionSubtitle>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="questions"})} onClick={()=>this.setFilter("questions")}>
           Questions
-        </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="events"})} onClick={()=>this.setFilter("events")}>
+        </SectionSubtitle>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="events"})} onClick={()=>this.setFilter("events")}>
           Events
-        </div>
-        <div className={classNames(classes.filter, {[classes.selected]:filter==="meta"})} onClick={()=>this.setFilter("meta")}>
+        </SectionSubtitle>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="meta"})} onClick={()=>this.setFilter("meta")}>
           Meta
-        </div>
+        </SectionSubtitle>
+        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="all"})} onClick={()=>this.setFilter("all")}>
+          All
+        </SectionSubtitle>
       </div>
     );
   }

--- a/packages/lesswrong/components/posts/PostsViews.jsx
+++ b/packages/lesswrong/components/posts/PostsViews.jsx
@@ -23,6 +23,10 @@ const styles = theme => ({
   divider: {
     margin: "10px 0 10px 80%",
     borderBottom: "solid 1px rgba(0,0,0,.2)"
+  },
+  bottomDivider: {
+    margin: "10px 0 10px 85%",
+    borderBottom: "solid 1px rgba(0,0,0,.15)"
   }
 })
 
@@ -104,24 +108,36 @@ class PostsViews extends Component {
           </Menu>
         </SectionSubtitle>
         <div className={classes.divider}/>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="curated"})} onClick={()=>this.setFilter("curated")}>
-          Curated
-        </SectionSubtitle>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="frontpage"})} onClick={()=>this.setFilter("frontpage")}>
-          Frontpage
-        </SectionSubtitle>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="questions"})} onClick={()=>this.setFilter("questions")}>
-          Questions
-        </SectionSubtitle>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="events"})} onClick={()=>this.setFilter("events")}>
-          Events
-        </SectionSubtitle>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="meta"})} onClick={()=>this.setFilter("meta")}>
-          Meta
-        </SectionSubtitle>
-        <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="all"})} onClick={()=>this.setFilter("all")}>
-          All
-        </SectionSubtitle>
+        <div onClick={()=>this.setFilter("curated")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="curated"})}>
+            Curated
+          </SectionSubtitle>
+        </div>
+        <div onClick={()=>this.setFilter("frontpage")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="frontpage"})}>
+            Frontpage
+          </SectionSubtitle>
+        </div>
+        <div onClick={()=>this.setFilter("questions")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="questions"})}>
+            Questions
+          </SectionSubtitle>
+        </div>
+        <div onClick={()=>this.setFilter("events")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="events"})}>
+            Events
+          </SectionSubtitle>
+        </div>
+        <div onClick={()=>this.setFilter("meta")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="meta"})}>
+            Meta
+          </SectionSubtitle>
+        </div>
+        <div onClick={()=>this.setFilter("all")}>
+          <SectionSubtitle className={classNames(classes.filter, {[classes.selected]:filter==="all"})}>
+            All
+          </SectionSubtitle>
+        </div>
       </div>
     );
   }

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -128,8 +128,8 @@ const UsersProfile = (props) => {
 
     const renderBlogPosts = (props) => {
       return (
-        <Components.Section title="Recent Posts"
-          titleComponent= {
+        <Components.Section title={`${user.displayName}'s Posts`}
+          titleComponent={
             <div className="recent-posts-title-component users-profile-recent-posts">
               <Components.PostsViews defaultView="community" hideDaily={true}/>
             </div>}
@@ -171,7 +171,7 @@ const UsersProfile = (props) => {
         { renderSequences(props) }
         { renderDrafts(props) }
         { renderBlogPosts(props) }
-        <Components.Section title="Recent Comments" >
+        <Components.Section title={`${user.displayName}'s Comments`} >
           <Components.RecentComments terms={{view: 'allRecentComments', limit: 10, userId: user._id}} fontSize="small" />
         </Components.Section>
       </div>

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -27,6 +27,8 @@ Posts.addDefaultView(terms => {
     }
   }
   if (terms.karmaThreshold && terms.karmaThreshold !== "0") {
+    console.log("asdf")
+    params.selector.baseScore = {$gte: parseInt(terms.karmaThreshold, 10)}
     params.selector.maxBaseScore = {$gte: parseInt(terms.karmaThreshold, 10)}
   }
   if (terms.userId) {
@@ -172,9 +174,6 @@ Posts.addView("old", terms => ({
 // Covered by the same index as `new`
 
 Posts.addView("daily", terms => ({
-  selector: {
-    baseScore: {$gt: terms.karmaThreshold || -100}
-  },
   options: {
     sort: {score: -1}
   }

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -161,6 +161,10 @@ ensureIndex(Posts,
   }
 );
 
+Posts.addView("recentComments", terms => ({
+  options: {sort: {lastCommentedAt:-1}}
+}))
+
 
 Posts.addView("old", terms => ({
   options: {sort: setStickies({postedAt: 1}, terms)}

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -27,7 +27,6 @@ Posts.addDefaultView(terms => {
     }
   }
   if (terms.karmaThreshold && terms.karmaThreshold !== "0") {
-    console.log("asdf")
     params.selector.baseScore = {$gte: parseInt(terms.karmaThreshold, 10)}
     params.selector.maxBaseScore = {$gte: parseInt(terms.karmaThreshold, 10)}
   }

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -9,7 +9,7 @@ import moment from 'moment';
  * @summary Base parameters that will be common to all other view unless specific properties are overwritten
  */
 Posts.addDefaultView(terms => {
-  const validFields = _.pick(terms, 'userId', 'meta', 'groupId', 'af', 'authorIsUnreviewed');
+  const validFields = _.pick(terms, 'userId', 'meta', 'groupId', 'af','question', 'authorIsUnreviewed');
   // Also valid fields: before, after, timeField (select on postedAt), and
   // karmaThreshold (selects on baseScore).
 
@@ -31,6 +31,25 @@ Posts.addDefaultView(terms => {
   }
   if (terms.userId) {
     params.selector.hideAuthor = false
+  }
+
+  if (terms.filter === "curated") {
+    params.selector.curatedDate ={$gt: new Date(0)}
+  }
+  if (terms.filter === "frontpage") {
+    params.selector.frontpageDate = {$gt: new Date(0)}
+  }
+  if (terms.filter === "all") {
+    params.selector.groupId = null
+  }
+  if (terms.filter === "questions") {
+    params.selector.question = true
+  }
+  if (terms.filter === "events") {
+    params.selector.isEvent = true
+  }
+  if (terms.filter === "meta") {
+    params.selector.meta = true
   }
   return params;
 })
@@ -80,7 +99,7 @@ const stickiesIndexPrefix = {
 };
 
 
-Posts.addView("magicalSorting", terms => ({
+Posts.addView("magic", terms => ({
   options: {sort: setStickies({score: -1}, terms)}
 }))
 ensureIndex(Posts,

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -95,6 +95,7 @@ import '../components/posts/PostsItemWrapper.jsx';
 import '../components/posts/PostsItemNewCommentsWrapper.jsx';
 import '../components/posts/PostsPage';
 import '../components/posts/PostsPageAdminActions.jsx';
+import '../components/posts/HomePostsViews.jsx';
 import '../components/posts/PostsViews.jsx';
 import '../components/posts/PostsSingleSlug.jsx';
 import '../components/posts/PostsSingleRoute.jsx';

--- a/packages/lesswrong/lib/i18n-en-us/en_US.js
+++ b/packages/lesswrong/lib/i18n-en-us/en_US.js
@@ -26,8 +26,6 @@ addStrings('en', {
   'posts.top': 'Top',
   'posts.new': 'New',
   'posts.best': 'Best',
-  'posts.old': 'Old',
-  'posts.unread': 'Unread',
   'posts.pending': 'Pending',
   'posts.rejected': 'Rejected',
   'posts.scheduled': 'Scheduled',

--- a/packages/lesswrong/lib/i18n-en-us/en_US.js
+++ b/packages/lesswrong/lib/i18n-en-us/en_US.js
@@ -26,6 +26,8 @@ addStrings('en', {
   'posts.top': 'Top',
   'posts.new': 'New',
   'posts.best': 'Best',
+  'posts.old': 'Old',
+  'posts.unread': 'Unread',
   'posts.pending': 'Pending',
   'posts.rejected': 'Rejected',
   'posts.scheduled': 'Scheduled',

--- a/packages/lesswrong/styles/_other.scss
+++ b/packages/lesswrong/styles/_other.scss
@@ -9,13 +9,6 @@
   }
 }
 
-// TODO: Possibly unused
-.dropdown-item.active{
-  a{
-    color: white;
-  }
-}
-
 .email-link {
   text-decoration: underline !important;
 


### PR DESCRIPTION
Includes:
 – updated PostsViews component, which lets users sort in different ways, and filter in different ways

 – after some reflection, I left the curated/frontpage/all distinction as it current is, rather than trying to be clever with the new "toggle personal posts" checkbox. We can do that when we actually are ready for a major UI overhaul, for now it seemed least confusing to stick with the current paradigm

 – I also added it to the /allPosts page (still currently not linked to from anywhere, but now is a pretty well-functioning page)

 – I added a view for "recentComments" which sorts by lastCommentedAt. This was something I could imagine wanting with some frequency to see which of my own posts were recently discussed, and on the allPosts page would let you keep up with recent discussion more easily.