### PR TITLE
Alignment Forum allposts and user-profile pages hotifx

### DIFF
--- a/packages/lesswrong/components/posts/PostsListSettings.jsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.jsx
@@ -14,6 +14,21 @@ import { DEFAULT_LOW_KARMA_THRESHOLD, MAX_LOW_KARMA_THRESHOLD } from '../../lib/
 import { views as defaultViews } from './AllPostsPage.jsx'
 
 const FILTERS_ALL = {
+  "AlignmentForum": [
+    {
+      name: "all",
+      label: "All Posts",
+      tooltip: "Includes all posts"},
+    {
+      name: "questions",
+      label: "Questions",
+      tooltip: "Open questions and answers, ranging from newbie-questions to important unsolved scientific problems."},
+    {
+      name: "meta",
+      label: "Meta",
+      tooltip: "Posts relating to LessWrong itself"
+    },
+  ],
   "LessWrong": [
     { name: "all",
       label: "All Posts",
@@ -73,7 +88,7 @@ const styles = theme => ({
     }
   },
   hidden: {
-    display: "none", // Uses CSS to show/hide 
+    display: "none", // Uses CSS to show/hide
     overflow: "hidden",
   },
   menuItem: {
@@ -140,7 +155,7 @@ class PostsListSettings extends Component {
         data: {
           allPostsView: view,
         },
-      })  
+      })
     }
   }
 
@@ -152,7 +167,7 @@ class PostsListSettings extends Component {
         data: {
           allPostsShowLowKarma: newSetting,
         },
-      })  
+      })
     }
   }
 
@@ -169,8 +184,8 @@ class PostsListSettings extends Component {
           </MetaInfo>
           {Object.entries(views).map(([name, label]) => {
             return (
-              <Link 
-                key={name} 
+              <Link
+                key={name}
                 onClick={() => this.setView(name)}
                 to={loc=> ({...loc, query: {...loc.query, view: name}})}
               >
@@ -188,8 +203,8 @@ class PostsListSettings extends Component {
           </MetaInfo>
           {FILTERS.map(filter => {
             return (
-              <Link 
-                key={filter.name} 
+              <Link
+                key={filter.name}
                 onClick={() => this.setFilter(filter.name)}
                 to={loc=> ({...loc, query: {...loc.query, filter: filter.name}})}
               >
@@ -204,18 +219,18 @@ class PostsListSettings extends Component {
         </div>
 
         <Tooltip title={<div><div>By default, posts below -10 karma are hidden.</div><div>Toggle to show them.</div></div>} placement="right-start">
-          <Link 
+          <Link
             className={classes.checkboxGroup}
             onClick={() => this.setShowLowKarma(!currentShowLowKarma)}
             to={loc=> ({...loc, query: {...loc.query, karmaThreshold: (currentShowLowKarma ? DEFAULT_LOW_KARMA_THRESHOLD : MAX_LOW_KARMA_THRESHOLD)}})}
           >
-            <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentShowLowKarma} /> 
+            <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentShowLowKarma} />
 
-            {/* {currentShowLowKarma ? 
+            {/* {currentShowLowKarma ?
             // Looks like Checkbox doesn't play nicely with the Link/route based check-status-setting/
             // This works fine but feels a bit hacky
-              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked /> 
-              : 
+              <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked />
+              :
               <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}}/>
             } */}
 

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -92,10 +92,15 @@ class UsersProfile extends Component {
     }
   }
 
+  getUserFromResults = (results) => {
+    // HOTFIX: Filtering out invalid users
+    return results?.find(user => !!user.displayName) || results?.[0]
+  }
+
   renderMeta = () => {
     const props = this.props
     const { classes, results } = props
-    const document = results?.[0]
+    const document = this.getUserFromResults(results)
     if (!document) return null
     const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma } = document;
 
@@ -146,14 +151,13 @@ class UsersProfile extends Component {
 
   render() {
     const { slug, classes, currentUser, loading, results, router } = this.props;
-    const document = results?.[0]
-  
+    const document = this.getUserFromResults(results)
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
         <Components.Loading/>
       </div>
     }
-    
+
     if (!document || !document._id || document.deleted) {
       //eslint-disable-next-line no-console
       console.error(`// missing user (_id/slug: ${slug})`);
@@ -168,7 +172,7 @@ class UsersProfile extends Component {
     }
 
     const { SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, SectionFooter, NewConversationButton, SubscribeTo, DialogGroup, SectionButton } = Components
-    
+
     const user = document;
     const query = _.clone(router.location.query || {});
 
@@ -205,14 +209,14 @@ class UsersProfile extends Component {
               </div>
             }
             { currentUser && currentUser._id != user._id && <NewConversationButton user={user}>
-              <a>Send Message</a> 
+              <a>Send Message</a>
             </NewConversationButton>}
             { currentUser && currentUser._id !== user._id && <SubscribeTo document={user} /> }
             {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
               <FormattedMessage id="users.edit_account"/>
             </Link>}
           </SectionFooter>
-        
+
           { user.bio && <div className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} /> }
 
         </SingleColumnSection>
@@ -226,7 +230,7 @@ class UsersProfile extends Component {
               terms={ownPage ? sequenceAllTerms : sequenceTerms}
               showLoadMore={true}/>
         </SingleColumnSection> }
-        
+
         {/* Drafts Section */}
         { ownPage && <SingleColumnSection>
           <SectionTitle title="My Drafts">


### PR DESCRIPTION
Fixes two bugs: 

+ Broken all posts page on Alignment Forum because we didn't specify filters
+ Broken user pages for some select users who have an account with a duplicate slug