### PR TITLE
Top-navigation can go between sequences in a collection

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.jsx
@@ -10,7 +10,7 @@ const PostsTopSequencesNav = ({post, sequenceId, routes}) => {
 
   const isSequenceRoute = _.some(routes, r => r.name === "sequencesPost")
 
-  if (sequenceId && isSequenceRoute) {
+  if (sequenceId && isSequenceRoute && !canonicalCollectionSlug) {
     return (
       <SequencesNavigation
         documentId={sequenceId}
@@ -27,7 +27,7 @@ const PostsTopSequencesNav = ({post, sequenceId, routes}) => {
         prevPostSlug={post.canonicalPrevPostSlug}
       />
     )
-  } else if (sequenceId){
+  } else if (sequenceId) {
     return (
       <SequencesNavigation
         documentId={sequenceId}


### PR DESCRIPTION
Sequence top-navigation can go between sequences in a collection again. Fixes a bug introduced in https://github.com/LessWrong2/Lesswrong2/pull/1537 . (Sequence *bottom* navigation still can't, tragically.)