### PR TITLE
Catch unhandled promiseRejection and log

### DIFF
--- a/packages/lesswrong/server/logging.js
+++ b/packages/lesswrong/server/logging.js
@@ -13,3 +13,16 @@ function initializeTimber() {
 }
 
 addCallback('graphql.init.before', initializeTimber)
+
+// Log unhandled promise rejections, eg exceptions escaping from async
+// callbacks. The default node behavior is to silently ignore these exceptions,
+// which is terrible and has led to unnoticed bugs in the past.
+process.on("unhandledRejection", r => {
+  //eslint-disable-next-line no-console
+  console.log(r);
+  
+  if (r.stack) {
+    //eslint-disable-next-line no-console
+    console.log(r.stack);
+  }
+});


### PR DESCRIPTION
Log unhandled promise rejections, eg exceptions escaping from async callbacks. The default node behavior is to silently ignore these exceptions, which is terrible and has led to unnoticed bugs in the past.