### PR TITLE
Add a "Subscribe to curated posts" checkbox to the signup form

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.jsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.jsx
@@ -15,7 +15,7 @@ const styles = theme => ({
 })
 
 const PostsNewForm = ({router, currentUser, flash, classes}) => {
-  const { PostSubmit, WrappedSmartForm, AccountsLoginForm, SubmitToFrontpageCheckbox } = Components
+  const { PostSubmit, WrappedSmartForm, WrappedLoginForm, SubmitToFrontpageCheckbox } = Components
   const mapsAPIKey = getSetting('googleMaps.apiKey', null);
   const userHasModerationGuidelines = currentUser && currentUser.moderationGuidelines && currentUser.moderationGuidelines.originalContents
   const af = getSetting('forumType') === 'AlignmentForum'
@@ -32,7 +32,7 @@ const PostsNewForm = ({router, currentUser, flash, classes}) => {
   const eventForm = router.location.query && router.location.query.eventForm
 
   if (!Posts.options.mutations.new.check(currentUser)) {
-    return (<AccountsLoginForm />);
+    return (<WrappedLoginForm />);
   }
   const NewPostsSubmit = (props) => {
     return <div className={classes.formSubmit}>

--- a/packages/lesswrong/components/users/AccountsResetPassword.jsx
+++ b/packages/lesswrong/components/users/AccountsResetPassword.jsx
@@ -11,7 +11,7 @@ class AccountsResetPassword extends PureComponent {
   }
 
   render() {
-    return <Components.AccountsLoginForm formState={ STATES.PASSWORD_CHANGE }/>
+    return <Components.WrappedLoginForm formState={ STATES.PASSWORD_CHANGE }/>
   }
 }
 

--- a/packages/lesswrong/components/users/LoginPage.jsx
+++ b/packages/lesswrong/components/users/LoginPage.jsx
@@ -18,7 +18,7 @@ class LoginPage extends Component {
       // `componentWillMount`.
       return <div />
     } else {
-      return <Components.AccountsLoginForm />;
+      return <Components.WrappedLoginForm />;
     }
   }
 }

