### PR TITLE
Fix a CSS load-order dependency in SubscribeWidget

### DIFF
--- a/packages/lesswrong/components/common/SubscribeWidget.jsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.jsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 
 const styles = theme => ({
   icon: {
-    width: "1.2rem"
+    width: "1.2rem",
+    fontSize: "inherit !important",
   },
   buttons: {
     display: "inline",
@@ -73,7 +74,7 @@ class SubscribeWidget extends Component {
           onMouseEnter={ () => this.setSubscribeLabel("Via RSS") }
           onMouseLeave={ () => this.resetSubscribeLabel() }
         >
-          <Icon fontSize="inherit" className={classes.icon}>rss_feed</Icon>
+          <Icon className={classes.icon}>rss_feed</Icon>
         </a>
         <a
           className={classes.subscribeButton}
@@ -81,7 +82,7 @@ class SubscribeWidget extends Component {
           onMouseEnter={ () => this.setSubscribeLabel("Via Email") }
           onMouseLeave={ () => this.resetSubscribeLabel() }
         >
-          <Icon fontSize="inherit" className={classes.icon}>email</Icon>
+          <Icon className={classes.icon}>email</Icon>
         </a>
         { dialogOpen && <Components.SubscribeDialog
           open={true}


### PR DESCRIPTION
Under some uncommon circumstances, `SubscribeWidget` renders its icons in the wrong font size. This is because of sensitivity to precedence order between `font-size` attributes in its builtin styles (controlled by a prop) and the material-icons class. Make this consistent by moving it all to JSS and adding a `!important`.

