### PR TITLE
Improve Ray's Special Snowflake Sunshine Options

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.jsx
@@ -26,11 +26,11 @@ const SunshineNewUserCommentsList = ({loading, results, classes, truncated}) => 
     <div>
       {loading && !truncated && <Loading />}
       {results.map(comment=><div className={classes.comment} key={comment._id}>
-        {!truncated && <MetaInfo>
+        <MetaInfo>
           <Link to={`/posts/${comment.postId}`}>
             Comment made <FormatDate date={comment.postedAt}/> {comment.status}
           </Link>
-        </MetaInfo>}
+        </MetaInfo>
         {!truncated && <div><MetaInfo>{comment.deleted && `[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}
         <div className={classes.commentStyle} dangerouslySetInnerHTML={{__html: (comment.contents && comment.contents.html) || ""}} />
       </div>)}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
@@ -9,13 +9,15 @@ const styles = theme => ({
   post: {
     marginTop: theme.spacing.unit*2,
     marginBottom: theme.spacing.unit*2,
+    fontSize: "1.1em",
+  },
+  postBody: {
     ...postHighlightStyles(theme),
-    fontSize: "1.1em"
   }
 })
 
 const SunshineNewUserPostsList = ({loading, results, classes, truncated}) => {
-  const { PostsItemTitle, Loading } = Components
+  const { Loading, MetaInfo } = Components
  
   if (!results && loading && !truncated) return <Loading />
   if (!results) return null
@@ -24,11 +26,13 @@ const SunshineNewUserPostsList = ({loading, results, classes, truncated}) => {
     <div>
       {loading && !truncated && <Loading />}
       {results.map(post=><div className={classes.post} key={post._id}>
-        {!truncated && <Link to={`/posts/${post._id}`}>
-          <PostsItemTitle post={post} />
-        </Link>}
-        {!truncated && !(post.status ==2) && `Flagged as Spam ${post.status}`}
-        <div dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />
+        <MetaInfo>
+          <Link to={`/posts/${post._id}`}>
+            Post: {post.title}
+          </Link>
+        </MetaInfo>
+        <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />
+        {!(post.status ==2) && `Flagged as Spam ${post.status}`}
       </div>)}
     </div>
   )

--- a/packages/lesswrong/lib/modules/fragments.js
+++ b/packages/lesswrong/lib/modules/fragments.js
@@ -373,6 +373,7 @@ registerFragment(`
     viewUnreviewedComments
     auto_subscribe_to_my_posts
     auto_subscribe_to_my_comments
+    sunshineShowNewUserContent
   }
 `);
 
@@ -391,6 +392,7 @@ registerFragment(`
     currentFrontpageFilter
     noCollapseCommentsPosts
     noCollapseCommentsFrontpage
+    sunshineShowNewUserContent
 
     # Emails
     email


### PR DESCRIPTION
Previously due to fragment bug you couldn't actually turn this feature on and off without Robo3T.

I also optimized the rendering of the content sample slightly so that I could skim it, click on a link to the post/comment if I wanted, *without* that link looking "green" (which was the heuristic I used to detect spam when skimming the sunshine sidebar)