### PR TITLE
Test server email handling

### DIFF
--- a/packages/lesswrong/server/debouncer.js
+++ b/packages/lesswrong/server/debouncer.js
@@ -1,4 +1,5 @@
 /*global Vulcan*/
+import { getSetting } from 'meteor/vulcan:core';
 import { DebouncerEvents } from '../lib/collections/debouncerEvents/collection.js';
 import { addCronJob } from './cronUtil.js';
 
@@ -158,13 +159,15 @@ export const forcePendingEvents = async () => {
 }
 Vulcan.forcePendingEvents = forcePendingEvents;
 
-addCronJob({
-  name: "Debounced event handler",
-  schedule(parser) {
-    // Once per minute, on the minute
-    return parser.cron('* * * * * *');
-  },
-  job() {
-    dispatchPendingEvents();
-  }
-});
+if (!getSetting("testServer", false)) {
+  addCronJob({
+    name: "Debounced event handler",
+    schedule(parser) {
+      // Once per minute, on the minute
+      return parser.cron('* * * * * *');
+    },
+    job() {
+      dispatchPendingEvents();
+    }
+  });
+}

--- a/packages/lesswrong/server/notificationCallbacks.js
+++ b/packages/lesswrong/server/notificationCallbacks.js
@@ -206,9 +206,18 @@ function findUsersToEmail(filter) {
 const curationEmailDelay = new EventDebouncer({
   name: "curationEmail",
   delayMinutes: 20,
-  callback: (postId) => {
-    let usersToEmail = findUsersToEmail({'emailSubscribedToCurated': true});
-    sendPostByEmail(usersToEmail, postId, "you have the \"Email me new posts in Curated\" option enabled");
+  callback: async (postId) => {
+    const post = await Posts.findOne(postId);
+    
+    // Still curated? If it was un-curated during the 20 minute delay, don't
+    // send emails.
+    if (post.curatedDate) {
+      let usersToEmail = findUsersToEmail({'emailSubscribedToCurated': true});
+      sendPostByEmail(usersToEmail, postId, "you have the \"Email me new posts in Curated\" option enabled");
+    } else {
+      //eslint-disable-next-line no-console
+      console.log(`Not sending curation notice for ${post.title} because it was un-curated during the delay period.`);
+    }
   }
 });
 

--- a/packages/lesswrong/server/notificationCallbacks.js
+++ b/packages/lesswrong/server/notificationCallbacks.js
@@ -203,10 +203,18 @@ function findUsersToEmail(filter) {
   return usersToEmail
 }
 
+const curationEmailDelay = new EventDebouncer({
+  name: "curationEmail",
+  delayMinutes: 20,
+  callback: (postId) => {
+    let usersToEmail = findUsersToEmail({'emailSubscribedToCurated': true});
+    sendPostByEmail(usersToEmail, postId, "you have the \"Email me new posts in Curated\" option enabled");
+  }
+});
+
 function PostsCurateNotification (post, oldPost) {
   if(post.curatedDate && !oldPost.curatedDate) {
-    let usersToEmail = findUsersToEmail({'emailSubscribedToCurated': true});
-    sendPostByEmail(usersToEmail, post._id, "you have the \"Email me new posts in Curated\" option enabled");
+    curationEmailDelay.recordEvent(post._id, null);
   }
 }
 addCallback("posts.edit.async", PostsCurateNotification);


### PR DESCRIPTION
Curation emails go through the debouncer, introducing a 20-minute delay. Servers with the `testServer` configuration option set don't handle debouncerEvents, so curation emails reliably get sent from the production server (rather than the dev server, which can't actually send emails.)

Fixes #1786.