### PR TITLE
ToC: Empty blocks can't be headers

### DIFF
--- a/packages/lesswrong/lib/collections/posts/tableOfContents.js
+++ b/packages/lesswrong/lib/collections/posts/tableOfContents.js
@@ -56,14 +56,17 @@ export function extractTableOfContents(postHTML, alwaysDisplayToC)
     }
 
     let title = cheerio(tag).text();
-    let anchor = titleToAnchor(title, usedAnchors);
-    usedAnchors[anchor] = true;
-    cheerio(tag).attr("id", anchor);
-    headings.push({
-      title: title,
-      anchor: anchor,
-      level: tagToHeadingLevel(tag.tagName),
-    });
+    
+    if (title && title.trim()!=="") {
+      let anchor = titleToAnchor(title, usedAnchors);
+      usedAnchors[anchor] = true;
+      cheerio(tag).attr("id", anchor);
+      headings.push({
+        title: title,
+        anchor: anchor,
+        level: tagToHeadingLevel(tag.tagName),
+      });
+    }
   }
 
   if ((headings.length < minHeadingsForToC) && !alwaysDisplayToC) {


### PR DESCRIPTION
Inspired by noticing a janky table of contents on [this post](https://www.lesswrong.com/s/HXkpm9b8o964jbQ89/p/ENBzEkoyvdakz4w5d), a heading-styled block which has no text can't be a heading.