### PR TITLE
Fix Sentry crash with null user

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.jsx
@@ -20,7 +20,7 @@ const PostsAuthors = ({classes, post}) => {
   return <Typography variant="body1" component="span" className={classes.root}>
     by
     <span className={classes.authorName}>
-      {!post.user || post.hideAuthor ? '[deleted]' : <UsersName user={post.user} />}
+      {!post.user || post.hideAuthor ? <Components.UserNameDeleted/> : <UsersName user={post.user} />}
       { post.coauthors.map(coauthor=><span key={coauthor._id} >
         , <UsersName user={coauthor} />
       </span>)}

--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.jsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.jsx
@@ -16,7 +16,7 @@ const styles = theme => ({
 
 const PostsUserAndCoauthors = ({post, abbreviateIfLong=false, classes}) => {
   if (!post.user || post.hideAuthor)
-    return '[deleted]';
+    return <Components.UserNameDeleted/>;
   
   return <div className={abbreviateIfLong ? classes.lengthLimited : classes.lengthUnlimited}>
     {<Components.UsersName user={post.user} />}

--- a/packages/lesswrong/components/users/UserNameDeleted.jsx
+++ b/packages/lesswrong/components/users/UserNameDeleted.jsx
@@ -1,0 +1,5 @@
+import { registerComponent } from 'meteor/vulcan:core';
+
+const UserNameDeleted = () => '[deleted]';
+
+registerComponent('UserNameDeleted', UserNameDeleted);

--- a/packages/lesswrong/components/users/UsersName.jsx
+++ b/packages/lesswrong/components/users/UsersName.jsx
@@ -5,8 +5,10 @@ import PropTypes from 'prop-types';
 const UsersName = ({user, documentId}) => {
   if (documentId) {
     return <Components.UsersNameWrapper documentId={documentId} />
-  } else {
+  } else if(user) {
     return <Components.UsersNameDisplay user={user}/>
+  } else {
+    return <Components.UserNameDeleted />
   }
 }
 UsersName.propTypes = {

--- a/packages/lesswrong/components/users/UsersNameDisplay.jsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.jsx
@@ -30,6 +30,7 @@ const styles = theme => ({
 })
 
 const UsersNameDisplay = ({user, classes}) => {
+  if (!user) return <Components.UserDeleted/>
   const { FormatDate } = Components
   const { htmlBio } = user
 

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -86,6 +86,7 @@ import '../components/users/LoginPopupLink.jsx';
 import '../components/users/KarmaChangeNotifier.jsx';
 import '../components/users/KarmaChangeNotifierSettings.jsx';
 import '../components/users/AccountsResetPassword.jsx';
+import '../components/users/UserNameDeleted.jsx';
 
 import '../components/icons/OmegaIcon.jsx';
 


### PR DESCRIPTION
Refactors user-name display handling a little bit, in the process making UsersNameDisplay and UsersName null-safe where they weren't before.

Observed Sentry crash: https://sentry.io/organizations/lesswrong/issues/976402041/?environment=production&project=1301611&query=is%3Aunresolved&statsPeriod=14d&utc=true


