### PR TITLE
Add an admin-only editor-type-select menu to Form components

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -164,9 +164,9 @@ class EditorFormComponent extends Component {
     this.context.addToSuccessForm(resetEditor);
   }
 
-  handleEditorOverride = () => {
+  handleEditorOverride = (editorType) => {
     const { currentUser } = this.props
-    const targetEditorType = this.getUserDefaultEditor(currentUser)
+    const targetEditorType = editorType || this.getUserDefaultEditor(currentUser)
     this.setState({
       editorOverride: targetEditorType,
       ...this.getEditorStatesFromType(targetEditorType)
@@ -249,6 +249,20 @@ class EditorFormComponent extends Component {
     </Select>
   }
 
+  renderEditorTypeSelect = () => {
+    const { currentUser, classes } = this.props
+    if (!currentUser || !currentUser.isAdmin) return null
+    return <Select
+      value={this.getCurrentEditorType()}
+      onChange={(e) => this.handleEditorOverride(e.target.value)}
+      className={classes.updateTypeSelect}
+      >
+      <MenuItem value={'html'}>HTML</MenuItem>
+      <MenuItem value={'markdown'}>Markdown</MenuItem>
+      <MenuItem value={'draftJS'}>Draft-JS</MenuItem>
+    </Select>
+  }
+
   render() {
     const { editorOverride, draftJSValue, htmlValue, markdownValue } = this.state
     const { document, currentUser, formType, form, classes, fieldName } = this.props
@@ -283,6 +297,7 @@ class EditorFormComponent extends Component {
             className={classnames(bodyStyles, heightClass, {[classes.questionWidth]: document.question})}
           />
           { this.renderUpdateTypeSelect() }
+          { this.renderEditorTypeSelect() }
         </div>);
     } else {
       const { multiLine, hintText, placeholder, label, fullWidth, disableUnderline, startAdornment } = this.props
@@ -306,6 +321,7 @@ class EditorFormComponent extends Component {
             /><br />
           </div>
           { this.renderUpdateTypeSelect() }
+          { this.renderEditorTypeSelect() }
         </div>
       );
     }


### PR DESCRIPTION
Admins used to have a form-field that allows them to directly edit the HTML of posts. We removed that with the form-rework, and this now adds an admin-only dropdown menu that allows you to select from the different document format options and choose whichever one you want to edit. 