### PR TITLE
Update Mingo to 2.2.11, fix #1570

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7229,9 +7229,9 @@
       }
     },
     "mingo": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-2.2.2.tgz",
-      "integrity": "sha1-vmnUhq5uCsVLl53F9EEtshhR9pM="
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-2.2.11.tgz",
+      "integrity": "sha512-IATnFhuIT9gVttpOIoy+zEhbvsYNokza9xsgrjO4GV5T+8mVQeLZ/ez72O79oYy4Jj0NIbcTnrY1sCX4s8XUGw=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "mathjax-node": "^2.1.1",
     "mathjax-node-page": "^3.0.0",
     "meteor-node-stubs": "^0.2.3",
-    "mingo": "^2.2.0",
+    "mingo": "^2.2.11",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21",
     "optics-agent": "^1.1.6",


### PR DESCRIPTION
Update Mingo to 2.2.11. This should fix a crash on iPhone 6S, #1570, with [this PR](https://github.com/kofrasa/mingo/pull/98).