### PR TITLE
Remove useless "Notifications for new posts" setting

### DIFF
--- a/packages/lesswrong/lib/collections/notifications/custom_fields.js
+++ b/packages/lesswrong/lib/collections/notifications/custom_fields.js
@@ -8,28 +8,6 @@ const notificationsGroup = {
 
 // Add notifications options to user profile settings
 addFieldsDict(Users, {
-  notifications_users: {
-    label: 'New users',
-    type: Boolean,
-    optional: true,
-    onInsert: (document, currentUser) => false,
-    control: "checkbox",
-    canRead: ['guests'],
-    canCreate: ['admins'],
-    canUpdate: ['admins'],
-    group: notificationsGroup,
-  },
-  notifications_posts: {
-    label: 'New posts',
-    type: Boolean,
-    optional: true,
-    onInsert: (document, currentUser) => false,
-    control: "checkbox",
-    canRead: ['guests'],
-    canCreate: ['members'],
-    canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
-    group: notificationsGroup,
-  },
   auto_subscribe_to_my_posts: {
     label: 'Comments on my posts',
     type: Boolean,

--- a/packages/lesswrong/lib/modules/fragments.js
+++ b/packages/lesswrong/lib/modules/fragments.js
@@ -359,8 +359,6 @@ registerFragment(`
     mongoLocation
     shortformFeedId
     viewUnreviewedComments
-    notifications_users
-    notifications_posts
     auto_subscribe_to_my_posts
     auto_subscribe_to_my_comments
   }

--- a/packages/lesswrong/server/callbacks.js
+++ b/packages/lesswrong/server/callbacks.js
@@ -194,13 +194,14 @@ function PostsUndraftNotification(post) {
 }
 addCallback("posts.undraft.async", PostsUndraftNotification);
 
-/**
- * @summary Add new post notification callback on post submit
- */
+/// Add new post notification callback on post submit
 function postsNewNotifications (post) {
   if (!post.draft && post.status === Posts.config.STATUS_APPROVED) {
     // add users who get notifications for all new posts
-    let usersToNotify = _.pluck(Users.find({'notifications_posts': true}, {fields: {_id:1}}).fetch(), '_id');
+    // Removed because this was useless. Will be reintroduced in a different
+    // form (with advanced filters and emailing.)
+    //let usersToNotify = _.pluck(Users.find({'notifications_posts': true}, {fields: {_id:1}}).fetch(), '_id');
+    let usersToNotify = [];
 
     // add users who are subscribed to this post's author
     const postAuthor = Users.findOne(post.userId);


### PR DESCRIPTION
It was useless because it included spam, and it was on-site notifications, when you could just go to the allPosts page and get a similar thing but much better organized.

Also remove the "Notifications for new users" setting, which was admin-only and literally did nothing.


