### PR TITLE
Fix double close buttons on Google Maps widget

### DIFF
--- a/packages/lesswrong/styles/_localgroups.scss
+++ b/packages/lesswrong/styles/_localgroups.scss
@@ -33,7 +33,7 @@
 }
 
 /* Experimental: Somewhat hacky solution to get rid of close window in google Info Windows */
-.gm-style-iw + button {
+.gm-style-iw button {
   display: none !important;
 }
 


### PR DESCRIPTION
A Google Maps update changed class names, and we need to change our style overrides to match. Because we used implementation details not part of the proper API and it changed under us.