### PR TITLE
More flexible format for user page URLs

### DIFF
--- a/packages/lesswrong/components/users/UsersSingle.jsx
+++ b/packages/lesswrong/components/users/UsersSingle.jsx
@@ -1,10 +1,18 @@
-import { Components, registerComponent } from 'meteor/vulcan:core';
+import { Components, registerComponent, Utils } from 'meteor/vulcan:core';
 import React from 'react';
+import { withRouter } from 'react-router';
 
-const UsersSingle = (props, context) => {
-  return <Components.UsersProfile userId={props.params._id} slug={props.params.slug} />
+const UsersSingle = ({params, router}) => {
+  const slug = Utils.slugify(params.slug);
+  const canonicalUrl = `/users/${slug}`;
+  if (router.location.pathname !== canonicalUrl) {
+    router.replace(canonicalUrl);
+    return null;
+  } else {
+    return <Components.UsersProfile userId={params._id} slug={slug} />
+  }
 };
 
 UsersSingle.displayName = "UsersSingle";
 
-registerComponent('UsersSingle', UsersSingle);
+registerComponent('UsersSingle', UsersSingle, withRouter);

--- a/packages/lesswrong/components/users/UsersSingle.jsx
+++ b/packages/lesswrong/components/users/UsersSingle.jsx
@@ -1,10 +1,11 @@
 import { Components, registerComponent, Utils } from 'meteor/vulcan:core';
 import React from 'react';
 import { withRouter } from 'react-router';
+import Users from "meteor/vulcan:users";
 
 const UsersSingle = ({params, router}) => {
   const slug = Utils.slugify(params.slug);
-  const canonicalUrl = `/users/${slug}`;
+  const canonicalUrl = Users.getProfileUrlFromSlug(slug);
   if (router.location.pathname !== canonicalUrl) {
     router.replace(canonicalUrl);
     return null;

--- a/packages/lesswrong/components/users/UsersSingle.jsx
+++ b/packages/lesswrong/components/users/UsersSingle.jsx
@@ -7,6 +7,9 @@ const UsersSingle = ({params, router}) => {
   const slug = Utils.slugify(params.slug);
   const canonicalUrl = Users.getProfileUrlFromSlug(slug);
   if (router.location.pathname !== canonicalUrl) {
+    // A Javascript redirect, which replaces the history entry (so you don't
+    // have a redirector interfering with the back button). Does not cause a
+    // pageload.
     router.replace(canonicalUrl);
     return null;
   } else {

--- a/packages/lesswrong/lib/collections/users/helpers.js
+++ b/packages/lesswrong/lib/collections/users/helpers.js
@@ -1,6 +1,6 @@
 import Users from "meteor/vulcan:users";
 import bowser from 'bowser'
-import { getSetting } from 'meteor/vulcan:core';
+import { getSetting, Utils } from 'meteor/vulcan:core';
 import { Votes } from '../votes';
 import { Comments } from '../comments'
 import { Posts } from '../posts'
@@ -168,6 +168,24 @@ Users.emailAddressIsVerified = (user) => {
   }
   return false;
 };
+
+// Replaces Users.getProfileUrl from the vulcan-users package.
+Users.getProfileUrl = (user, isAbsolute=false) => {
+  if (!user) return "";
+  
+  if (user.slug) {
+    return Users.getProfileUrlFromSlug(user.slug, isAbsolute);
+  } else {
+    return "";
+  }
+}
+
+Users.getProfileUrlFromSlug = (userSlug, isAbsolute=false) => {
+  if (!userSlug) return "";
+  
+  const prefix = isAbsolute ? Utils.getSiteUrl().slice(0,-1) : '';
+  return `${prefix}/users/${userSlug}`;
+}
 
 
 

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -4,8 +4,8 @@ import { addRoute, getSetting} from 'meteor/vulcan:core';
 addRoute([
   {name:'posts.daily',      path:'daily',                 componentName: 'PostsDaily', title: "Posts by Day" },
   {name:'users.single',     path:'users/:slug',           componentName: 'UsersSingle'},
-  {name:'users.single.u',   path:'user/:slug',            componentName: 'UsersSingle'},
-  {name:'users.single.user',path:'u/:slug',               componentName: 'UsersSingle'},
+  {name:'users.single.user',   path:'user/:slug',            componentName: 'UsersSingle'},
+  {name:'users.single.u',path:'u/:slug',               componentName: 'UsersSingle'},
   {name:'users.account',    path:'account',               componentName: 'UsersAccount'},
   {name:'users.edit',       path:'users/:slug/edit',      componentName: 'UsersAccount'}
 ]);

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -4,6 +4,8 @@ import { addRoute, getSetting} from 'meteor/vulcan:core';
 addRoute([
   {name:'posts.daily',      path:'daily',                 componentName: 'PostsDaily', title: "Posts by Day" },
   {name:'users.single',     path:'users/:slug',           componentName: 'UsersSingle'},
+  {name:'users.single.u',   path:'user/:slug',            componentName: 'UsersSingle'},
+  {name:'users.single.user',path:'u/:slug',               componentName: 'UsersSingle'},
   {name:'users.account',    path:'account',               componentName: 'UsersAccount'},
   {name:'users.edit',       path:'users/:slug/edit',      componentName: 'UsersAccount'}
 ]);


### PR DESCRIPTION
You can now reach a user's user page via /u/<slug> or /user/<slug> (rather than just /users/<slug>). If you type something which isn't a slug (in the sense of Utils.slugify), it will be slugified. All non-canonical URLs are Javascript redirects to the canonical URL.

Fixes #1619.
