### PR TITLE
Script for one-off spam ban, include bio hackers in review

### DIFF
--- a/packages/lesswrong/lib/collections/users/views.js
+++ b/packages/lesswrong/lib/collections/users/views.js
@@ -90,3 +90,7 @@ Users.addView("sunshineNewUsers", function () {
     },
   }
 })
+ensureIndex(Users, {voteCount: 1, reviewedByUserId: 1, banned: 1})
+ensureIndex(Users, {commentCount: 1, reviewedByUserId: 1, banned: 1})
+ensureIndex(Users, {postCount: 1, signUpReCaptchaRating: 1, reviewedByUserId: 1, banned: 1})
+ensureIndex(Users, {bio: 1, reviewedByUserId: 1, banned: 1})

--- a/packages/lesswrong/lib/collections/users/views.js
+++ b/packages/lesswrong/lib/collections/users/views.js
@@ -83,6 +83,7 @@ Users.addView("sunshineNewUsers", function () {
         { voteCount: {$gt: 12}},
         { commentCount: {$gt: 0}},
         { postCount: {$gt: 0}, ...reCaptchaSelector},
+        { bio: {$exists: true}},
       ],
       reviewedByUserId: {$exists: false},
       banned: {$exists: false},

--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -31,6 +31,8 @@ import './server/scripts/localgroupsEditCallbacks.js';
 import './server/scripts/nullifyVotes.js';
 import './server/scripts/fixSSCDrafts.js';
 import './server/scripts/invites.js';
+
+import './server/scripts/oneOffBanSpammers'
 import './server/scripts/exportPostDetails.js';
 import './server/scripts/legacyKarma_aggregate2.js';
 import './server/scripts/removeObsoleteIndexes.js';

--- a/packages/lesswrong/server/scripts/oneOffBanSpammers.js
+++ b/packages/lesswrong/server/scripts/oneOffBanSpammers.js
@@ -1,0 +1,47 @@
+import { wrapVulcanAsyncScript } from './utils'
+import { runCallbacksAsync } from 'meteor/vulcan:core';
+import Users from 'meteor/vulcan:users'
+import moment from 'moment'
+
+const banUser = async (user) => {
+  await Users.rawCollection().bulkWrite([{
+    updateOne: {
+      filter: {_id: user._id},
+      update: {
+        $set: {
+          bio: '',
+          htmlBio: '',
+          banned: moment().add(12, 'months').toDate(),
+          deleteContent: true,
+        },
+      },
+    }
+  }])
+  runCallbacksAsync('users.ban.async', user);
+  runCallbacksAsync('users.deleteContent.async', user);
+}
+
+Vulcan.oneOffBanSpammers = wrapVulcanAsyncScript(
+  'oneOffBanSpammers',
+  async () => {
+    const spammers = Users.find({
+      // signUpReCaptchaRating: {$exists: false},
+      reviewedByUserId: {$exists: false},
+      createdAt: {
+        $gte: moment.utc("2019-05-21").toDate(),
+        $lt: moment.utc("2019-06-13").toDate(),
+      },
+      banned: {$exists: false},
+      $or: [
+        {bio: {$exists: true}},
+        {commentCount: {$gt: 0}},
+        {postCount: {$gt: 0}},
+        {signUpReCaptchaRating: {$lt: 0.4}},
+      ]
+    })
+    console.log('Spammer count', spammers.count())
+    for (const spammer of spammers) {
+      await banUser(spammer)
+    }
+  }
+)

--- a/packages/lesswrong/server/scripts/oneOffBanSpammers.js
+++ b/packages/lesswrong/server/scripts/oneOffBanSpammers.js
@@ -1,3 +1,4 @@
+/* global Vulcan */
 import { wrapVulcanAsyncScript } from './utils'
 import { runCallbacksAsync } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users'
@@ -39,6 +40,7 @@ Vulcan.oneOffBanSpammers = wrapVulcanAsyncScript(
         {signUpReCaptchaRating: {$lt: 0.4}},
       ]
     })
+    // eslint-disable-next-line no-console
     console.log('Spammer count', spammers.count())
     for (const spammer of spammers) {
       await banUser(spammer)


### PR DESCRIPTION
Add script to ban users who meet some selection criteria, which I imagine I might be a desire someone might have in the future.

More likely to be used change: if user has a bio, include them in review. Spammers seem to be using their bio to advertise spam, and currently it won't get reviewed.