### PR TITLE
Voting rate limit tweaks

### DIFF
--- a/packages/lesswrong/server/voteServer.js
+++ b/packages/lesswrong/server/voteServer.js
@@ -227,6 +227,10 @@ const getVotingRateLimits = async (user) => {
 // Check whether a given vote would exceed voting rate limits, and if so, throw
 // an error. Otherwise do nothing.
 const checkRateLimit = async ({ document, collection, voteType, user }) => {
+  // No rate limit on self-votes
+  if(document.userId === user._id)
+    return;
+  
   const rateLimits = await getVotingRateLimits(user);
   
   // Retrieve all non-cancelled votes cast by this user in the past 24 hours

--- a/packages/lesswrong/server/voteServer.js
+++ b/packages/lesswrong/server/voteServer.js
@@ -165,8 +165,6 @@ export const performVoteServer = async ({ documentId, document, voteType = 'bigU
   const collectionName = collection.options.collectionName;
   document = document || await Connectors.get(collection, documentId);
   
-  await checkRateLimit({ document, collection, voteType, user });
-
   debug('');
   debugGroup('--------------- start \x1b[35mperformVoteServer\x1b[0m  ---------------');
   debug('collectionName: ', collectionName);
@@ -193,6 +191,8 @@ export const performVoteServer = async ({ documentId, document, voteType = 'bigU
     runCallbacksAsync(`votes.cancel.async`, voteDocTuple, collection, user);
 
   } else {
+
+    await checkRateLimit({ document, collection, voteType, user });
 
     // console.log('action: vote')
 


### PR DESCRIPTION
When you're rate-limited, you can still self-upvote and cancel votes. Throw a better error type if you try to vote while not logged in.