### PR TITLE
Archive to All Posts

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu.jsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu.jsx
@@ -269,7 +269,7 @@ const TabNavigationMenu = ({
               { allPostsIcon }
             </span>
             <span className={classes.navText}>
-              Archive
+              All Posts
             </span>
           </Link>
         </Tooltip>


### PR DESCRIPTION
Changes the name because Archive sounds old and fuddy duddy and too much like "Library" and not at all like "keep up with daily stuff"