### PR TITLE
Don't omit 'validate' option in various mutator calls

### DIFF
--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -186,7 +186,8 @@ function ModerateCommentsPostUpdate (comment, oldComment) {
       lastCommentedAt:new Date(lastCommentedAt),
       commentCount:comments.length
     },
-    unset: {}
+    unset: {},
+    validate: false,
   })
 }
 addCallback("comments.moderate.async", ModerateCommentsPostUpdate);

--- a/packages/lesswrong/lib/modules/alignment-forum/comments/callbacks.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/comments/callbacks.js
@@ -20,7 +20,8 @@ function recalculateAFCommentMetadata(postId) {
       afLastCommentedAt:new Date(lastCommentedAt),
       afCommentCount:afComments.length
     },
-    unset: {}
+    unset: {},
+    validate: false,
   })
 }
 

--- a/packages/lesswrong/lib/modules/alignment-forum/posts/helpers.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/posts/helpers.js
@@ -6,7 +6,8 @@ Posts.suggestForAlignment = ({ currentUser, post, editMutation }) => {
   editMutation({
     documentId: post._id,
     set: {suggestForAlignmentUserIds: newSuggestUserIds},
-    unset: {}
+    unset: {},
+    validate: false,
   })
 }
 
@@ -16,6 +17,7 @@ Posts.unSuggestForAlignment = ({ currentUser, post, editMutation }) => {
   editMutation({
     documentId: post._id,
     set: {suggestForAlignmentUserIds:newSuggestUserIds},
-    unset: {}
+    unset: {},
+    validate: false,
   })
 }

--- a/packages/lesswrong/lib/modules/callbacks.js
+++ b/packages/lesswrong/lib/modules/callbacks.js
@@ -418,6 +418,7 @@ function userDeleteContent(user) {
       removeMutation({
         collection: Notifications,
         documentId: notification._id,
+        validate: false,
       })
     })
 
@@ -460,6 +461,7 @@ function userDeleteContent(user) {
       removeMutation({
         collection: Notifications,
         documentId: notification._id,
+        validate: false,
       })
     })
 


### PR DESCRIPTION
Vulcan's mutation functions have a named argument "validate", which was never meant to be optional. However, due to the way it's used (as a boolean with truthiness), it was effectively treated as an optional parameter with a default value of false. No code within Vulcan relies on this, but some code within LessWrong does. Fix that dependency, by always providing the argument to `validate`. Paired with a Vulcan PR, which will change the default value from falsy to truthy.


