### PR TITLE
Reenable skipping of async function in user creation

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -127,8 +127,8 @@ ensureIndex(Revisions, {documentId: 1, version: 1, fieldName: 1, editedAt: 1})
 export function addEditableCallbacks({collection, options = {}}) {
   const {
     fieldName = "contents",
-    // deactivateNewCallback // Because of Meteor shenannigans we don't have access to the full user object when a new user is created, and this creates
-    // // bugs when we register callbacks that trigger on new user creation. So we allow the deactivation of the new callbacks.
+    deactivateNewCallback // Because of Meteor shenannigans we don't have access to the full user object when a new user is created, and this creates
+    // bugs when we register callbacks that trigger on new user creation. So we allow the deactivation of the new callbacks.
   } = options
 
   const { typeName } = collection.options
@@ -147,7 +147,9 @@ export function addEditableCallbacks({collection, options = {}}) {
     return doc
   }
 
-  addCallback(`${typeName.toLowerCase()}.create.before`, editorSerializationNew);
+  if (!deactivateNewCallback) {
+    addCallback(`${typeName.toLowerCase()}.create.before`, editorSerializationNew);
+  }
 
   async function editorSerializationEdit (docData, { document, currentUser }) {
     if (docData[fieldName] && docData[fieldName].originalContents) {


### PR DESCRIPTION
Fixes error that happened on login. This was disabled in
https://github.com/LessWrong2/Lesswrong2/commit/a403c705db7ca1ef95471e10096a3a70c07b9e5a#diff-f9f3038a8715bba754e6ce9d49adba11R88
but I don't see it causing test failures now and suspect it maybe have been in error.