### PR TITLE
Factor four copy-pastes of post-view recording into a HoC

### DIFF
--- a/packages/lesswrong/components/common/withRecordPostView.jsx
+++ b/packages/lesswrong/components/common/withRecordPostView.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { getActions, withMutation } from 'meteor/vulcan:core';
+import compose from 'recompose/compose';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import withNewEvents from '../../lib/events/withNewEvents.jsx';
+
+export const withRecordPostView = (Component) => {
+  const mapStateToProps = state => ({ postsViewed: state.postsViewed });
+  const mapDispatchToProps = dispatch => bindActionCreators(getActions().postsViewed, dispatch);
+
+  async function recordPostView(props) {
+    try {
+
+      // destructure the relevant props
+      const {
+        // from the parent component, used in withDocument, GraphQL HOC
+        documentId,
+        // from connect, Redux HOC
+        setViewed,
+        postsViewed,
+        // from withMutation, GraphQL HOC
+        increasePostViewCount,
+        
+        document,
+        currentUser,
+        recordEvent,
+      } = props;
+
+      // a post id has been found & it's has not been seen yet on this client session
+      if (documentId && !postsViewed.includes(documentId)) {
+
+        // Trigger the asynchronous mutation with postId as an argument
+        // Deliberately not awaiting, because this should be fire-and-forget
+        increasePostViewCount({postId: documentId});
+
+        // Update the redux store
+        setViewed(documentId);
+      }
+
+      //LESSWRONG: register page-visit event
+      if(currentUser) {
+        const eventProperties = {
+          userId: currentUser._id,
+          important: false,
+          intercom: true,
+        };
+
+        if(document) {
+          eventProperties.documentId = document._id;
+          eventProperties.postTitle = document.title;
+        } else if (documentId){
+          eventProperties.documentId = documentId;
+        }
+        recordEvent('post-view', true, eventProperties);
+      }
+    } catch(error) {
+      console.log("recordPostView error:", error); // eslint-disable-line
+    }
+  }
+  
+  function ComponentWithRecordPostView(props) {
+    return <Component {...props} recordPostView={recordPostView}/>
+  }
+  
+  return compose(
+    withMutation({
+      name: 'increasePostViewCount',
+      args: {postId: 'String'},
+    }),
+    withNewEvents,
+    connect(mapStateToProps, mapDispatchToProps),
+  )(ComponentWithRecordPostView);
+}
+
+export default withRecordPostView;

--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, withMutation, getActions } from 'meteor/vulcan:core';
+import { Components, registerComponent } from 'meteor/vulcan:core';
 import React, { PureComponent } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from '../../lib/reactRouterWrapper.js';
@@ -7,12 +7,10 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import Typography from '@material-ui/core/Typography';
 import withUser from "../common/withUser";
 import classNames from 'classnames';
-import { connect } from 'react-redux';
-import withNewEvents from '../../lib/events/withNewEvents.jsx';
-import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import grey from '@material-ui/core/colors/grey';
 import Hidden from '@material-ui/core/Hidden';
+import withRecordPostView from '../common/withRecordPostView';
 
 import { POSTED_AT_WIDTH } from './PostsItemDate.jsx';
 
