### PR TITLE
Tweak cancel-votes mongo query to better use indexes

### DIFF
--- a/packages/lesswrong/server/voteServer.js
+++ b/packages/lesswrong/server/voteServer.js
@@ -64,7 +64,7 @@ const clearVotesServer = async ({ document, user, collection, updateDocument }) 
   if (votes.length) {
     // Cancel all the existing votes
     await Connectors.update(Votes,
-      {documentId: document._id, userId: user._id},
+      {documentId: document._id, userId: user._id, cancelled: false},
       {$set: {cancelled: true}},
       {multi:true}, true);
     votes.forEach((vote) => {


### PR DESCRIPTION
This query was selecting on `{documentId, userId}` when our index was for `{documentId, userId, cancelled}`. The latter makes more sense anyways, so update the query.