### PR TITLE
Validate that posts are contained by their canonical sequence

### DIFF
--- a/packages/lesswrong/lib/collections/posts/validate.js
+++ b/packages/lesswrong/lib/collections/posts/validate.js
@@ -1,0 +1,19 @@
+import { registerCollectionValidator } from '../../../server/scripts/validateDatabase.js';
+import { Posts } from './collection.js';
+import { Sequences } from '../sequences/collection.js';
+
+registerCollectionValidator({
+  collection: Posts,
+  name: "Canonical sequence contains post",
+  validateBatch: async (documents, recordError) => {
+    for (let post of documents) {
+      // If the post has a canonicalSequenceId, make sure that sequence contains the post
+      if (post.canonicalSequenceId) {
+        let postsInSequence = Sequences.getAllPosts(post.canonicalSequenceId);
+        let idsInSequence = _.map(postsInSequence, post=>post._id);
+        if (!_.find(idsInSequence, post._id))
+          recordError("canonicalSequenceId", `${post._id} is not contained by its canonical sequence`);
+      }
+    }
+  }
+});

--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -50,6 +50,7 @@ import './server/siteAdminMetadata.js';
 import './lib/collections/comments/callbacks.js';
 import './lib/collections/comments/graphql.js';
 import './lib/collections/posts/callbacks.js';
+import './lib/collections/posts/validate.js';
 import './lib/collections/chapters/callbacks.js';
 import './lib/collections/sequences/callbacks.js';
 import './lib/collections/books/callbacks.js';


### PR DESCRIPTION
Adds a mechanism to extend `validateDatabase` with arbitrary custom validation functions. Adds one such validation function, which checks that every post with a `canonicalSequenceId` is contained in its canonical sequence.