### PR TITLE
Fix EditorFormComponent emptying when changing editor type

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -309,7 +309,7 @@ class EditorFormComponent extends Component {
     const { type } = (value && value.originalContents) || (document[fieldName] && document[fieldName].originalContents) || {}
     return <Typography variant="body2" color="primary">
       This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-      <a className={classes.errorTextColor} onClick={this.handleEditorOverride}> Click here </a>
+      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(null)}> Click here </a>
       to switch to {this.getUserDefaultEditor(currentUser)} editor (your default editor).
     </Typography>
   }

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -309,7 +309,7 @@ class EditorFormComponent extends Component {
     const { type } = (value && value.originalContents) || (document[fieldName] && document[fieldName].originalContents) || {}
     return <Typography variant="body2" color="primary">
       This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(null)}> Click here </a>
+      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride()}> Click here </a>
       to switch to {this.getUserDefaultEditor(currentUser)} editor (your default editor).
     </Typography>
   }


### PR DESCRIPTION
Fixes #1835. The bug was introduced in https://github.com/LessWrong2/Lesswrong2/pull/1709 .