### PR TITLE
Fix Deepscan issues that keep resurfacing

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -207,13 +207,13 @@ class CommentsItem extends Component {
                   <Components.FormatDate date={comment.postedAt}/>
                   <Icon className="material-icons comments-item-permalink"> link
                   </Icon>
-                  {showPostTitle && post && post.title && <span className={classes.postTitle}> { post.title }</span>}
+                  {showPostTitle && post.title && <span className={classes.postTitle}> { post.title }</span>}
                 </a>
                 }
               </div>
               <Components.CommentsVote comment={comment} currentUser={currentUser} />
-                            
-              <span className={classes.metaRight}> 
+              
+              <span className={classes.metaRight}>
                 <span className={classes.menu}>
                   <CommentsMenu
                     comment={comment}

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -84,7 +84,7 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
                         <Components.FormatDate date={comment.postedAt}/>
                         <Icon className="material-icons comments-item-permalink"> link </Icon>
                       </div>
-                      { showTitle && comment.post && comment.post.title}
+                      { showTitle && comment.post.title}
                     </div>
                   </Link>
                 )}

--- a/packages/lesswrong/components/posts/MoveToDraft.jsx
+++ b/packages/lesswrong/components/posts/MoveToDraft.jsx
@@ -1,6 +1,5 @@
 import { registerComponent, withEdit } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { Posts } from '../../lib/collections/posts';
 import withUser from '../common/withUser';
 

--- a/packages/lesswrong/components/posts/PostsDailyList.jsx
+++ b/packages/lesswrong/components/posts/PostsDailyList.jsx
@@ -139,7 +139,7 @@ class PostsDailyList extends PureComponent {
         <div className={classNames("posts-daily", {[classes.loading]: dim})}>
           { loading && <Loading />}
           {dates.map((date, index) =>
-            <PostsDay key={index} number={index}
+            <PostsDay key={index}
               date={moment(date)}
               posts={this.getDatePosts(posts, date)}
               networkStatus={networkStatus}

--- a/packages/lesswrong/components/posts/PostsDay.jsx
+++ b/packages/lesswrong/components/posts/PostsDay.jsx
@@ -53,7 +53,6 @@ class PostsDay extends PureComponent {
 PostsDay.propTypes = {
   currentUser: PropTypes.object,
   date: PropTypes.object,
-  number: PropTypes.number
 };
 
 registerComponent('PostsDay', PostsDay, withStyles(styles, { name: "PostsDay" }));

--- a/packages/lesswrong/components/votes/withVote.js
+++ b/packages/lesswrong/components/votes/withVote.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { performVoteClient } from '../../lib/modules/vote.js';

--- a/packages/lesswrong/lib/collections/comments/tests.js
+++ b/packages/lesswrong/lib/collections/comments/tests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { chai } from 'meteor/practicalmeteor:chai';
 import chaiAsPromised from 'chai-as-promised';
 import { runQuery } from 'meteor/vulcan:core';

--- a/packages/lesswrong/lib/collections/users/tests.js
+++ b/packages/lesswrong/lib/collections/users/tests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { chai } from 'meteor/practicalmeteor:chai';
 import chaiAsPromised from 'chai-as-promised';
 import { createDummyUser, userUpdateFieldSucceeds, userUpdateFieldFails, catchGraphQLErrors, assertIsPermissionsFlavoredError } from '../../../testing/utils.js'

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -1,6 +1,13 @@
 import { getSetting } from 'meteor/vulcan:core';
 import { registerSplitComponent } from 'meteor/vulcan:routing';
 
+if(getSetting('AlignmentForum', false)) {
+  // HACK: At the top of the file because DeepScan false-positively warns about
+  // imports not at top level, and it re-detects it every time the line number
+  // changes. Putting it at the top makes its line number stable.
+  import '../components/alignment-forum/AlignmentForumHome.jsx';
+}
+
 import '../components/messaging/ConversationTitleEditForm.jsx';
 import '../components/messaging/ConversationDetails.jsx';
 import '../components/messaging/MessageItem.jsx';
@@ -310,10 +317,6 @@ import '../components/alignment-forum/AlignmentCheckbox.jsx';
 import '../components/alignment-forum/withSetAlignmentPost.jsx';
 import '../components/alignment-forum/withSetAlignmentComment.jsx';
 import '../components/alignment-forum/AFApplicationForm.jsx';
-if(getSetting('AlignmentForum', false)) {
-    import '../components/alignment-forum/AlignmentForumHome.jsx';
-}
-
 
 import '../components/questions/NewQuestionDialog.jsx';
 import '../components/questions/NewAnswerForm.jsx';

--- a/packages/lesswrong/lib/modules/alignment-forum/posts/tests.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/posts/tests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { chai } from 'meteor/practicalmeteor:chai';
 import chaiAsPromised from 'chai-as-promised';
 import { runQuery } from 'meteor/vulcan:core';

--- a/packages/lesswrong/lib/modules/alignment-forum/users/callbacks.js
+++ b/packages/lesswrong/lib/modules/alignment-forum/users/callbacks.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { addCallback, newMutation } from 'meteor/vulcan:core';
 import Users from "meteor/vulcan:users";
 import Messages from '../../../collections/messages/collection.js';

--- a/packages/lesswrong/testing/metatest.tests.js
+++ b/packages/lesswrong/testing/metatest.tests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { chai } from 'meteor/practicalmeteor:chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/lesswrong/testing/moderation/moderation.server.tests.js
+++ b/packages/lesswrong/testing/moderation/moderation.server.tests.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { chai, expect } from 'meteor/practicalmeteor:chai';
 import chaiAsPromised from 'chai-as-promised';
 import { runQuery } from 'meteor/vulcan:core';


### PR DESCRIPTION
There's a false-positive Deepscan issue in `components.js`, which keeps appearing on PRs as "1 fixed, 1 new" because its line number changes. Move it to the top so its line number stops changing. Also fix a few other random easy Deepscan issues.