### PR TITLE
Add schema-version migration script, reset-on-edit callback

### DIFF
--- a/packages/lesswrong/lib/collectionUtils.js
+++ b/packages/lesswrong/lib/collectionUtils.js
@@ -131,3 +131,13 @@ export function addUniversalFields({ collection, schemaVersion=1 }) {
   ])
   ensureIndex(collection, {schemaVersion: 1});
 }
+
+export function isUnbackedCollection(collection)
+{
+  if (collection.collectionName === 'Settings' || collection.collectionName === 'Callbacks') {
+    // Vulcan collections with no backing database table
+    return true;
+  }
+  
+  return false;
+}

--- a/packages/lesswrong/lib/collectionUtils.js
+++ b/packages/lesswrong/lib/collectionUtils.js
@@ -116,7 +116,7 @@ export function schemaDefaultValue(defaultValue) {
   }
 }
 
-export function addUniversalFields({ collection }) {
+export function addUniversalFields({ collection, schemaVersion=1 }) {
   collection.addField([
     {
       fieldName: 'schemaVersion',
@@ -124,7 +124,8 @@ export function addUniversalFields({ collection }) {
         type: Number,
         canRead: ['guests'],
         optional: true,
-        ...schemaDefaultValue(1)
+        ...schemaDefaultValue(schemaVersion),
+        onUpdate: () => schemaVersion
       }
     }
   ])

--- a/packages/lesswrong/server/indexUtil.js
+++ b/packages/lesswrong/server/indexUtil.js
@@ -1,15 +1,6 @@
 import { expectedIndexes } from '../lib/collectionUtils';
 import { Collections } from 'meteor/vulcan:lib';
-
-function isUnbackedCollection(collection)
-{
-  if (collection.collectionName === 'Settings' || collection.collectionName === 'Callbacks') {
-    // Vulcan collections with no backing database table
-    return true;
-  }
-  
-  return false;
-}
+import { isUnbackedCollection } from '../lib/collectionUtils';
 
 function indexesMatch(indexA, indexB)
 {

--- a/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
+++ b/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
@@ -1,0 +1,39 @@
+import { registerMigration, migrateDocuments } from './migrationUtils';
+import { editableCollections } from '../../lib/editor/make_editable'
+import { getCollection } from 'meteor/vulcan:core'
+
+registerMigration({
+  name: "addSchemaVersionToEditableCollections",
+  idempotent: true,
+  action: async () => {
+    for (let collectionName of editableCollections) {
+      const collection = getCollection(collectionName)
+      await migrateDocuments({
+        description: `Add schema version to ${collectionName}`,
+        collection,
+        batchSize: 1000,
+        unmigratedDocumentQuery: {
+          schemaVersion: {$exists: false}
+        },
+        migrate: async (documents) => {
+          const updates = documents.map(doc => {
+            return {
+              updateOne: {
+                filter: {_id: doc._id},
+                update: {
+                  $set: {
+                    schemaVersion: 0,
+                  }
+                }
+              }
+            }
+          })
+          await collection.rawCollection().bulkWrite(
+            updates,
+            { ordered: false }
+          )
+        }
+      })
+    }
+  },
+});

--- a/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
+++ b/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
@@ -24,7 +24,7 @@ registerMigration({
                 filter: {_id: doc._id},
                 update: {
                   $set: {
-                    schemaVersion: 0,
+                    schemaVersion: 1,
                   }
                 }
               }

--- a/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
+++ b/packages/lesswrong/server/migrations/2019-02-04-addSchemaVersionEverywhere.js
@@ -1,15 +1,17 @@
+import { Collections } from 'meteor/vulcan:core'
 import { registerMigration, migrateDocuments } from './migrationUtils';
-import { editableCollections } from '../../lib/editor/make_editable'
-import { getCollection } from 'meteor/vulcan:core'
+import { isUnbackedCollection } from '../../lib/collectionUtils';
 
 registerMigration({
-  name: "addSchemaVersionToEditableCollections",
+  name: "addSchemaVersionEverywhere",
   idempotent: true,
   action: async () => {
-    for (let collectionName of editableCollections) {
-      const collection = getCollection(collectionName)
+    for (let collection of Collections) {
+      if (isUnbackedCollection(collection))
+        continue;
+      
       await migrateDocuments({
-        description: `Add schema version to ${collectionName}`,
+        description: `Add schema version to ${collection.collectionName}`,
         collection,
         batchSize: 1000,
         unmigratedDocumentQuery: {

--- a/packages/lesswrong/server/migrations/index.js
+++ b/packages/lesswrong/server/migrations/index.js
@@ -3,4 +3,4 @@
 // and are named "YYYY-MM-DD-migrationDescription.js", with the date when the
 // script was written.
 
-import '2019-02-04-addSchemaVersionEverywhere'
+import './2019-02-04-addSchemaVersionEverywhere'

--- a/packages/lesswrong/server/migrations/index.js
+++ b/packages/lesswrong/server/migrations/index.js
@@ -3,3 +3,4 @@
 // and are named "YYYY-MM-DD-migrationDescription.js", with the date when the
 // script was written.
 
+import '2019-02-04-addSchemaVersionEverywhere'


### PR DESCRIPTION
Add schema-version migration script and reset-on-edit callback. This PR is against master, not devel, in preparation for our upcoming migration.