### PR TITLE
Fix nesting errors in HomeLatestPosts

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.jsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.jsx
@@ -44,17 +44,16 @@ class HomeLatestPosts extends PureComponent {
     }
 
     const latestTitle = (
-      <p>
+      <div>
         <p>Recent posts, sorted by a mix of 'new' and 'highly upvoted'.</p>
         <p>By default shows only frontpage posts, and can optionally include personal blogposts.</p>
-        <p><em>Moderators promote posts to frontpage if they seem to be:</em>
-          <ul>
-            <li>Aiming to explain rather than persuade</li>
-            <li>Relatively timeless (avoiding reference to current events or local social knowledge)</li>
-            <li>Reasonably relevant to the average LW user</li>
-          </ul>
-        </p>
-      </p>
+        <p><em>Moderators promote posts to frontpage if they seem to be:</em></p>
+        <ul>
+          <li>Aiming to explain rather than persuade</li>
+          <li>Relatively timeless (avoiding reference to current events or local social knowledge)</li>
+          <li>Reasonably relevant to the average LW user</li>
+        </ul>
+      </div>
     )
 
     return (


### PR DESCRIPTION
`HomeLatestPosts` had some DOM nesting violations (`<p>` in `<p>`, and `<ul>` in `<p>`). This didn't cause any symptoms in production, but did cause a pile of noisy console errors in development. Fix those.