### PR TITLE
Slightly faster test cycle

### DIFF
--- a/packages/lesswrong/server/cronUtil.js
+++ b/packages/lesswrong/server/cronUtil.js
@@ -11,7 +11,10 @@ export function addCronJob(options)
 {
   Meteor.startup(function() {
     if (!Meteor.isTest && !Meteor.isAppTest && !Meteor.isPackageTest) {
-      SyncedCron.add(options);
+      // Defer starting of cronjobs until 20s after server startup
+      Meteor.setTimeout(() => {
+        SyncedCron.add(options);
+      }, 20000);
     }
   });
 }


### PR DESCRIPTION
This defers index-building and cron-job setup until 15 and 20 seconds after server startup, respectively. This is mainly for the benefit of test environments, where you want the server to be responsive to a page load as soon as possible after initiating a rebuild.