### PR TITLE
Properly render comment section when no comments are returned

### DIFF
--- a/packages/lesswrong/components/posts/PostsCommentsThread.jsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.jsx
@@ -7,7 +7,7 @@ class PostsCommentsThread extends PureComponent {
   render() {
     const {loading, results, loadMore, networkStatus, totalCount, post} = this.props;
     const loadingMore = networkStatus === 2;
-    if (loading || !results) {
+    if (loading) {
       return <Components.Loading/>
     } else {
       const nestedComments = unflattenComments(results);
@@ -18,7 +18,7 @@ class PostsCommentsThread extends PureComponent {
             lastEvent={post.lastVisitedAt}
             loadMoreComments={loadMore}
             totalComments={totalCount}
-            commentCount={results.length}
+            commentCount={(results && results.length) || 0}
             loadingMoreComments={loadingMore}
             post={post}
           />


### PR DESCRIPTION
There was a bug where sometimes (maybe due to 503's?) the Comments query would return `null` for results instead of an empty array. This caused a bunch of bugs with sometimes empty comment sections taking forever to load, until you refresh the page. This makes it so that it renders more robustly when it gets null instead of an empty array. 