### PR TITLE
Fix a pointlessly slow query in /out redirector

### DIFF
--- a/packages/lesswrong/server/posts/out.js
+++ b/packages/lesswrong/server/posts/out.js
@@ -3,18 +3,11 @@ import escapeStringRegexp from 'escape-string-regexp';
 import { Picker } from 'meteor/meteorhacks:picker';
 import { Posts } from '../../lib/collections/posts';
 
+// Click-tracking redirector for outgoing links in linkposts
 Picker.route('/out', ({ query}, req, res, next) => {
-  if(query.url){ // for some reason, query.url doesn't need to be decoded
-    /*
-    If the URL passed to ?url= is in plain text, any hash fragment
-    will get stripped out.
-    So we search for any post whose URL contains the current URL to get a match
-    even without the hash
-    */
-
+  if(query.url) {
     try {
-
-      const post = Posts.findOne({url: {$regex: escapeStringRegexp(query.url)}}, {sort: {postedAt: -1, createdAt: -1}});
+      const post = Posts.findOne({url: query.url}, {sort: {postedAt: -1, createdAt: -1}});
 
       if (post) {
         const ip = (req.headers && req.headers['x-forwarded-for']) || req.connection.remoteAddress;

--- a/packages/lesswrong/server/posts/out.js
+++ b/packages/lesswrong/server/posts/out.js
@@ -1,5 +1,4 @@
 import { runCallbacksAsync } from 'meteor/vulcan:core';
-import escapeStringRegexp from 'escape-string-regexp';
 import { Picker } from 'meteor/meteorhacks:picker';
 import { Posts } from '../../lib/collections/posts';
 


### PR DESCRIPTION
Currently our #2 slow query is in the linkpost redirector. When you click on the outgoing link in a linkpost, it goes to lesswrong.com/out?url=... which records the click and forwards you to the destination. This is a feature we inherited from vulcan-starter/example-forum.

At some point, the link-post URL generation must have been broken and not URL-encoded the destination URL, because the redirector is designed to handle URLs which haven't been escaped properly. Where "designed to handle" means "searches the database for link-posts which fuzzy-match the destination URL". The fuzzy-matching is quite resistant to indexing, and also completely unnecessary. Remove that.