### PR TITLE
Record user-agent and referrer with posts

### DIFF
--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -123,6 +123,23 @@ addCallback('comments.remove.async', CommentsRemoveChildrenComments);
 // other                                            //
 //////////////////////////////////////////////////////
 
+function AddReferrerToComment(comment, properties)
+{
+  if (properties && properties.context && properties.context.headers) {
+    let referrer = properties.context.headers["referer"];
+    let origin = properties.context.headers["origin"];
+    let userAgent = properties.context.headers["user-agent"];
+    
+    return {
+      ...comment,
+      referrer: referrer,
+      userAgent: userAgent,
+    };
+  }
+}
+addCallback("comment.create.before", AddReferrerToComment);
+
+
 function UsersRemoveDeleteComments (user, options) {
   if (options.deleteComments) {
     Comments.remove({userId: user._id});

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -127,7 +127,6 @@ function AddReferrerToComment(comment, properties)
 {
   if (properties && properties.context && properties.context.headers) {
     let referrer = properties.context.headers["referer"];
-    let origin = properties.context.headers["origin"];
     let userAgent = properties.context.headers["user-agent"];
     
     return {

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -171,7 +171,6 @@ function AddReferrerToPost(post, properties)
 {
   if (properties && properties.context && properties.context.headers) {
     let referrer = properties.context.headers["referer"];
-    let origin = properties.context.headers["origin"];
     let userAgent = properties.context.headers["user-agent"];
     
     return {

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -166,3 +166,19 @@ function PostsNewUserApprovedStatus (post) {
 }
 
 addCallback("posts.new.sync", PostsNewUserApprovedStatus);
+
+function AddReferrerToPost(post, properties)
+{
+  if (properties && properties.context && properties.context.headers) {
+    let referrer = properties.context.headers["referer"];
+    let origin = properties.context.headers["origin"];
+    let userAgent = properties.context.headers["user-agent"];
+    
+    return {
+      ...post,
+      referrer: referrer,
+      userAgent: userAgent,
+    };
+  }
+}
+addCallback("post.create.before", AddReferrerToPost);


### PR DESCRIPTION
The post/comment schemas we inherited from Vulcan/Example-Forum already had fields for a referrer and a user agent, but they weren't being filled in. The reason they weren't being filled in was because the Vulcan mutator callbacks weren't providing callbacks with the necessary information.

This is a pair of commits/PRs, one against Vulcan which adds that information, and one against LessWrong which uses it to fill in referrer and userAgent fields on posts and comments. This isn't used anywhere on the site directly, but is something we want for analytics; most notably, we want to know where comments/posts are posted from so we can better distinguish between LessWrong users and GreaterWrong users.