### PR TITLE
Fix an SSR crash in EditorFormComponent

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -187,7 +187,7 @@ class EditorFormComponent extends Component {
     }
     this.context.addToSuccessForm(resetEditor);
     
-    if (window) {
+    if (Meteor.isClient && window) {
       this.unloadEventListener = window.addEventListener("beforeunload", (ev) => {
         if (this.hasUnsavedData) {
           ev.preventDefault();


### PR DESCRIPTION
Fix a server-side exception in EditorFormComponent, introduced by my previous autosaving PR. It doesn't have any obvious symptoms, but is easy to fix.