### PR TITLE
Scroll to fallback

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
@@ -97,14 +97,18 @@ class TableOfContentsList extends Component {
     if (this.props.onClickSection) {
       this.props.onClickSection();
     }
-
-    window.scrollTo({
-      top: y - this.getCurrentSectionMark() + 1,
-      behavior: "smooth"
-    });
-
-    if (ev)
-      ev.preventDefault();
+    try {
+      window.scrollTo({
+        top: y - this.getCurrentSectionMark() + 1,
+        behavior: "smooth"
+      });
+  
+      if (ev) ev.preventDefault();
+    } catch(e) {
+      // eslint-disable-next-line no-console
+      console.warn("scrollTo not supported, using link fallback")
+    }
+    
   }
 
   updateHighlightedSection = () => {

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.jsx
@@ -106,7 +106,7 @@ class TableOfContentsList extends Component {
       if (ev) ev.preventDefault();
     } catch(e) {
       // eslint-disable-next-line no-console
-      console.warn("scrollTo not supported, using link fallback")
+      console.warn("scrollTo not supported, using link fallback", e)
     }
     
   }


### PR DESCRIPTION
Some browsers support scrollTo, but not with an options object like we are providing. This wraps the relevant call in a try-catch and makes sure not to call `preventDefault` when the call to scrollTo fails