### PR TITLE
exportPostDetails only reviewed

### DIFF
--- a/packages/lesswrong/server/scripts/exportPostDetails.js
+++ b/packages/lesswrong/server/scripts/exportPostDetails.js
@@ -35,7 +35,8 @@ function getPosts (selector) {
   const defaultSelector = {
     baseScore: {$gte: 0},
     draft: {$ne: true},
-    status: { $in: [1, 2] }
+    status: { $in: [1, 2] },
+    authorIsUnreviewed: false,
   }
 
   const fields = {


### PR DESCRIPTION
`exportPostDetails` is the function written to get the Forum Prize candidates every month, which may be useful elsewhere. This month it had some spam, because it was including posts by unreviewed authors. I believe it is generally more useful when exporting a list of posts to have the authors be reviewed, so I think this should be the default.