### PR TITLE
Change line-height of post highlights, answers

### DIFF
--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -175,7 +175,7 @@ export const postHighlightStyles = theme => {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
     fontSize: "1.25rem",
-    lineHeight: "1.6em",
+    lineHeight: "1.8rem",
     '& blockquote': {
       ...theme.typography.body2,
       ...theme.typography.postStyle,


### PR DESCRIPTION
Posts have a font height of 18.2px and a line-height of 26.0px, for a font-height-to-line-height ratio of 0.7. Post highlights and answers, on the other hand, had a font height of 16.25px but the same line-height of 26.0px, a ratio of 0.625. This adjusts the line-height from 1.6em to 1.8rem (note the change of units), making the new line height 23.4px and the font-to-line-height ratio 0.69.