### PR TITLE
Fix Removing Posts from Sequences

### DIFF
--- a/packages/lesswrong/components/sequences/BottomNavigationWrapper.jsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationWrapper.jsx
@@ -1,6 +1,7 @@
 import { Components, registerComponent, withDocument, Utils} from 'meteor/vulcan:core';
 import Sequences from '../../lib/collections/sequences/collection.js';
 import React from 'react';
+import withErrorBoundary from '../common/withErrorBoundary.jsx';
 
 const BottomNavigationWrapper = ({document, loading, post, router, nextTitle, nextLink}) => {
   if (document && !loading){
@@ -19,4 +20,4 @@ const options = {
   ssr: true,
 }
 
-registerComponent('BottomNavigationWrapper', BottomNavigationWrapper, [withDocument, options]);
+registerComponent('BottomNavigationWrapper', BottomNavigationWrapper, [withDocument, options], withErrorBoundary);

--- a/packages/lesswrong/components/sequences/SequencesNavigation.jsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigation.jsx
@@ -1,6 +1,7 @@
 import { Components, registerComponent, withDocument, Utils } from 'meteor/vulcan:core';
 import Sequences from '../../lib/collections/sequences/collection.js';
 import React from 'react';
+import withErrorBoundary from '../common/withErrorBoundary.jsx';
 
 const SequencesNavigation = ({
   document,
@@ -34,4 +35,4 @@ const options = {
   ssr: true
 }
 
-registerComponent('SequencesNavigation', SequencesNavigation, [withDocument, options]);
+registerComponent('SequencesNavigation', SequencesNavigation, [withDocument, options], withErrorBoundary);

--- a/packages/lesswrong/lib/collections/chapters/callbacks.js
+++ b/packages/lesswrong/lib/collections/chapters/callbacks.js
@@ -10,8 +10,17 @@ async function ChaptersEditCanonizeCallback (chapter) {
   const posts = await Sequences.getAllPosts(chapter.sequenceId)
   const sequence = await Sequences.findOne({_id:chapter.sequenceId})
 
-  posts.forEach((currentPost, i) => {
+  const allPostsInSequence = Posts.find({canonicalSequenceId: chapter.sequenceId}).fetch()
+  const removedPosts = _.difference(_.pluck(allPostsInSequence, '_id'), _.pluck(posts, '_id'))
+  removedPosts.forEach((postId) => {
+    Posts.update({_id: postId}, {$unset: {
+      canonicalPrevPostSlug: true,
+      canonicalNextPostSlug: true,
+      canonicalSequenceId: true,
+    }});
+  })
 
+  posts.forEach((currentPost, i) => {
     const validSequenceId = (currentPost, sequence) => {
       // Only update a post if it either doesn't have a canonicalSequence, or if we're editing
       // chapters *from* its canonicalSequence

--- a/packages/lesswrong/lib/collections/chapters/callbacks.js
+++ b/packages/lesswrong/lib/collections/chapters/callbacks.js
@@ -10,8 +10,9 @@ async function ChaptersEditCanonizeCallback (chapter) {
   const posts = await Sequences.getAllPosts(chapter.sequenceId)
   const sequence = await Sequences.findOne({_id:chapter.sequenceId})
 
-  const allPostsInSequence = Posts.find({canonicalSequenceId: chapter.sequenceId}).fetch()
-  const removedPosts = _.difference(_.pluck(allPostsInSequence, '_id'), _.pluck(posts, '_id'))
+  const postsWithCanonicalSequenceId = Posts.find({canonicalSequenceId: chapter.sequenceId}).fetch()
+  const removedPosts = _.difference(_.pluck(postsWithCanonicalSequenceId, '_id'), _.pluck(posts, '_id'))
+
   removedPosts.forEach((postId) => {
     Posts.update({_id: postId}, {$unset: {
       canonicalPrevPostSlug: true,


### PR DESCRIPTION
– Removing a post from a sequence chapter will now properly remove that post's canonicalSequence data
– added withErrorBounary to sequence navigation components