### PR TITLE
Views don't use $in:[false,null]

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.js
+++ b/packages/lesswrong/lib/collections/comments/views.js
@@ -1,4 +1,5 @@
 import { getSetting } from 'meteor/vulcan:core'
+import { viewFieldNullOrMissing } from 'meteor/vulcan:lib';
 import { Comments } from './index';
 import moment from 'moment';
 import { ensureIndex,  combineIndexWithDefaultViewIndex} from '../../collectionUtils';
@@ -74,7 +75,7 @@ Comments.addView("postCommentsTop", function (terms) {
   return {
     selector: {
       postId: terms.postId,
-      parentAnswerId: { $in: [false,null] },
+      parentAnswerId: viewFieldNullOrMissing,
       answer: false,
     },
     options: {sort: {deleted: 1, baseScore: -1, postedAt: -1}},
@@ -87,11 +88,11 @@ Comments.addView("postCommentsOld", function (terms) {
   return {
     selector: {
       postId: terms.postId,
-      parentAnswerId: { $in: [false,null] },
+      parentAnswerId: viewFieldNullOrMissing,
       answer: false,
     },
     options: {sort: {deleted: 1, postedAt: 1}},
-    parentAnswerId: { $in: [false,null] }
+    parentAnswerId: viewFieldNullOrMissing
   };
 });
 // Uses same index as postCommentsNew
@@ -100,7 +101,7 @@ Comments.addView("postCommentsNew", function (terms) {
   return {
     selector: {
       postId: terms.postId,
-      parentAnswerId: { $in: [false,null] },
+      parentAnswerId: viewFieldNullOrMissing,
       answer: false,
     },
     options: {sort: {deleted: 1, postedAt: -1}}
@@ -112,7 +113,7 @@ Comments.addView("postCommentsBest", function (terms) {
   return {
     selector: {
       postId: terms.postId,
-      parentAnswerId: { $in: [false,null] },
+      parentAnswerId: viewFieldNullOrMissing,
       answer: false,
     },
     options: {sort: {deleted: 1, baseScore: -1}, postedAt: -1}
@@ -126,7 +127,7 @@ Comments.addView("postLWComments", function (terms) {
       postId: terms.postId,
       af: null,
       answer: false,
-      parentAnswerId: { $in: [false,null] }
+      parentAnswerId: viewFieldNullOrMissing
     },
     options: {sort: {deleted: 1, baseScore: -1, postedAt: -1}}
   };

--- a/packages/lesswrong/lib/collections/posts/custom_fields.js
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.js
@@ -1059,8 +1059,8 @@ Posts.addField([
           }
           if (tocData) {
             const selector = {
-              answer:false,
-              parentAnswerId:{$in:[undefined,null]},
+              answer: false,
+              parentAnswerId: null,
               postId: document._id
             }
             if (document.af && getSetting('AlignmentForum', false)) {

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -1,5 +1,6 @@
 import { Posts } from './collection';
 import Users from 'meteor/vulcan:users';
+import { viewFieldNullOrMissing } from 'meteor/vulcan:lib';
 import { getSetting } from 'meteor/vulcan:core';
 import { ensureIndex,  combineIndexWithDefaultViewIndex} from '../../collectionUtils';
 import moment from 'moment';
@@ -549,7 +550,7 @@ Posts.addView("sunshineNewPosts", function () {
   return {
     selector: {
       reviewedByUserId: {$exists: false},
-      frontpageDate: {$in: [false,null] },
+      frontpageDate: viewFieldNullOrMissing,
       authorIsUnreviewed: null
     },
     options: {


### PR DESCRIPTION
Requires matching Vulcan PR: https://github.com/LessWrong2/Vulcan/pull/58 , to make it possible to use `field: null` queries in Vulcan views and have them actually reach Mongo.