### PR TITLE
Update posts default index, and a missing Notifications index

### DIFF
--- a/packages/lesswrong/lib/collections/notifications/views.js
+++ b/packages/lesswrong/lib/collections/notifications/views.js
@@ -38,3 +38,7 @@ Notifications.addView("unreadUserNotifications", (terms) => {
   }
 })
 ensureIndex(Notifications, {userId:1, type:1, createdAt:-1});
+
+// Index used in callbacks for finding notifications related to a document
+// that is being deleted
+ensureIndex(Notifications, {documentId:1});

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -59,8 +59,8 @@ export function augmentForDefaultView(indexFields)
 {
   return combineIndexWithDefaultViewIndex({
     viewFields: indexFields,
-    prefix: {status:1, isFuture:1, draft:1, meta:1, isEvent:1, unlisted:1,  authorIsUnreviewed:1, groupId:1 },
-    suffix: { _id:1, af:1, postedAt:1, baseScore:1 },
+    prefix: {status:1, isFuture:1, draft:1, unlisted:1, authorIsUnreviewed:1, groupId:1 },
+    suffix: { _id:1, meta:1, isEvent:1, af:1, frontpageDate:1, curatedDate:1, postedAt:1, baseScore:1 },
   });
 }
 


### PR DESCRIPTION
This (hopefully) fixes indexing issues introduced in/noticed after our last deploy to master.