### PR TITLE
Make posts-item border a tiny bit thinner

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -46,7 +46,7 @@ const styles = (theme) => ({
     display: "flex",
     paddingTop: theme.spacing.unit*1.5,
     paddingBottom: theme.spacing.unit*1.5,
-    borderBottom: "solid 1px rgba(0,0,0,.2)",
+    borderBottom: "solid 0.5px rgba(0,0,0,.2)",
     alignItems: "center",
     flexWrap: "wrap",
   },


### PR DESCRIPTION
I was experimenting a bit with the PostsItem design and found that making the border a bit thinner made the site a good amount easier to scan for me (since I had an easier time focusing on the important information instead of all the borders). 

Would want to test this on some low-contrast screen to make sure this doesn't cause the border to disappear completely on some screens.