### PR TITLE
Don't randomly load and throw out the top 10 sequences

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGrid.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.jsx
@@ -61,5 +61,5 @@ const options = {
 }
 
 
-registerComponent('SequencesGrid', SequencesGrid, [withList, options],
+registerComponent('SequencesGrid', SequencesGrid,
   withStyles(styles, {name: "SequencesGrid"}));

--- a/packages/lesswrong/components/sequences/SequencesGrid.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.jsx
@@ -1,6 +1,5 @@
-import { Components, registerComponent, withList } from 'meteor/vulcan:core';
+import { Components, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import Sequences from '../../lib/collections/sequences/collection.js';
 import { withStyles } from '@material-ui/core/styles';
 import { legacyBreakpoints } from '../../lib/modules/utils/theme';
 
@@ -50,16 +49,6 @@ const SequencesGrid = ({sequences, showAuthor, classes}) =>
       })}
     </div>
   </div>
-
-const options = {
-  collection: Sequences,
-  queryName: 'SequencesGridQuery',
-  fragmentName: 'SequencesPageFragment',
-  enableTotal: false,
-  enableCache: true,
-  ssr: true,
-}
-
 
 registerComponent('SequencesGrid', SequencesGrid,
   withStyles(styles, {name: "SequencesGrid"}));


### PR DESCRIPTION
This HoC loads the top 10 sequences (with the default view, no filters). But the component is taking a set of sequences to render directly, not getting them via the HoC, so this query's results aren't going anywhere.

Remove the unnecessary query, slightly speeding up library and user pages.