### PR TITLE
User profile form fixes

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.jsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.jsx
@@ -2,7 +2,6 @@ import {
   Components,
   registerComponent,
   withMessages,
-  withEdit
 } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';

--- a/packages/lesswrong/components/localGroups/CommunityHome.jsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.jsx
@@ -125,13 +125,6 @@ class CommunityHome extends Component {
   }
 }
 
-
-const withEditOptions = {
-  collection: Users,
-  fragmentName: 'UsersProfile',
-};
-
 registerComponent('CommunityHome', CommunityHome,
   withUser, withMessages, withRouter,
-  [withEdit, withEditOptions],
   withStyles(styles, { name: "CommunityHome" }));

--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -195,6 +195,7 @@ addFieldsDict(Users, {
   allPostsView: {
     type: String,
     optional: true,
+    hidden: true,
     canRead: Users.owns,
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     canCreate: Users.owns,

--- a/packages/lesswrong/lib/modules/fragments.js
+++ b/packages/lesswrong/lib/modules/fragments.js
@@ -359,6 +359,10 @@ registerFragment(`
     mongoLocation
     shortformFeedId
     viewUnreviewedComments
+    notifications_users
+    notifications_posts
+    auto_subscribe_to_my_posts
+    auto_subscribe_to_my_comments
   }
 `);
 


### PR DESCRIPTION
Remove the allPostsView from the user profile form (it isn't meant to be exposed this way, and doesn't have an appropriate widget). Add missing notification settings to the `UsersProfile` fragment, so that their true state is shown and it's possible to set them to false.