### PR TITLE
Add error boundary around new-comment form

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.jsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.jsx
@@ -7,6 +7,7 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import withUser from '../common/withUser'
+import withErrorBoundary from '../common/withErrorBoundary'
 
 const styles = theme => ({
   root: {
@@ -114,4 +115,4 @@ CommentsNewForm.propTypes = {
   prefilledProps: PropTypes.object
 };
 
-registerComponent('CommentsNewForm', CommentsNewForm, withUser, withMessages, withStyles(styles));
+registerComponent('CommentsNewForm', CommentsNewForm, withUser, withMessages, withStyles(styles), withErrorBoundary);


### PR DESCRIPTION
There is a current IE11 and Edge 17 (not the latest version) bug that causes forms to fail. I don't think we can easily fix it, but this at least prevents the bug from exploding the whole page.