### PR TITLE
Sequences grid hover

### DIFF
--- a/packages/lesswrong/components/common/LinkCard.jsx
+++ b/packages/lesswrong/components/common/LinkCard.jsx
@@ -3,6 +3,7 @@ import { registerComponent } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper.js';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = theme => ({
   root: {
@@ -39,13 +40,23 @@ const styles = theme => ({
 // described in https://www.sarasoueidan.com/blog/nested-links/, we make the
 // card background and card contents siblings rather than nested, then use
 // z-index to control which is clickable.
-const LinkCard = ({children, to, className, classes}) => {
-  return <div className={classNames(className, classes.root)}>
-    <div className={classes.background}>
-      <Link to={to}/>
+const LinkCard = ({children, to, tooltip, className, classes}) => {
+  const card = (
+    <div className={classNames(className, classes.root)}>
+      <div className={classes.background}>
+        <Link to={to}/>
+      </div>
+      {children}
     </div>
-    {children}
-  </div>;
+  );
+  
+  if (tooltip) {
+    return <Tooltip title={tooltip} placement="bottom-start">
+      {card}
+    </Tooltip>;
+  } else {
+    return card;
+  }
 }
 
 

--- a/packages/lesswrong/components/sequences/SequenceTooltip.jsx
+++ b/packages/lesswrong/components/sequences/SequenceTooltip.jsx
@@ -16,9 +16,10 @@ const SequenceTooltip = ({ sequence, classes }) => {
   const truncatedDescription = truncate(sequence.contents && sequence.contents.htmlHighlight, SEQUENCE_DESCRIPTION_TRUNCATION_LENGTH);
   
   return <div>
-    <div>{sequence.title}</div>
-    <div>by {sequence.user.displayName}</div>
-    <div>Created <CalendarDate date={sequence.createdAt}/></div>
+    { /*<div>Created <CalendarDate date={sequence.createdAt}/></div>*/ }
+    { /* TODO: Show a date here. We can't use sequence.createdAt because it's often
+      very mismatched with the dates of the posts; ideally we'd say something like
+      "15 posts from Dec 2010-Feb 2011". */ }
     
     <ContentItemBody
       className={classes.sequenceDescriptionHighlight}

--- a/packages/lesswrong/components/sequences/SequenceTooltip.jsx
+++ b/packages/lesswrong/components/sequences/SequenceTooltip.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Components, registerComponent, } from 'meteor/vulcan:core';
+import { withStyles } from '@material-ui/core/styles';
+import { truncate } from '../../lib/editor/ellipsize';
+
+const SEQUENCE_DESCRIPTION_TRUNCATION_LENGTH = 750;
+
+const styles = theme => ({
+  sequenceDescriptionHighlight: {
+  },
+});
+
+const SequenceTooltip = ({ sequence, classes }) => {
+  const { CalendarDate, ContentItemBody } = Components;
+  
+  const truncatedDescription = truncate(sequence.contents && sequence.contents.htmlHighlight, SEQUENCE_DESCRIPTION_TRUNCATION_LENGTH);
+  
+  return <div>
+    <div>{sequence.title}</div>
+    <div>by {sequence.user.displayName}</div>
+    <div>Created <CalendarDate date={sequence.createdAt}/></div>
+    
+    <ContentItemBody
+      className={classes.sequenceDescriptionHighlight}
+      dangerouslySetInnerHTML={{__html: truncatedDescription}}/>
+  </div>;
+}
+
+registerComponent('SequenceTooltip', SequenceTooltip, withStyles(styles, { name: "SequenceTooltip" }));

--- a/packages/lesswrong/components/sequences/SequenceTooltip.jsx
+++ b/packages/lesswrong/components/sequences/SequenceTooltip.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 });
 
 const SequenceTooltip = ({ sequence, classes }) => {
-  const { CalendarDate, ContentItemBody } = Components;
+  const { ContentItemBody } = Components;
   
   const truncatedDescription = truncate(sequence.contents && sequence.contents.htmlHighlight, SEQUENCE_DESCRIPTION_TRUNCATION_LENGTH);
   

--- a/packages/lesswrong/components/sequences/SequencesGridItem.jsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.jsx
@@ -108,10 +108,10 @@ class SequencesGridItem extends PureComponent {
 
   render() {
     const { sequence, showAuthor=false, classes } = this.props
-    const { LinkCard } = Components;
+    const { LinkCard, SequenceTooltip } = Components;
     const url = this.getSequenceUrl()
 
-    return <LinkCard className={classes.root} to={url}>
+    return <LinkCard className={classes.root} to={url} tooltip={<SequenceTooltip sequence={sequence}/>}>
       <div className={classNames(classes.top, {[classes.topWithAuthor]: showAuthor})} style={{borderTopColor: sequence.color}}>
         <Link key={sequence._id} to={url}>
           <Typography variant='title' className={classes.title}>
@@ -133,7 +133,7 @@ class SequencesGridItem extends PureComponent {
           />
         </NoSSR>
       </div>
-    </LinkCard>;
+    </LinkCard>
   }
 }
 

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -287,6 +287,7 @@ import '../components/sequences/SequencesNewForm.jsx';
 import '../components/sequences/SequencesHome.jsx';
 import '../components/sequences/SequencesGrid.jsx';
 import '../components/sequences/SequencesGridWrapper.jsx';
+import '../components/sequences/SequenceTooltip.jsx';
 import '../components/sequences/SequencesNavigationLink.jsx';
 import '../components/sequences/SequencesNewButton.jsx';
 import '../components/sequences/BottomNavigation.jsx';


### PR DESCRIPTION
Adds a hover-over tooltip to SequencesGridItem, containing a truncated version of the sequence description. Fixes #2080.