### PR TITLE
Delete VulcanJS-specific contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,1 @@
-Before starting on a new feature, please [check out the roadmap](https://trello.com/b/dwPR0LTz/vulcanjs-roadmap) and come check-in in the [Vulcan Slack channel](http://slack.telescopeapp.org/).
-
-Also, all PRs should be made to the `devel` branch, not `master`. 
+All PRs should be made to the `devel` branch, not `master`. 


### PR DESCRIPTION
This saves newcomers to the project from having to read irrelevant information before they create an issue or pull request.


