### PR TITLE
Fix AlignmentForum->forumType setting change

### DIFF
--- a/packages/lesswrong/components/comments/CommentsViews.jsx
+++ b/packages/lesswrong/components/comments/CommentsViews.jsx
@@ -64,7 +64,8 @@ class CommentsViews extends Component {
       views = views.concat(adminViews);
     }
 
-    if (getSetting("AlignmentForum", false)) {
+    const af = getSetting('forumType') === 'AlignmentForum'
+    if (af) {
       views = views.concat(afViews);
     }
 

--- a/packages/lesswrong/components/posts/PostsNewForm.jsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.jsx
@@ -18,12 +18,13 @@ const PostsNewForm = ({router, currentUser, flash, classes}) => {
   const { PostSubmit, WrappedSmartForm, AccountsLoginForm, SubmitToFrontpageCheckbox } = Components
   const mapsAPIKey = getSetting('googleMaps.apiKey', null);
   const userHasModerationGuidelines = currentUser && currentUser.moderationGuidelines && currentUser.moderationGuidelines.originalContents
+  const af = getSetting('forumType') === 'AlignmentForum'
   const prefilledProps = {
     isEvent: router.location.query && router.location.query.eventForm,
     types: router.location.query && router.location.query.ssc ? ['SSC'] : [],
     meta: router.location.query && !!router.location.query.meta,
-    frontpageDate: getSetting("AlignmentForum", false) ? new Date() : null,
-    af: getSetting("AlignmentForum", false) || (router.location.query && !!router.location.query.af),
+    frontpageDate: af ? new Date() : null,
+    af: af || (router.location.query && !!router.location.query.af),
     groupId: router.location.query && router.location.query.groupId,
     moderationStyle: currentUser && currentUser.moderationStyle,
     moderationGuidelines: userHasModerationGuidelines ? currentUser.moderationGuidelines : undefined

--- a/packages/lesswrong/server/debouncer.js
+++ b/packages/lesswrong/server/debouncer.js
@@ -146,7 +146,7 @@ export const dispatchPendingEvents = async () => {
 // would do this interactively if you're testing and don't want to wait.
 export const forcePendingEvents = async () => {
   let eventToHandle = null;
-  const af = getSetting('AlignmentForum', false);
+  const af = getSetting('forumType') === 'AlignmentForum'
   
   do {
     const queryResult = await DebouncerEvents.rawCollection().findOneAndUpdate(


### PR DESCRIPTION
PR https://github.com/LessWrong2/Lesswrong2/pull/1838 replaced the AlignmentForum setting with a forumType setting, but missed four places that needed updating. This broke unit tests, but CircleCI was broken for us that day to a problem on CircleCI's end, so we didn't notice.