### PR TITLE
Upgrade ESLint, fix a spurious warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^5.5.0",
+    "eslint": "^5.12.1",
     "eslint-config-meteor": "^0.1.1",
     "eslint-import-resolver-meteor": "^0.4.0",
     "eslint-plugin-babel": "^5.1.0",

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -265,9 +265,8 @@ class CommentsItem extends Component {
   }
 
   renderReply = () => {
-    const levelClass = ((this.props.nestingLevel || 1) + 1) % 2 === 0 ? "comments-node-even" : "comments-node-odd"
-
-    const { currentUser, post, comment, parentAnswerId } = this.props
+    const { currentUser, post, comment, parentAnswerId, nestingLevel=1 } = this.props
+    const levelClass = (nestingLevel + 1) % 2 === 0 ? "comments-node-even" : "comments-node-odd"
 
     return (
       <div className={classNames("comments-item-reply", levelClass)}>


### PR DESCRIPTION
ESLint got confused by (this.props.nestingLevel||1) as a default-value-for-missing-variable idiom, assuming that the expression was being used as a boolean rather than as an arithmetic value. Since the version of ESLint is unpinned, this was causing lint failures on CircleCI (but not on our dev machines, which were all still on a slightly out of date ESLint version which didn't have this warning).