### PR TITLE
Use ReadStatuses collection for faster post-read-status queries

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.js
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.js
@@ -6,8 +6,8 @@ import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
 import { Utils } from 'meteor/vulcan:core';
 import GraphQLJSON from 'graphql-type-json';
 import { schemaDefaultValue } from '../../collectionUtils';
-//import { getWithCustomLoader } from '../../loaders.js';
-//import keyBy from 'lodash/keyBy';
+import { getWithCustomLoader } from '../../loaders.js';
+import keyBy from 'lodash/keyBy';
 
 export const formGroups = {
   adminOptions: {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.js
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.js
@@ -147,13 +147,7 @@ addFieldsDict(Posts, {
     resolver: async (post, args, { ReadStatuses, LWEvents, currentUser }) => {
       if (!currentUser) return null;
       
-      // Slow method, from the LWEvents table. This is an N+1 select. Switch
-      // after the migration script is run.
-      const event = await LWEvents.findOne({name:'post-view', documentId: post._id, userId: currentUser._id}, {sort:{createdAt:-1}});
-      return event && event.createdAt
-      
-      // Faster method, using the ReadStatuses table.
-      /*return await getWithCustomLoader(ReadStatuses, `postsReadByUser${currentUser._id}`, post._id,
+      return await getWithCustomLoader(ReadStatuses, `postsReadByUser${currentUser._id}`, post._id,
         async postIDs => {
           const readDates = await ReadStatuses.find({
             userId: currentUser._id,
@@ -164,7 +158,7 @@ addFieldsDict(Posts, {
           const readDateByPostID = keyBy(readDates, ev=>ev.postId);
           return postIDs.map(postID => readDateByPostID[postID] ? readDateByPostID[postID].lastUpdated : null);
         }
-      );*/
+      );
     }
   }),
 

--- a/packages/lesswrong/server/partiallyReadSequences.js
+++ b/packages/lesswrong/server/partiallyReadSequences.js
@@ -119,11 +119,10 @@ const postsToReadStatuses = async (user, postIDs) => {
     } },
     
     { $lookup: {
-      from: "lwevents",
+      from: "readstatuses",
       let: { documentId: "$_id", },
       pipeline: [
         { $match: {
-          name: "post-view",
           userId: user._id,
         } },
         { $match: { $expr: {

--- a/packages/lesswrong/server/recommendations.js
+++ b/packages/lesswrong/server/recommendations.js
@@ -24,11 +24,10 @@ const pipelineFilterUnread = ({currentUser}) => {
   
   return [
     { $lookup: {
-      from: "lwevents",
+      from: "readstatuses",
       let: { documentId: "$_id", },
       pipeline: [
         { $match: {
-          name: "post-view",
           userId: currentUser._id,
         } },
         { $match: { $expr: {


### PR DESCRIPTION
Merge only after the `denormalizeReadStatus` migration has been run.