### PR TITLE
Fix mobile rendering of sequences grid items

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGrid.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.jsx
@@ -15,6 +15,10 @@ export const styles = theme => ({
   gridContent: {
     marginLeft: -15,
     marginRight: -24,
+    [theme.breakpoints.down('md')]: {
+      marginLeft: 0,
+      marginRight: 0
+    },
     paddingRight: 6,
     [legacyBreakpoints.maxTiny]: {
       paddingLeft: 0,

--- a/packages/lesswrong/components/sequences/SequencesGridItem.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.jsx
@@ -81,11 +81,9 @@ const styles = theme => ({
     width: "100%",
     height: 95,
     backgroundColor: "rgba(0,0,0,0.05)",
+    display: 'block',
     [legacyBreakpoints.maxTiny]: {
       width: "100%",
-    },
-    [theme.breakpoints.down('sm')]: {
-      height: "auto",
     },
     "& img": {
       [legacyBreakpoints.maxSmall]: {


### PR DESCRIPTION
This fixes some small issues with the mobile rendering of sequences grid items. In particular an overflow that can happen at smaller device sizes. 