### PR TITLE
RecentDiscussion Tweak

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -185,12 +185,12 @@ class CommentsNode extends Component {
 
   isSingleLine = () => {
     const { currentUser, comment, condensed, lastCommentId } = this.props 
-    const newAndMostRecent = (this.isNewComment() && (!condensed || (lastCommentId === comment._id)))
+    const mostRecent = (!condensed || (lastCommentId === comment._id))
     const lowKarmaOrCondensed = (comment.baseScore < 10 || condensed) 
     return (
       currentUser?.beta &&
       this.isTruncated() && 
-      !newAndMostRecent && 
+      !mostRecent && 
       lowKarmaOrCondensed
     )
     

--- a/packages/lesswrong/components/comments/recentDiscussionThreadsList.jsx
+++ b/packages/lesswrong/components/comments/recentDiscussionThreadsList.jsx
@@ -21,7 +21,7 @@ const RecentDiscussionThreadsList = ({
     return null
   }
 
-  const limit = (currentUser && currentUser.isAdmin) ? 8 : 3
+  const limit = (currentUser && currentUser.isAdmin) ? 4 : 3
 
   return (
     <div>


### PR DESCRIPTION
I found myself slightly annoyed sometimes when browsing recent discussion in braindead mode, that a) a lot of things have no text, b) as soon as I click an unread thing and then refresh the page it disappears, c) somewhat too much stuff going on for each post.

This shifts the SingleLineComments admin mode so that it only shows up to 4 comments, but one of them is always expanded, which changes the feel back to something closer to what it was originally