### PR TITLE
remove reports newMutation in akismet

### DIFF
--- a/packages/lesswrong/server/akismet.js
+++ b/packages/lesswrong/server/akismet.js
@@ -71,19 +71,6 @@ async function checkPostForSpamWithAkismet(post, currentUser) {
   if (akismetKey) {
     const spam = await checkForAkismetSpam({document: post,type: "post"})
     if (spam) {
-      //eslint-disable-next-line no-console
-      console.log("Spam post detected, creating new Report", currentUser)
-      newMutation({
-        collection: Reports,
-        document: {
-          userId: currentUser._id,
-          postId: post._id,
-          link: Posts.getPageUrl(post),
-          description: "Akismet reported this as spam",
-          reportedAsSpam: true,
-        },
-        validate: false,
-      })
       if ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD) {
         // eslint-disable-next-line no-console
         console.log("Deleting post from user below spam threshold", post)
@@ -108,20 +95,6 @@ async function checkCommentForSpamWithAkismet(comment, currentUser) {
     if (akismetKey) {
       const spam = await checkForAkismetSpam({document: comment, type: "comment"})
       if (spam) {
-        //eslint-disable-next-line no-console
-        console.log("Spam comment detected, creating new Report", currentUser)
-        newMutation({
-          collection: Reports,
-          document: {
-            userId: currentUser._id,
-            postId: comment.postId,
-            commentId: comment._id,
-            link: comment.postId && Comments.getPageUrl(comment),
-            description: "Akismet reported this as spam",
-            reportedAsSpam: true
-          },
-          validate: false,
-        })
         if ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD) {
           // eslint-disable-next-line no-console
           console.log("Deleting comment from user below spam threshold", comment)

--- a/packages/lesswrong/server/akismet.js
+++ b/packages/lesswrong/server/akismet.js
@@ -1,8 +1,7 @@
 import LWEvents from '../lib/collections/lwevents/collection'
-import Reports from '../lib/collections/reports/collection.js'
 import { Posts } from '../lib/collections/posts/collection.js'
 import { Comments } from '../lib/collections/comments/collection.js'
-import { editMutation, newMutation, getSetting, addCallback, runCallbacksAsync } from 'meteor/vulcan:core';
+import { editMutation, getSetting, addCallback, runCallbacksAsync } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
 import akismet from 'akismet-api'
 

--- a/packages/lesswrong/server/akismet.js
+++ b/packages/lesswrong/server/akismet.js
@@ -70,17 +70,15 @@ client.verifyKey()
 async function checkPostForSpamWithAkismet(post, currentUser) {
   if (akismetKey) {
     const spam = await checkForAkismetSpam({document: post,type: "post"})
-    if (spam) {
-      if ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD) {
-        // eslint-disable-next-line no-console
-        console.log("Deleting post from user below spam threshold", post)
-        editMutation({
-          collection: Posts,
-          documentId: post._id,
-          set: {status: 4},
-          validate: false,
-        });
-      }
+    if (spam && ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD)) {
+      // eslint-disable-next-line no-console
+      console.log("Deleting post from user below spam threshold", post)
+      editMutation({
+        collection: Posts,
+        documentId: post._id,
+        set: {status: 4},
+        validate: false,
+      });
     } else {
       //eslint-disable-next-line no-console
       console.log('Post marked as not spam', post._id);
@@ -94,22 +92,20 @@ addCallback('posts.new.after', checkPostForSpamWithAkismet);
 async function checkCommentForSpamWithAkismet(comment, currentUser) {
     if (akismetKey) {
       const spam = await checkForAkismetSpam({document: comment, type: "comment"})
-      if (spam) {
-        if ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD) {
-          // eslint-disable-next-line no-console
-          console.log("Deleting comment from user below spam threshold", comment)
-          await editMutation({
-            collection: Comments,
-            documentId: comment._id,
-            set: {
-              deleted: true,
-              deletedDate: new Date(), 
-              deletedReason: "Your comment has been marked as spam by the Akismet span integration. We will review your comment in the coming hours and restore it if we determine that it isn't spam"
-            },
-            validate: false,
-            user: currentUser
-          });
-        }
+      if (spam && ((currentUser.karma || 0) < SPAM_KARMA_THRESHOLD)) {
+        // eslint-disable-next-line no-console
+        console.log("Deleting comment from user below spam threshold", comment)
+        await editMutation({
+          collection: Comments,
+          documentId: comment._id,
+          set: {
+            deleted: true,
+            deletedDate: new Date(), 
+            deletedReason: "Your comment has been marked as spam by the Akismet span integration. We will review your comment in the coming hours and restore it if we determine that it isn't spam"
+          },
+          validate: false,
+          user: currentUser
+        });
       } else {
         //eslint-disable-next-line no-console
         console.log('Comment marked as not spam', comment._id);


### PR DESCRIPTION
So, one way to do this would have been to create *another* callback that removes the akismet reports after creating them. Or, possibly, having a better system for deciding when to create them in first place (taking recaptcha data into account).

But my sense is that this is mostly just an unnecessary loop in the process, and that using reports in this way is always going to be pretty brittle. I'd rather remove the auto-report creation process, and declare bankruptcy (deleting all existing reports), and then going forward reports will be a higher-signal thing that reliably has a human in the loop.