### PR TITLE
related questions in draft, fix draft-bug in list

### DIFF
--- a/packages/lesswrong/components/questions/RelatedQuestionsList.jsx
+++ b/packages/lesswrong/components/questions/RelatedQuestionsList.jsx
@@ -59,7 +59,7 @@ const RelatedQuestionsList = ({ post, currentUser, classes }) => {
 
   
   const sourcePostRelations = _.filter(post.sourcePostRelations, rel => !!rel.sourcePost)
-  const targetPostRelations = _.filter(post.targetPostRelations, rel => rel.sourcePostId === post._id)
+  const targetPostRelations = _.filter(post.targetPostRelations, rel => (rel.sourcePostId === post._id && !!rel.targetPost))
 
   const totalRelatedQuestionCount = sourcePostRelations.length + targetPostRelations.length
   

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -360,6 +360,7 @@ Posts.addView("drafts", terms => {
       unlisted: null,
       groupId: null, // TODO: fix vulcan so it doesn't do deep merges on viewFieldAllowAny
       authorIsUnreviewed: viewFieldAllowAny,
+      hiddenRelatedQuestion: viewFieldAllowAny,
     },
     options: {
       sort: {createdAt: -1}


### PR DESCRIPTION
Related questions now appear in your draft section on userProfile

Drafts were also rendering weird on a posts's related questions list. Our query doesn't filter out drafts. It probably should, but also seemed like the related questions list shouldn't bother trying to render posts that you aren't allowed to see for whatever reason