### PR TITLE
BannedUsers tooltip

### DIFF
--- a/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
@@ -10,7 +10,7 @@ const UsersSearchAutoComplete = ({clickAction, label}) => {
   const algoliaSearchKey = getSetting('algolia.searchKey')
 
   if(!algoliaAppId) {
-    return <div className="users-search-auto-complete">User search is disabled (Algolia App ID not configured on server)</div>
+    return <div>User search is disabled (Algolia App ID not configured on server)</div>
   }
 
   return <InstantSearch
@@ -18,7 +18,7 @@ const UsersSearchAutoComplete = ({clickAction, label}) => {
     appId={algoliaAppId}
     apiKey={algoliaSearchKey}
   >
-    <div className="users-search-auto-complete">
+    <div>
       <AutoComplete clickAction={clickAction} label={label}/>
       <Configure hitsPerPage={7} />
     </div>
@@ -33,7 +33,7 @@ const AutoComplete = connectAutoComplete(
       event.stopPropagation();
       clickAction(suggestion.objectID)
     }
-    return <span className="users-search-auto-complete">
+    return <span>
       <Autosuggest
         suggestions={hits}
         onSuggestionsFetchRequested={({ value }) => refine(value)}

--- a/packages/lesswrong/components/search/UsersSearchInput.jsx
+++ b/packages/lesswrong/components/search/UsersSearchInput.jsx
@@ -9,8 +9,7 @@ const styles = theme => ({
   input: {
     // this needs to be here because of Bootstrap. I am sorry :(
     padding: "6px 0 7px !important",
-    fontSize: "13px !important",
-    width: 160,
+    fontSize: "13px !important"
   }
 })
 

--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -330,7 +330,7 @@ addFieldsDict(Users, {
     canUpdate: [Users.ownsAndInGroup('trustLevel1'), 'sunshineRegiment', 'admins'],
     canCreate: [Users.ownsAndInGroup('trustLevel1'), 'sunshineRegiment', 'admins'],
     optional: true,
-    label: "Banned Users",
+    label: "Banned Users (All)",
     control: 'UsersListEditor'
   },
   'bannedUserIds.$': {
@@ -347,8 +347,9 @@ addFieldsDict(Users, {
     canUpdate: [Users.ownsAndInGroup('canModeratePersonal'), 'sunshineRegiment', 'admins'],
     canCreate: [Users.ownsAndInGroup('canModeratePersonal'), 'sunshineRegiment', 'admins'],
     optional: true,
-    label: "Banned Users from Personal Blog Posts",
-    control: 'UsersListEditor'
+    label: "Banned Users (Personal)",
+    control: 'UsersListEditor',
+    tooltip: "Users who are banned from commenting on your personal blogposts (will not affect posts promoted to frontpage)"
   },
   "bannedPersonalUserIds.$": {
     type: String,


### PR DESCRIPTION
 – REQUIRES CORRESPONDING VULCAN PR
 – removes unused scss class
 – adds a tooltip to the bannedPersonalUsersIds field on users