### PR TITLE
Improve new comment placeholder message

### DIFF
--- a/packages/lesswrong/styles/_editor.scss
+++ b/packages/lesswrong/styles/_editor.scss
@@ -192,6 +192,7 @@ figure:after {
     position: absolute;
     color: rgba(0,0,0,0.55);
     font-weight: 200;
+    white-space: pre-wrap;
 }
 
 .form-component-EditorFormComponent {

--- a/packages/lesswrong/styles/_editor.scss
+++ b/packages/lesswrong/styles/_editor.scss
@@ -186,8 +186,8 @@ figure:after {
 
 .content-editor-is-empty:before {
     content: "Write here. Select text for formatting options.\A
-    You can switch to a markdown editor in your user settings.\A
-    We support LaTeX! Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).";
+    You can switch to a Markdown editor in your user settings.\A
+    We support LaTeX: Cmd-4 for inline, Cmd-M for block-level (Ctrl on Windows).";
     max-width: 540px;
     position: absolute;
     color: rgba(0,0,0,0.55);


### PR DESCRIPTION
See commit messages for details.

I didn’t run the site locally to test these changes, since it was hard to set up. These changes and screenshots are based on editing the CSS live using Firefox’s Inspector.

### Before

> <img width="736" alt="before" src="https://user-images.githubusercontent.com/79168/55432793-d37ec500-5561-11e9-8aaa-1f031c877734.png">

### After

> <img width="737" alt="after" src="https://user-images.githubusercontent.com/79168/55432796-d5488880-5561-11e9-9d29-26362e031585.png">
