### PR TITLE
Increase number of answers rendered by default

### DIFF
--- a/packages/lesswrong/components/questions/PostsPageQuestionContent.jsx
+++ b/packages/lesswrong/components/questions/PostsPageQuestionContent.jsx
@@ -5,6 +5,8 @@ import withUser from '../common/withUser'
 import Users from 'meteor/vulcan:users';
 import withErrorBoundary from '../common/withErrorBoundary';
 
+const MAX_ANSWERS_QUERIED = 100
+
 const PostsPageQuestionContent = ({post, currentUser, refetch}) => {
   const { AnswersList, NewAnswerCommentQuestionForm, CantCommentExplanation, RelatedQuestionsList } = Components
   return (
@@ -13,7 +15,7 @@ const PostsPageQuestionContent = ({post, currentUser, refetch}) => {
       {currentUser && !Users.isAllowedToComment(currentUser, post) &&
         <CantCommentExplanation post={post}/>
       }
-      <AnswersList terms={{view: "questionAnswers", postId: post._id}} post={post}/>
+      <AnswersList terms={{view: "questionAnswers", postId: post._id, limit: MAX_ANSWERS_QUERIED}} post={post}/>
       <RelatedQuestionsList post={post} />
     </div>
   )


### PR DESCRIPTION
Turns out by default we only render 10 answers. We don't seem to have run into this problem before, but it's visible on the open problems in rationality question, so seems important to fix