### PR TITLE
Fix a crash on null revisions, seen in devel

### DIFF
--- a/packages/lesswrong/lib/collections/revisions/resolvers.js
+++ b/packages/lesswrong/lib/collections/revisions/resolvers.js
@@ -32,6 +32,8 @@ export function htmlToDraftServer(...args) {
 }
 
 export function dataToDraftJS(data, type) {
+  if (data===undefined || data===null) return null;
+  
   switch (type) {
     case "draftJS": {
       return data


### PR DESCRIPTION
Recently introduced defensive programming in `dataToDraftJS` caused it to throw an exception when `data` and `type` were null/undefined. Put in a special case so that doesn't happen.