### PR TITLE
Upgrade bcrypt dependency to 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "apollo-engine": "^1.1.2",
     "apollo-errors": "^1.9.0",
     "apollo-server-express": "^1.4.0",
-    "bcrypt": "^3.0.1",
+    "bcrypt": "^3.0.6",
     "body-parser": "^1.18.3",
     "bowser": "^1.9.4",
     "chalk": "^2.4.1",


### PR DESCRIPTION
When trying to run unit tests locally, I was getting

```
Error: ENOENT: no such file or directory, open '/home/jbabcock/repositories/Lesserwrong/alt-LessWrong2/node_modules/bcrypt/build/Release/.deps/home/jbabcock/repositories/Lesserwrong/alt-LessWrong2/node_modules/bcrypt/lib/binding/bcrypt_lib.node.d'
```

Upgrading bcrypt to the latest version (from 3.0.1 to 3.0.6) and running npm install seemed to fix it.