### PR TITLE
Handle index name conflicts

### DIFF
--- a/packages/lesswrong/lib/collectionUtils.js
+++ b/packages/lesswrong/lib/collectionUtils.js
@@ -4,9 +4,37 @@ SimpleSchema.extendOptions([ 'canAutofillDefault' ]);
 
 export let expectedIndexes = {};
 
+// Returns true if the specified index has a name, and the collection has an
+// existing index with the same name but different columns or options.
+async function conflictingIndexExists(collection, index, options)
+{
+  if (!options.name)
+    return false;
+  
+  let existingIndexes = await collection.rawCollection().indexes();
+  
+  for (let existingIndex of existingIndexes) {
+    if (existingIndex.name === options.name) {
+      if (!_.isEqual(existingIndex.key, index)
+         || !_.isEqual(existingIndex.partialFilterExpression, options.partialFilterExpression))
+      {
+        return true;
+      }
+    }
+  }
+  
+  return false;
+}
+
 export async function ensureIndex(collection, index, options)
 {
   if (Meteor.isServer) {
+    if (options.name && await conflictingIndexExists(collection, index, options)) {
+      //eslint-disable-next-line no-console
+      console.log(`Differing index exists with the same name: ${options.name}. Dropping.`);
+      collection.rawCollection().dropIndex(options.name);
+    }
+    
     const mergedOptions = {background: true, ...options};
     collection._ensureIndex(index, mergedOptions);
     


### PR DESCRIPTION
Modifies ensureIndex so that if there's a preexisting index with the same name, but different keys, the old index gets dropped.