### PR TITLE
Render whitespace for newly edited draftJS documents

### DIFF
--- a/packages/lesswrong/lib/editor/utils.js
+++ b/packages/lesswrong/lib/editor/utils.js
@@ -114,6 +114,10 @@ export const draftToHTML = convertToHTML({
     if (type === 'spoiler') {
      return <p className="spoiler" />
     }
+    if (type === 'unstyled') {
+      if (block.text === ' ' || block.text === '') return <br />;
+      return <p />
+    }
     //  return <span/>;
    },
 });


### PR DESCRIPTION
This changes our draftJS to HTML conversion to work properly with empty paragraphs and move it closer to the WYSIWYG paradigm. 

I intentionally made a change that would not change historical document rendering, just to avoid all the pain associated with that. 

I tested this with the following edit operations: 

+ Add an empty paragraph
+ Add an empty paragraph with only an image
+ Add an empty paragraph with only LaTeX
+ Add a non-empty paragraph
+ Add a non-empty paragraph with LaTeX
+ Add an empty heading (this does not actually follow WYSIWYG, but it never did and this doesn't make it worse) 
+ Add an empty divider