### PR TITLE
Algolia indexing scripts: fix cleaning to work on large DBs, more logging

### DIFF
--- a/packages/lesswrong/server/scripts/algoliaExport.js
+++ b/packages/lesswrong/server/scripts/algoliaExport.js
@@ -104,7 +104,6 @@ async function algoliaCleanIndex(collection)
       hitsPerPage: 1000,
       page: currentPage,
     });
-    currentPage++;
     
     const ids = _.map(pageResults.hits, hit=>hit._id);
     const mongoIdsToDelete = await subsetOfIdsAlgoliaShouldntIndex(collection, ids);
@@ -112,9 +111,15 @@ async function algoliaCleanIndex(collection)
     if (mongoIdsToDelete.length > 0) {
       const hitsToDelete = _.filter(pageResults.hits, hit=>hit._id in mongoIdsToDeleteDict);
       const objectIdsToDelete = _.map(hitsToDelete, hit=>hit.objectID);
+      // eslint-disable-next-line no-console
+      console.log(`Deleting ${objectIdsToDelete.length} object IDs for ${mongoIdsToDelete.length} mongo IDs`);
       await algoliaDeleteIds(algoliaIndex, objectIdsToDelete);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`Nothing to delete in page ${currentPage} with ${ids.length} hits`);
     }
     
+    currentPage++;
   } while(pageResults.hits.length > 0)
 }
 


### PR DESCRIPTION
The main change here is that `algoliaCleanIndex` now uses `browseAll`, an export API rather than the query API. Using the query API for this didn't work, because you couldn't get more than 1000 results that way. However, `browseAll` doesn't support pagination, so this requires holding the entire index (and some transformations of it) in RAM at once, which might turn out to be a problem.

Lightly tested by creating and removing posts and inspecting the index on a small DB.