### PR TITLE
SunshineSidebar on home only

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -16,9 +16,6 @@ import { TimezoneContext } from './common/withTimezone';
 import { DialogManager } from './common/withDialog';
 import { TableOfContentsContext } from './posts/TableOfContents/TableOfContents';
 
-import Users from 'meteor/vulcan:users';
-import { SplitComponent } from 'meteor/vulcan:routing';
-
 const intercomAppId = getSetting('intercomAppId', 'wtb8z7sj');
 
 const styles = theme => ({
@@ -81,12 +78,6 @@ class Layout extends PureComponent {
         timezone: newTimezone
       });
     }
-  }
-
-  shouldRenderSidebar = () => {
-    const { currentUser } = this.props
-    return Users.canDo(currentUser, 'posts.moderate.all') ||
-      Users.canDo(currentUser, 'alignment.sidebar')
   }
 
   render () {
@@ -154,7 +145,6 @@ class Layout extends PureComponent {
                 <Components.FlashMessages />
               </Components.ErrorBoundary>
               {children}
-              {this.shouldRenderSidebar() && <SplitComponent name="SunshineSidebar" />}
             </div>
             <Components.Footer />
           </div>

--- a/packages/lesswrong/components/common/Home2.jsx
+++ b/packages/lesswrong/components/common/Home2.jsx
@@ -3,12 +3,19 @@ import { getSetting } from 'meteor/vulcan:lib';
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper.js';
 import withUser from '../common/withUser';
+import { SplitComponent } from 'meteor/vulcan:routing';
+import Users from 'meteor/vulcan:users';
 
 const Home2 = ({ currentUser }) => {
   const { SingleColumnSection, SectionTitle, PostsList2, RecentDiscussionThreadsList, SubscribeWidget, HomeLatestPosts, TabNavigationMenu } = Components
 
+  const shouldRenderSidebar = Users.canDo(currentUser, 'posts.moderate.all') ||
+      Users.canDo(currentUser, 'alignment.sidebar')
+
   return (
     <React.Fragment>
+      {shouldRenderSidebar && <SplitComponent name="SunshineSidebar" />}
+
       <Components.HeadTags image={getSetting('siteImage')} />
       <TabNavigationMenu />
 

--- a/packages/lesswrong/components/sunshineDashboard/SidebarActionMenu.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarActionMenu.jsx
@@ -9,7 +9,6 @@ const styles = theme => ({
     top:0,
     right:0,
     height: "100%",
-    maxHeight: 80,
     display:"flex",
     alignItems: "center",
     backgroundColor: theme.palette.grey[50],

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
@@ -21,14 +21,6 @@ const styles = theme => ({
     wordBreak: "break-word",
     display: "inline-block"
   },
-  sample: {
-    maxHeight: 100,
-    overflow: "hidden",
-    '&:hover': {
-      maxHeight: "unset",
-      overflow: "unset"
-    }
-  }
 })
 class SunshineNewUsersItem extends Component {
   state = {hidden: false}
@@ -105,7 +97,7 @@ class SunshineNewUsersItem extends Component {
             </MetaInfo>
           </div>
           {showNewUserContent && 
-            <div className={classes.sample}>
+            <div>
               <SunshineNewUserPostsList truncated={true} terms={{view:"sunshineNewUsersPosts", userId: user._id}}/>
               <SunshineNewUserCommentsList truncated={true} terms={{view:"sunshineNewUsersComments", userId: user._id}}/>
             </div>


### PR DESCRIPTION
This makes it so:
– sunshine sidebar only appears on the home page (where it's least 'in the way' of whatever else I'm trying to do on LessWrong)

– reverts some of the previous changes I'd made to the sidebar to make it easier for me to process spam, making it require juuuust enough attention that I can't accidentally get into a rhythm where I purge things accidentally (this should only affect admins who've enabled 'show post preview by default' in the sidebar, which presumably is just me)