### PR TITLE
Hotfix: Abbreviate long coauthor lists in PostsItem2

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -246,7 +246,7 @@ class PostsItem2 extends PureComponent {
             </Link>
 
             { post.user && !post.isEvent && <PostsItem2MetaInfo className={classes.author}>
-              <PostsUserAndCoauthors post={post}/>
+              <PostsUserAndCoauthors post={post} abbreviateIfLong={true} />
             </PostsItem2MetaInfo>}
 
             { post.isEvent && <PostsItem2MetaInfo className={classes.event}>


### PR DESCRIPTION
Same as the last PR, except this one is against master instead of devel.