### PR TITLE
Login tokens no longer expire after 90 days

### DIFF
--- a/packages/lesswrong/lib/modules/accounts/configuration.js
+++ b/packages/lesswrong/lib/modules/accounts/configuration.js
@@ -1,3 +1,6 @@
 import { Accounts } from 'meteor/accounts-base';
 
-Accounts._options.forbidClientAccountCreation = false;
+Accounts.config({
+  forbidClientAccountCreation: false,
+  loginExpirationInDays: 365*100,
+});


### PR DESCRIPTION
Before: When you log in with the form, your login token gets a date-stamp. If it's older than 90 days, you have to log in again. Visiting the site with a saved login does not reset the date-stamp.

After: As above, but replace "90 days" with "100 years". Tested by editing the database to back-date login tokens into the distance, expired past.

Fixes #1908.