### PR TITLE
Meta bugfixes

### DIFF
--- a/packages/lesswrong/components/common/Meta.jsx
+++ b/packages/lesswrong/components/common/Meta.jsx
@@ -12,7 +12,7 @@ const Meta = ({location, currentUser}, context) => {
         titleComponent= {<div className="recent-posts-title-component">
           {currentUser && <div className="new-post-link"><Link to={{pathname:"/newPost", query: {meta: true}}}> new post </Link></div>}
           </div>} >
-          <Components.PostsList terms={recentPostsTerms} />
+          <Components.PostsList2 terms={recentPostsTerms} />
         </Components.Section>
     </div>
   )

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -607,7 +607,7 @@ Posts.addView("sunshineNewPosts", function () {
   }
 })
 ensureIndex(Posts,
-  augmentForDefaultView({ status:1, reviewedByUserId:1, frontpageDate: 1, authorIsUnreviewed:1 }),
+  augmentForDefaultView({ status:1, reviewedByUserId:1, frontpageDate: 1, authorIsUnreviewed:1, meta: 1 }),
   { name: "posts.sunshineNewPosts" }
 );
 

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -597,6 +597,7 @@ Posts.addView("sunshineNewPosts", function () {
     selector: {
       reviewedByUserId: {$exists: false},
       frontpageDate: viewFieldNullOrMissing,
+      meta: false,
     },
     options: {
       sort: {


### PR DESCRIPTION
Meta page use PostList2 — fixes text overflow issue.
Exclude Meta posts from sunshine sidebar.

Y'all have meta posts, so I'm surprised you haven't seen the second error at least.