--- a/packages/lesswrong/components/users/LoginPopupLink.jsx
+++ b/packages/lesswrong/components/users/LoginPopupLink.jsx
@@ -38,7 +38,7 @@ class LoginPopupLink extends PureComponent {
           onClose={(e) => this.setState({isOpen: false})}
         >
           <div className={classes.popup}>
-            <Components.AccountsLoginForm/>
+            <Components.WrappedLoginForm/>
           </div>
         </Modal>
       </div>

--- a/packages/lesswrong/components/users/UsersAccountMenu.jsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.jsx
@@ -63,7 +63,7 @@ class UsersAccountMenu extends PureComponent {
           {this.state.open
             && getSetting('reCaptcha.apiKey')
             && <Components.ReCaptcha verifyCallback={this.setReCaptchaToken} action="login/signup"/>}
-          <Components.AccountsLoginForm 
+          <Components.WrappedLoginForm 
             onPreSignUpHook={(options) => {
               const reCaptchaToken = this.state.reCaptchaToken
               return {...options, profile: {...options.profile, reCaptchaToken}}

--- a/packages/lesswrong/components/users/UsersAccountMenu.jsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.jsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
+import { Components, registerComponent } from 'meteor/vulcan:core';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
@@ -22,7 +22,6 @@ class UsersAccountMenu extends PureComponent {
     super(props);
     this.state = {
       open: false,
-      reCaptchaToken: null
     }
   }
 
@@ -38,10 +37,6 @@ class UsersAccountMenu extends PureComponent {
     this.setState({
       open: false,
     });
-  }
-
-  setReCaptchaToken = (token) => {
-    this.setState({reCaptchaToken: token})
   }
 
   render() {
@@ -60,15 +55,7 @@ class UsersAccountMenu extends PureComponent {
           anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
           onClose={this.handleRequestClose}
         >
-          {this.state.open
-            && getSetting('reCaptcha.apiKey')
-            && <Components.ReCaptcha verifyCallback={this.setReCaptchaToken} action="login/signup"/>}
-          <Components.WrappedLoginForm 
-            onPreSignUpHook={(options) => {
-              const reCaptchaToken = this.state.reCaptchaToken
-              return {...options, profile: {...options.profile, reCaptchaToken}}
-            }}
-          />
+          {this.state.open && <Components.WrappedLoginForm />}
         </Popover>
       </div>
     )

--- a/packages/lesswrong/components/users/WrappedLoginForm.jsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.jsx
@@ -1,7 +1,28 @@
-import { registerComponent } from 'meteor/vulcan:core';
+import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
+import React, { Component } from 'react';
 
-const WrappedLoginForm = ({}) => {
-  return <Components.AccountsLoginForm />
+class WrappedLoginForm extends Component
+{
+  state = {
+    reCaptchaToken: null
+  };
+  
+  setReCaptchaToken = (token) => {
+    this.setState({reCaptchaToken: token})
+  }
+  
+  render() {
+    return <React.Fragment>
+      {getSetting('reCaptcha.apiKey')
+        && <Components.ReCaptcha verifyCallback={this.setReCaptchaToken} action="login/signup"/>}
+      <Components.AccountsLoginForm
+        onPreSignUpHook={(options) => {
+          const reCaptchaToken = this.state.reCaptchaToken
+          return {...options, profile: {...options.profile, reCaptchaToken}}
+        }}
+      />
+    </React.Fragment>;
+  }
 }
 
 registerComponent('WrappedLoginForm', WrappedLoginForm);

--- a/packages/lesswrong/components/users/WrappedLoginForm.jsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.jsx
@@ -1,0 +1,7 @@
+import { registerComponent } from 'meteor/vulcan:core';
+
+const WrappedLoginForm = ({}) => {
+  return <Components.AccountsLoginForm />
+}
+
+registerComponent('WrappedLoginForm', WrappedLoginForm);

--- a/packages/lesswrong/components/users/WrappedLoginForm.jsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.jsx
@@ -1,5 +1,28 @@
 import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+
+class SignupSubscribeToCurated extends Component
+{
+  state = {
+    checked: this.props.defaultValue
+  }
+  render() {
+    const {onChange, id} = this.props;
+    return <div key={id}>
+      <Checkbox
+        checked={this.state.checked}
+        onChange={(ev, checked) => {
+          this.setState({
+            checked: checked
+          });
+          onChange({target: {value: checked}})
+        }}
+      />
+      Subscribe to curated posts
+    </div>
+  }
+}
 
 class WrappedLoginForm extends Component
 {
@@ -12,6 +35,15 @@ class WrappedLoginForm extends Component
   }
   
   render() {
+    const customSignupFields = [
+      {
+        id: "subscribeToCurated",
+        type: 'custom',
+        defaultValue: true,
+        renderCustom: SignupSubscribeToCurated
+      }
+    ]
+    
     return <React.Fragment>
       {getSetting('reCaptcha.apiKey')
         && <Components.ReCaptcha verifyCallback={this.setReCaptchaToken} action="login/signup"/>}
@@ -20,6 +52,7 @@ class WrappedLoginForm extends Component
           const reCaptchaToken = this.state.reCaptchaToken
           return {...options, profile: {...options.profile, reCaptchaToken}}
         }}
+        customSignupFields={customSignupFields}
       />
     </React.Fragment>;
   }

--- a/packages/lesswrong/lib/collections/users/callbacks.js
+++ b/packages/lesswrong/lib/collections/users/callbacks.js
@@ -119,7 +119,7 @@ addCallback('users.new.async', addReCaptchaRating);
 
 async function subscribeOnSignup (user) {
   // If the subscribed-to-curated checkbox was checked, set the corresponding config setting
-  const subscribeToCurated = user?.profile?.subscribeToCurated;
+  const subscribeToCurated = user.profile?.subscribeToCurated;
   if (subscribeToCurated) {
     Users.update(user._id, {$set: {emailSubscribedToCurated: true}});
   }

--- a/packages/lesswrong/lib/collections/users/callbacks.js
+++ b/packages/lesswrong/lib/collections/users/callbacks.js
@@ -121,10 +121,7 @@ async function subscribeOnSignup (user) {
   // If the subscribed-to-curated checkbox was checked, set the corresponding config setting
   const subscribeToCurated = user?.profile?.subscribeToCurated;
   if (subscribeToCurated) {
-    console.log("Subscribing to curated");
     Users.update(user._id, {$set: {emailSubscribedToCurated: true}});
-  } else {
-    console.log("Not subscribing to curated");
   }
   
   // Regardless of the config setting, try to confirm the user's email address

--- a/packages/lesswrong/lib/collections/users/callbacks.js
+++ b/packages/lesswrong/lib/collections/users/callbacks.js
@@ -125,6 +125,10 @@ async function subscribeOnSignup (user) {
   }
   
   // Regardless of the config setting, try to confirm the user's email address
-  Accounts.sendVerificationEmail(user._id);
+  // (But not in unit-test contexts, where this function is unavailable and sending
+  // emails doesn't make sense.)
+  if (!Meteor.isTest && !Meteor.isAppTest && !Meteor.isPackageTest) {
+    Accounts.sendVerificationEmail(user._id);
+  }
 }
 addCallback('users.new.async', subscribeOnSignup);

--- a/packages/lesswrong/lib/collections/users/callbacks.js
+++ b/packages/lesswrong/lib/collections/users/callbacks.js
@@ -115,5 +115,19 @@ async function addReCaptchaRating (user) {
     }
   }
 }
-
 addCallback('users.new.async', addReCaptchaRating);
+
+async function subscribeOnSignup (user) {
+  // If the subscribed-to-curated checkbox was checked, set the corresponding config setting
+  const subscribeToCurated = user?.profile?.subscribeToCurated;
+  if (subscribeToCurated) {
+    console.log("Subscribing to curated");
+    Users.update(user._id, {$set: {emailSubscribedToCurated: true}});
+  } else {
+    console.log("Not subscribing to curated");
+  }
+  
+  // Regardless of the config setting, try to confirm the user's email address
+  Accounts.sendVerificationEmail(user._id);
+}
+addCallback('users.new.async', subscribeOnSignup);

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -94,6 +94,7 @@ import '../components/users/AccountsResetPassword.jsx';
 import '../components/users/EmailTokenPage.jsx';
 import '../components/users/EmailTokenResult.jsx';
 import '../components/users/UserNameDeleted.jsx';
+import '../components/users/WrappedLoginForm.jsx';
 
 import '../components/icons/OmegaIcon.jsx';
 


### PR DESCRIPTION
This adds a "Subscribe to curated posts" checkbox to the signup form. Requires matching Vulcan PR, https://github.com/LessWrong2/Vulcan/pull/75 , to add the extension point for custom fields to `vulcan-accounts`.

The signup checkbox sets the value of the existing "Email me new posts in Curated" setting. Regardless of whether you check the subscribe box, you will now get an email verification request email on signup. Users need to click the verification link to actually start getting emails.

Important decision: What is the default value of the checkbox? What is the wording of the label on the checkbox?

Less important, but still todo: Make the checkbox label use a nicer font (rather than just the browser default).