### PR TITLE
Vary robots.txt based on a setting

### DIFF
--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -5,6 +5,7 @@ import './server/rss-integration/cron.js';
 import './server/rss-integration/callbacks.js';
 import './server/database-import/force_batch_update_scores.js';
 import './server/database-import/cleanup_scripts.js';
+import './server/robots.js';
 
 // Scripts
 import './server/scripts/sscImport.js';

--- a/packages/lesswrong/server/robots.js
+++ b/packages/lesswrong/server/robots.js
@@ -1,0 +1,13 @@
+import { getSetting, registerSetting } from 'meteor/vulcan:core';
+
+registerSetting('disallowCrawlers', false, 'Whether to serve a robots.txt that asks crawlers not to index');
+
+// Vary robots.txt based on a setting, because we want development servers
+// (lessestwrong.com, baserates.org) to not be indexed by search engines.
+Picker.route('/robots.txt', ({query}, req, res, next) => {
+  if (getSetting('disallowCrawlers', false)) {
+    res.end("User-agent: *\nDisallow: /");
+  } else {
+    res.end("User-agent: *\ncrawl-delay: 5");
+  }
+});

--- a/packages/lesswrong/server/robots.js
+++ b/packages/lesswrong/server/robots.js
@@ -1,4 +1,5 @@
 import { getSetting, registerSetting } from 'meteor/vulcan:core';
+import { Picker } from 'meteor/meteorhacks:picker';
 
 registerSetting('disallowCrawlers', false, 'Whether to serve a robots.txt that asks crawlers not to index');
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-crawl-delay: 5


### PR DESCRIPTION
Vary robots.txt based on a setting, because we want development servers (lessestwrong.com, baserates.org) to not be indexed by search engines. This should be accompanied by a config change on those development servers.