### PR TITLE
Properly center posts without ToCs

### DIFF
--- a/packages/lesswrong/components/common/Section.jsx
+++ b/packages/lesswrong/components/common/Section.jsx
@@ -3,8 +3,9 @@ import { Link } from '../../lib/reactRouterWrapper.js';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
+import Grid from '@material-ui/core/Grid';``
 import classNames from 'classnames';
+import withErrorBoundary from './withErrorBoundary.jsx';
 
 
 const BORDER_TOP_WIDTH = 3
@@ -100,31 +101,29 @@ const Section = ({
   if (deactivateSection) return <React.Fragment>{children}</React.Fragment>
 
   return (
-    <Components.ErrorBoundary>
-      <div className={classNames(className, classes.root)}>
-      <Grid container className={classes.section} spacing={0}>
-        <Grid item xs={12} md={3} className={classes.sectionTitleContainer}>
-          {title && <div className={classes.sectionTitleTop}>
-            <Typography variant="display1" className={classes.sectionTitle}>
-              {!titleLink ? <span className="heading">{title}</span> : <Link className="heading" to={titleLink}>{title}</Link>}
-              { subscribeLinks && <Typography className={classes.subscribeWidget} variant="body2">
-                {subscribeLinks}
-              </Typography> }
-            </Typography>
-          </div>}
-          {titleComponent && <div className={classes.sectionTitleBottom}>
-            {titleComponent}
-          </div>}
-        </Grid>
-        <Grid item xs={12} md={9}>
-          <div className={classes.sectionContent}>
-            {children}
-          </div>
-        </Grid>
+    <div className={classNames(className, classes.root)}>
+    <Grid container className={classes.section} spacing={0}>
+      <Grid item xs={12} md={3} className={classes.sectionTitleContainer}>
+        {title && <div className={classes.sectionTitleTop}>
+          <Typography variant="display1" className={classes.sectionTitle}>
+            {!titleLink ? <span className="heading">{title}</span> : <Link className="heading" to={titleLink}>{title}</Link>}
+            { subscribeLinks && <Typography className={classes.subscribeWidget} variant="body2">
+              {subscribeLinks}
+            </Typography> }
+          </Typography>
+        </div>}
+        {titleComponent && <div className={classes.sectionTitleBottom}>
+          {titleComponent}
+        </div>}
       </Grid>
-      </div>
-    </Components.ErrorBoundary>
+      <Grid item xs={12} md={9}>
+        <div className={classes.sectionContent}>
+          {children}
+        </div>
+      </Grid>
+    </Grid>
+    </div>
   )
 };
 
-registerComponent('Section', Section, withStyles(styles, { name: 'Section'}));
+registerComponent('Section', Section, withStyles(styles, { name: 'Section'}), withErrorBoundary);

--- a/packages/lesswrong/components/common/Section.jsx
+++ b/packages/lesswrong/components/common/Section.jsx
@@ -93,8 +93,11 @@ const Section = ({
   subscribeLinks = null,
   className = null,
   children,
-  classes
+  classes,
+  deactivateSection
 }) => {
+
+  if (deactivateSection) return <React.Fragment>{children}</React.Fragment>
 
   return (
     <Components.ErrorBoundary>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -291,7 +291,7 @@ class PostsPage extends Component {
              
             
             {/* Answers Section */}
-            {post.question && <div>
+            {post.question && <div className={classes.post}>
               <div id="answers"/>
               <PostsPageQuestionContent terms={{...commentTerms, postId: post._id}} post={post} refetch={refetch}/>
             </div>}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -29,10 +29,8 @@ const styles = theme => ({
     },
     post: {
       maxWidth: 650 + (theme.spacing.unit*4),
-      [theme.breakpoints.down('md')]: {
-        marginLeft: "auto",
-        marginRight: "auto"
-      }
+      marginLeft: "auto",
+      marginRight: "auto"
     },
     header: {
       position: 'relative',
@@ -107,7 +105,6 @@ const styles = theme => ({
       display: 'inline-block',
       marginLeft: 'auto',
       marginRight: 'auto',
-      paddingRight: 50,
       marginBottom: 40
     },
     draft: {
@@ -144,7 +141,6 @@ const styles = theme => ({
     },
     commentsSection: {
       minHeight: 'calc(70vh - 100px)',
-      marginLeft: -67,
       [theme.breakpoints.down('sm')]: {
         paddingRight: 0,
         marginLeft: 0
@@ -213,7 +209,7 @@ class PostsPage extends Component {
           <HeadTags url={Posts.getPageUrl(post, true)} title={post.title} description={description}/>
 
           {/* Header/Title */}
-          <Section>
+          <Section deactivateSection={!sectionData}>
             <div className={classes.post}>
               {post.groupId && <PostsGroupDetails post={post} documentId={post.groupId} />}
               <PostsTopSequencesNav post={post} sequenceId={sequenceId} />
@@ -257,7 +253,7 @@ class PostsPage extends Component {
               {post.isEvent && <PostsPageEventData post={post}/>}
             </div>
           </Section>
-          <Section titleComponent={
+          <Section deactivateSection={!sectionData} titleComponent={
             <TableOfContents sectionData={sectionData} document={post} />
           }>
             <div className={classes.post}>


### PR DESCRIPTION
This makes it so that when we don't have a ToC for a post, we center the post at small screens instead of weirdly offsetting it to hold space for a ToC that isn't there. 

The best way of doing this would be with flexboxes, but this was the smallest change that I could find that would make it work without having to rewrite all of our section-related code. 