### PR TITLE
Upgrade synced-cron across a maintainer change

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -45,6 +45,7 @@ http@1.4.1
 id-map@1.1.0
 inter-process-messaging@0.1.0
 lesswrong@0.1.0
+littledata:synced-cron@1.5.1
 lmieulet:meteor-coverage@2.0.2
 localstorage@1.2.0
 logging@1.1.20
@@ -66,7 +67,6 @@ npm-mongo@3.1.1
 oauth@1.2.3
 oauth2@1.2.1
 ordered-dict@1.1.0
-percolatestudio:synced-cron@1.1.0
 practicalmeteor:mocha-core@1.0.1
 promise@0.11.1
 random@1.1.0

--- a/packages/lesswrong/server/cronUtil.js
+++ b/packages/lesswrong/server/cronUtil.js
@@ -1,4 +1,4 @@
-import { SyncedCron } from 'meteor/percolatestudio:synced-cron';
+import { SyncedCron } from 'meteor/littledata:synced-cron';
 
 SyncedCron.options = {
   log: true,


### PR DESCRIPTION
Fixes #1659. Also reduces the rate of score-update queries from 2/min/server to 2/min.

The story here is that `synced-cron` switched maintainers, and so `percolatestudio:synced-cron` was stuck on the last version by `percolatestudio`. Which was from 2014, and was missing a number of important bug fixes. Migrate to the new version, under the new maintainer.

Requires a synchronized Vulcan PR.