### PR TITLE
Fix race condition that intermittently caused unit test failures

### DIFF
--- a/packages/lesswrong/lib/collections/notifications/tests.js
+++ b/packages/lesswrong/lib/collections/notifications/tests.js
@@ -101,6 +101,7 @@ describe('notification generation', async () => {
     const post = await createDummyPost(user1);
     const comment = await createDummyComment(user2, {postId: post._id});
     performSubscriptionAction('subscribe', Comments, comment._id, user3)
+    await waitUntilCallbacksFinished();
     await createDummyComment(user1, {postId: post._id, parentCommentId: comment._id});
     await waitUntilCallbacksFinished();
     


### PR DESCRIPTION
Hopefully this fixes the intermittent unit test failure we were seeing in this test. Not tested locally, and because this is a stochastic failure we won't know for sure whether it worked for awhile, but since the change is only in a test it's very low risk.