@@ -195,7 +193,7 @@ class PostsItem2 extends PureComponent {
   }
 
   toggleComments = (scroll) => {
-    this.handleMarkAsRead()
+    this.props.recordPostView({...this.props, document:this.props.post})
     this.setState((prevState) => {
       if (scroll) {
         this.postsItemRef.current.scrollIntoView({behavior: "smooth", block: "center", inline: "nearest"})
@@ -205,40 +203,6 @@ class PostsItem2 extends PureComponent {
         readComments: true
       })
     })
-  }
-
-  async handleMarkAsRead () {
-    const {
-      // from the parent component, used in withDocument, GraphQL HOC
-      // from connect, Redux HOC
-      setViewed,
-      postsViewed,
-      post,
-      // from withMutation, GraphQL HOC
-      increasePostViewCount,
-    } = this.props;
-    // a post id has been found & it's has not been seen yet on this client session
-    if (post && post._id && postsViewed && !postsViewed.includes(post._id)) {
-
-      // trigger the asynchronous mutation with postId as an argument
-      await increasePostViewCount({postId: post._id});
-
-      // once the mutation is done, update the redux store
-      setViewed(post._id);
-    }
-
-    //LESSWRONG: register page-visit event
-    if (this.props.currentUser) {
-      const eventProperties = {
-        userId: this.props.currentUser._id,
-        important: false,
-        intercom: true,
-      };
-
-      eventProperties.documentId = post._id;
-      eventProperties.postTitle = post.title;
-      this.props.recordEvent('post-view', false, eventProperties)
-    }
   }
 
   isSticky = (post, terms) => {
@@ -325,26 +289,13 @@ class PostsItem2 extends PureComponent {
 PostsItem2.propTypes = {
   currentUser: PropTypes.object,
   post: PropTypes.object.isRequired,
-  postsViewed: PropTypes.array,
-  setViewed: PropTypes.func,
-  increasePostViewCount: PropTypes.func,
 };
-
-const mutationOptions = {
-  name: 'increasePostViewCount',
-  args: {postId: 'String'},
-};
-
-const mapStateToProps = state => ({ postsViewed: state.postsViewed });
-const mapDispatchToProps = dispatch => bindActionCreators(getActions().postsViewed, dispatch);
 
 registerComponent(
   'PostsItem2',
   PostsItem2,
-  withMutation(mutationOptions),
-  withNewEvents,
-  connect(mapStateToProps, mapDispatchToProps),
   withStyles(styles, { name: "PostsItem2" }),
+  withUser,
+  withRecordPostView,
   withErrorBoundary,
-  withUser
 );

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -1,14 +1,6 @@
-import {
-  Components,
-  withDocument,
-  registerComponent,
-  getActions,
-  withMutation } from 'meteor/vulcan:core';
-import withNewEvents from '../../../lib/events/withNewEvents.jsx';
+import { Components, withDocument, registerComponent } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { withRouter } from '../../../lib/reactRouterWrapper.js';
 import { Posts } from '../../../lib/collections/posts';
 import { Comments } from '../../../lib/collections/comments'
@@ -20,6 +12,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import classNames from 'classnames';
 import { extractVersionsFromSemver } from '../../../lib/editor/utils'
 import Users from 'meteor/vulcan:users';
+import withRecordPostView from '../../common/withRecordPostView';
 
 const HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT = 300
 
@@ -306,72 +299,20 @@ class PostsPage extends Component {
   }
 
   async componentDidMount() {
-    this.recordPostView();
+    this.props.recordPostView(this.props);
   }
   
   componentDidUpdate(prevProps) {
     if (prevProps.document && this.props.document && prevProps.document._id !== this.props.document._id) {
       this.props.closeAllEvents();
-      this.recordPostView();
-    }
-  }
-  
-  async recordPostView() {
-    try {
-
-      // destructure the relevant props
-      const {
-        // from the parent component, used in withDocument, GraphQL HOC
-        documentId,
-        // from connect, Redux HOC
-        setViewed,
-        postsViewed,
-        // from withMutation, GraphQL HOC
-        increasePostViewCount,
-      } = this.props;
-
-      // a post id has been found & it's has not been seen yet on this client session
-      if (documentId && !postsViewed.includes(documentId)) {
-
-        // Trigger the asynchronous mutation with postId as an argument
-        // Deliberately not awaiting, because this should be fire-and-forget
-        increasePostViewCount({postId: documentId});
-
-        // Update the redux store
-        setViewed(documentId);
-      }
-
-      //LESSWRONG: register page-visit event
-      if(this.props.currentUser) {
-        const recordEvent = this.props.recordEvent;
-        const currentUser = this.props.currentUser;
-        const eventProperties = {
-          userId: currentUser._id,
-          important: false,
-          intercom: true,
-        };
-
-        if(this.props.document) {
-          eventProperties.documentId = this.props.document._id;
-          eventProperties.postTitle = this.props.document.title;
-        } else if (this.props.documentId){
-          eventProperties.documentId = this.props.documentId;
-        }
-        recordEvent('post-view', true, eventProperties);
-      }
-    } catch(error) {
-      console.log("PostPage componentDidMount error:", error); // eslint-disable-line
+      this.props.recordPostView(this.props);
     }
   }
 }
 PostsPage.displayName = "PostsPage";
 
 PostsPage.propTypes = {
-  documentId: PropTypes.string,
   document: PropTypes.object,
-  postsViewed: PropTypes.array,
-  setViewed: PropTypes.func,
-  increasePostViewCount: PropTypes.func,
 }
 
 const queryOptions = {
@@ -386,14 +327,6 @@ const queryOptions = {
   }
 };
 
-const mutationOptions = {
-  name: 'increasePostViewCount',
-  args: {postId: 'String'},
-};
-
-const mapStateToProps = state => ({ postsViewed: state.postsViewed });
-const mapDispatchToProps = dispatch => bindActionCreators(getActions().postsViewed, dispatch);
-
 registerComponent(
   // component name used by Vulcan
   'PostsPage',
@@ -401,18 +334,13 @@ registerComponent(
   PostsPage,
   // HOC to give access to the current user
   withUser,
-  // HOC to give access to LW2 event API
-  withNewEvents,
   // HOC to give access to router and params
   withRouter,
   // HOC to load the data of the document, based on queryOptions & a documentId props
   [withDocument, queryOptions],
-  // HOC to provide a single mutation, based on mutationOptions
-  withMutation(mutationOptions),
-  // HOC to give access to the redux store & related actions
-  connect(mapStateToProps, mapDispatchToProps),
   // HOC to add JSS styles to component
   withStyles(styles, { name: "PostsPage" }),
+  withRecordPostView,
   // Add error boundary to post
-  withErrorBoundary
+  withErrorBoundary,
 );


### PR DESCRIPTION
The function `handleMarkAsRead` and its associated pile of support HoCs was copy-pasted four times: in `PostsItem`, `PostsItem2`, `recentDiscussionThread`, and `PostsPage`. That copy-pasted code was built on Redux, which goes away with the Apollo 2 upgrade. So before doing that part of the migration, we need to undo this bit of technical debt.

Adds a HoC `withRecordPostView`, and uses it to replace the four copy-pastes. The interface is slightly awkward; it adds a bunch of HoCs plus a pseudo-method, which takes a props object to get the props that the other HoCs added. It'll get mostly-rewritten with Apollo 2 anyways, so there's not much point micro-optimizing the interface just yet.