### PR TITLE
Remove all the useless sanitization in ellipsize.jsx

### DIFF
--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -12,19 +12,19 @@ export const highlightFromMarkdown = (body, mdi) => {
 }
 
 export const highlightFromHTML = (html) => {
-  return Utils.sanitize(truncatise(html, {
+  return truncatise(html, {
     TruncateLength: highlightMaxChars,
     TruncateBy: "characters",
     Suffix: "...",
-  }));
+  });
 };
 
 export const truncate = (html, truncateLength) => {
-  return Utils.sanitize(truncatise(html, {
+  return truncatise(html, {
     TruncateLength: Math.floor(truncateLength - (truncateLength/4)) || truncateLength,
     TruncateBy: "characters",
     Suffix: "...",
-  }));
+  });
 }
 
 export const postExcerptFromHTML = (html, truncationCharCount) => {
@@ -32,11 +32,11 @@ export const postExcerptFromHTML = (html, truncationCharCount) => {
   const styles = html.match(/<style[\s\S]*?<\/style>/g) || ""
   const htmlRemovedStyles = html.replace(/<style[\s\S]*?<\/style>/g, '');
 
-  return Utils.sanitize(truncatise(htmlRemovedStyles, {
+  return truncatise(htmlRemovedStyles, {
     TruncateLength: truncationCharCount || postExcerptMaxChars,
     TruncateBy: "characters",
     Suffix: `... <a class="read-more-default">(Read more)</a>${styles}`,
-  }));
+  });
 };
 
 export const commentExcerptFromHTML = (html, truncationCharCount) => {
@@ -44,14 +44,14 @@ export const commentExcerptFromHTML = (html, truncationCharCount) => {
   const styles = html.match(/<style[\s\S]*?<\/style>/g) || ""
   const htmlRemovedStyles = html.replace(/<style[\s\S]*?<\/style>/g, '');
 
-  return Utils.sanitize(truncatise(htmlRemovedStyles, {
+  return truncatise(htmlRemovedStyles, {
     // We want the amount comments get truncated to to be less than the threshold at which they are truncated, so that users don't have the experience of expanding a comment only to see a couple more words (which just feels silly).
 
     // This varies by the size of the comment or truncation amount, and reducing it by 1/4th seems about right.
     TruncateLength: Math.floor(truncationCharCount - (truncationCharCount/4)) || excerptMaxChars,
     TruncateBy: "characters",
     Suffix: `... <span class="read-more"><a class="read-more-default">(Read more)</a><a class="read-more-tooltip">(Click to expand thread)</a><span class="read-more-f-tooltip">Cmd/Ctrl F to expand all comments on this post</span></span>${styles}`,
-  }));
+  });
 };
 
 export const excerptFromMarkdown = (body, mdi) => {

--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import truncatise from 'truncatise';
-import { Utils } from 'meteor/vulcan:core';
 
 const highlightMaxChars = 2400;
 export const excerptMaxChars = 700;


### PR DESCRIPTION
Utils.sanitize is stubbed out on the client, which is where this code mostly runs. This can cause SSR client render mismatches, and also causes a wrong impression of the html being sanitized on the client, when it isn't. 