### PR TITLE
Local storage: save markdown/HTML, don't pollute Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "intl-locales-supported": "^1.0.0",
     "jsdom": "^13.1.0",
     "juice": "^1.11.0",
-    "local-storage": "^1.4.2",
     "lolex": "^3.0.0",
     "mailchimp": "^1.1.6",
     "markdown-it": "^8.4.2",

--- a/packages/lesswrong/components/async/localStorageHandlers.js
+++ b/packages/lesswrong/components/async/localStorageHandlers.js
@@ -4,6 +4,7 @@ function getBrowserLocalStorage() {
     return 'localStorage' in global && global.localStorage ? global.localStorage : null;
   } catch(e) {
     // Some browsers don't have an accessible localStorage
+    // eslint-disable-next-line no-console
     console.warn("localStorage is unavailable; posts/comments will not be autosaved");
     return null;
   }
@@ -47,7 +48,9 @@ export const getLSHandlers = (getLocalStorageId = null) => {
           return savedState
         }
       } catch(e) {
+        // eslint-disable-next-line no-console
         console.warn("Failed reading from localStorage:");
+        // eslint-disable-next-line no-console
         console.warn(e);
         return null;
       }
@@ -60,7 +63,9 @@ export const getLSHandlers = (getLocalStorageId = null) => {
       try {
         ls.setItem(id, JSON.stringify(state))
       } catch(e) {
+        // eslint-disable-next-line no-console
         console.warn("Failed writing to localStorage:");
+        // eslint-disable-next-line no-console
         console.warn(e);
         return false;
       }
@@ -74,7 +79,9 @@ export const getLSHandlers = (getLocalStorageId = null) => {
       try {
         ls.removeItem(id)
       } catch(e) {
+        // eslint-disable-next-line no-console
         console.warn("Failed writing to localStorage:");
+        // eslint-disable-next-line no-console
         console.warn(e);
       }
     }

--- a/packages/lesswrong/components/async/localStorageHandlers.js
+++ b/packages/lesswrong/components/async/localStorageHandlers.js
@@ -1,5 +1,12 @@
 import ls from 'local-storage';
 
+// Given a document and a field name, return:
+// {
+//   id: The name to use for storing drafts related to this document in
+//     localStorage. This may be combined with an editor-type prefix.
+//   verify: Whether to prompt before restoring a draft (as opposed to just
+//     always restoring it).
+// }
 const defaulGetDocumentStorageId = (doc, name) => {
   const { _id, conversationId } = doc
   if (_id && name) { return {id: `${_id}${name}`, verify: true}}
@@ -11,12 +18,14 @@ const defaulGetDocumentStorageId = (doc, name) => {
   }
 }
 
+// Return a wrapper around localStorage, with get, set, and reset functions
+// which handle the (document, field-name, prefix) => key mapping.
 export const getLSHandlers = (getLocalStorageId = null) => {
   const idGenerator = getLocalStorageId || defaulGetDocumentStorageId
   return {
-    get: ({doc, name}) => {
+    get: ({doc, name, prefix}) => {
       const { id, verify } = idGenerator(doc, name)
-      const savedState = ls.get(id)
+      const savedState = ls.get(prefix+id)
       if (verify && savedState && Meteor.isClient && window) {
         const result = window.confirm("We've found a previously saved state for this document, would you like to restore it?")
         return result ? savedState : null
@@ -24,7 +33,13 @@ export const getLSHandlers = (getLocalStorageId = null) => {
         return savedState
       }
     },
-    set: ({state, doc, name}) => {ls.set(idGenerator(doc, name).id, state)},
-    reset: ({doc, name}) => {ls.remove(idGenerator(doc, name).id)}
+    set: ({state, doc, name, prefix}) => {
+      const id = prefix+idGenerator(doc, name).id;
+      ls.set(id, state)
+    },
+    reset: ({doc, name, prefix}) => {
+      const id = prefix+idGenerator(doc, name).id;
+      ls.remove(id)
+    }
   }
 }

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -192,11 +192,12 @@ class EditorFormComponent extends Component {
     const { draftJSValue } = this.state
     const currentContent = draftJSValue.getCurrentContent()
     const newContent = value.getCurrentContent()
-    const changed = (currentContent != newContent);
+    const changed = (currentContent !== newContent);
     this.setState({draftJSValue: value})
     
-    if (changed)
+    if (changed) {
       this.maybeSaveBackup();
+    }
   }
   
   setHtml = (e) => {

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -73,11 +73,14 @@ class EditorFormComponent extends Component {
     const { editorOverride } = this.state || {} // Provide default value, since we can call this before state is initialized
 
     // Initialize the editor to whatever the canonicalContent is
-    if (value && value.originalContents && value.originalContents.data && !editorOverride && editorType === value.originalContents.type ) {
+    if (value && value.originalContents && value.originalContents.data
+        && !editorOverride
+        && editorType === value.originalContents.type)
+    {
       return {
         draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(value.originalContents.data) : null,
-        markdownValue: editorType === "markdown" ? value.originalContents.data : null,
-        htmlValue: editorType === "html" ? value.originalContents.data : null  
+        markdownValue: editorType === "markdown" ? this.initializeText(value.originalContents.data) : null,
+        htmlValue: editorType === "html" ? this.initializeText(value.originalContents.data) : null
       }
     }
 
@@ -85,8 +88,8 @@ class EditorFormComponent extends Component {
     const { draftJS, html, markdown } = document[fieldName] || {}
     return {
       draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(draftJS) : null,
-      markdownValue: editorType === "markdown" ? markdown : null,
-      htmlValue: editorType === "html" ? html : null
+      markdownValue: editorType === "markdown" ? this.initializeText(markdown) : null,
+      htmlValue: editorType === "html" ? this.initializeText(html) : null
     }
   }
 
@@ -95,12 +98,12 @@ class EditorFormComponent extends Component {
     return getLSHandlers(form && form.getLocalStorageId)
   }
 
-  initializeDraftJS = (draftJS) => { 
+  initializeDraftJS = (draftJS) => {
     const { document, name } = this.props
     let state = {}
 
     // Check whether we have a state from a previous session saved (in localstorage)
-    const savedState = this.getStorageHandlers().get({doc: document, name})
+    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix()})
     if (savedState) {
       try {
         // eslint-disable-next-line no-console
@@ -127,18 +130,28 @@ class EditorFormComponent extends Component {
     // And lastly, if the field is empty, create an empty draftJS object
     return EditorState.createEmpty();
   }
+  
+  initializeText = (originalContents) => {
+    const { document, name } = this.props
+    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix()})
+    if (savedState) {
+      return savedState;
+    }
+  
+    return originalContents;
+  }
 
   UNSAFE_componentWillMount() {
-    const { document, name, fieldName } = this.props
+    const { document, fieldName } = this.props
     const submitData = (submission) => {
       let data = null
       const { draftJSValue, markdownValue, htmlValue, updateType} = this.state
       const type = this.getCurrentEditorType()
       switch(type) {
-        case "draftJS": 
+        case "draftJS":
           const draftJS = draftJSValue.getCurrentContent()
           data = draftJS.hasText() ? convertToRaw(draftJS) : null
-          break 
+          break
         case "markdown":
           data = markdownValue
           break
@@ -151,12 +164,13 @@ class EditorFormComponent extends Component {
     this.context.addToSubmitForm(submitData);
 
     const resetEditor = (result) => {
+      const { name } = this.props;
       // On Form submit, create a new empty editable
-      this.getStorageHandlers().reset({doc: document, name})
+      this.getStorageHandlers().reset({doc: document, name, prefix:this.getLSKeyPrefix()})
       this.setState({
-        draftJSValue: this.initializeDraftJS(), 
+        draftJSValue: this.initializeDraftJS(),
         htmlValue: null,
-        markdownValue: null, 
+        markdownValue: null,
         editorOverride: null,
       });
       return result;
@@ -175,24 +189,76 @@ class EditorFormComponent extends Component {
 
   changeCount = 0
   setDraftJS = (value) => { // Takes in an editorstate
-    const { document, name } = this.props
     const { draftJSValue } = this.state
     const currentContent = draftJSValue.getCurrentContent()
     const newContent = value.getCurrentContent()
-    if (currentContent !== newContent) {
-      // Only save to localStorage on every 30th content change
-      // TODO: Consider debouncing rather than saving every 30th change
-      // TODO: Consider saving on blur
-      this.changeCount = this.changeCount + 1;
-      if (this.changeCount % 30 === 0) {
-        const rawContent = convertToRaw(newContent);
-        this.getStorageHandlers().set({state: rawContent, doc: document, name})
-      }
-    }
+    const changed = (currentContent != newContent);
     this.setState({draftJSValue: value})
+    
+    if (changed)
+      this.maybeSaveBackup();
   }
-  setHtml = (e) => {this.setState({htmlValue: e.target.value})}
-  setMarkdown = (e) => {this.setState({markdownValue: e.target.value})}
+  
+  setHtml = (e) => {
+    const newContent = e.target.value
+    const changed = (this.state.htmlValue !== newContent);
+    this.setState({htmlValue: newContent})
+    
+    if (changed)
+      this.maybeSaveBackup();
+  }
+  
+  setMarkdown = (e) => {
+    const newContent = e.target.value
+    const changed = (this.state.htmlValue !== newContent);
+    this.setState({markdownValue: newContent})
+    
+    if (changed)
+      this.maybeSaveBackup();
+  }
+  
+  maybeSaveBackup = () => {
+    const { document } = this.props;
+    
+    // Only save to localStorage on every 30th content change
+    // TODO: Consider debouncing rather than saving every 30th change
+    // TODO: Consider saving on blur
+    this.changeCount = this.changeCount + 1;
+    if (this.changeCount % 30 === 0) {
+      const serialized = this.editorContentsToJson();
+      
+      this.getStorageHandlers().set({
+        state: serialized,
+        doc: document,
+        name: this.getLocalStorageName()
+      })
+    }
+  }
+  
+  // Take the editor contents (whichever editor you're using), and return
+  // something JSON (ie, a JSON object or a string) which represents the
+  // content and can be saved to localStorage.
+  editorContentsToJson = () => {
+    switch(this.getCurrentEditorType()) {
+      case "draftJS":
+        const draftJScontent = this.state.draftJSValue.getCurrentContent()
+        return convertToRaw(draftJScontent);
+      case "markdown":
+        return this.state.markdownValue;
+      case "html":
+        return this.state.htmlValue;
+    }
+  }
+  
+  // Get an editor-type-specific prefix to use on localStorage keys, to prevent
+  // drafts written with different editors from having conflicting names.
+  getLSKeyPrefix = () => {
+    switch(this.getCurrentEditorType()) {
+      case "draftJS":  return "";
+      case "markdown": return "md_";
+      case "html":     return "html_";
+    }
+  }
 
   renderEditorWarning = () => {
     const { classes, currentUser, document, fieldName, value } = this.props

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -218,7 +218,7 @@ class EditorFormComponent extends Component {
   }
   
   maybeSaveBackup = () => {
-    const { document } = this.props;
+    const { document, name } = this.props;
     
     // Only save to localStorage on every 30th content change
     // TODO: Consider debouncing rather than saving every 30th change
@@ -230,7 +230,8 @@ class EditorFormComponent extends Component {
       this.getStorageHandlers().set({
         state: serialized,
         doc: document,
-        name: this.getLocalStorageName()
+        name,
+        prefix: this.getLSKeyPrefix()
       })
     }
   }


### PR DESCRIPTION
Makes it so that the code which saves unfinished posts and comments to localStorage works with all the editors (DraftJS, markdown, HTML) rather than just DraftJS. Also strips away a wrapper library around localStorage, and changes error handling so that browsers not having localStorage is only a `console.warn` rather than a `console.error` (because the wide variety of ways of reporting that there's no localStorage, was polluting Sentry).