### PR TITLE
Don't allow guests to see user's votecounts

### DIFF
--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -628,35 +628,35 @@ addFieldsDict(Users, {
     denormalized: true,
     optional: true,
     label: "Small Upvote Count",
-    canRead: ['guests'],
+    canRead: ['sunshineRegiment'],
   },
 
   smallUpvoteCount: {
     type: Number,
     denormalized: true,
     optional: true,
-    canRead: ['guests'],
+    canRead: ['sunshineRegiment'],
   },
 
   smallDownvoteCount: {
     type: Number,
     denormalized: true,
     optional: true,
-    canRead: ['guests'],
+    canRead: ['sunshineRegiment'],
   },
 
   bigUpvoteCount: {
     type: Number,
     denormalized: true,
     optional: true,
-    canRead: ['guests'],
+    canRead: ['sunshineRegiment'],
   },
 
   bigDownvoteCount: {
     type: Number,
     denormalized: true,
     optional: true,
-    canRead: ['guests'],
+    canRead: ['sunshineRegiment'],
   },
 
   // Full Name field to display full name for alignment forum users


### PR DESCRIPTION
Currently anyone is allowed to access someone else's vote-counts. This seems mildly bad, so this fixes it. 