### PR TITLE
Kill a unit test that was pseudo-failing

### DIFF
--- a/packages/lesswrong/testing/voting.tests.js
+++ b/packages/lesswrong/testing/voting.tests.js
@@ -16,23 +16,6 @@ chai.use(chaiAsPromised);
 describe('Voting', async function() {
   describe('batchUpdating', async function() {
     this.timeout(20000)
-    it('updates if post in the future', async function(){
-      const user = await createDummyUser();
-      const currentTime = new Date();
-      const tomorrow = currentTime.getTime()+(1*24*60*60*1000)
-      const in_a_month = currentTime.getTime()+(30*24*60*60*1000)
-      const in_half_an_hour = currentTime.getTime()+(30*60*1000)
-      const in_ten_minutes = currentTime.getTime()+(10*60*1000)
-      const dates = [tomorrow, in_ten_minutes, in_half_an_hour, tomorrow, in_a_month];
-      dates.forEach(async date => {
-        const post = await createDummyPost(user, {postedAt: date});
-        await batchUpdateScore({collection: Posts});
-        const updatedPost = await Posts.find({_id: post._id}).fetch();
-
-        updatedPost[0].score.should.equal(0);
-        updatedPost[0].postedAt.should.be.closeTo(date, 1000);
-      })
-    });
     it('does not update if post is inactive', async () => {
       const user = await createDummyUser();
       const yesterday = new Date().getTime()-(1*24*60*60*1000)


### PR DESCRIPTION
Fix #1244. The unit test Voting/batchUpdating/updates if post in the future was failing in a way where it would output the failure to stderr, rather than actually fail the tests. Also, the test was incorrect--its assertion that future posts should have their score updated was incorrect (they shouldn't have their score updated).