### PR TITLE
Shortform flags

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -67,7 +67,7 @@ class PostActions extends Component {
   }
   
   handleMakeShortform = () => {
-    const { post, updateUser, currentUser } = this.props;
+    const { post, updateUser } = this.props;
     updateUser({
       selector: { _id: post.userId },
       data: {

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -65,6 +65,16 @@ class PostActions extends Component {
       },
     })
   }
+  
+  handleMakeShortform = () => {
+    const { post, updateUser, currentUser } = this.props;
+    updateUser({
+      selector: { _id: currentUser._id },
+      data: {
+        shortformFeedId: post._id
+      },
+    });
+  }
 
   handleMoveToAlignmentForum = () => {
     const { post, setAlignmentPostMutation } = this.props
@@ -120,6 +130,14 @@ class PostActions extends Component {
                  </Container>
                </div>
             }
+            
+            { !post.shortform &&
+               <div onClick={this.handleMakeShortform}>
+                 <Container>
+                   Set as user's Shortform Post
+                 </Container>
+               </div>
+            }
           </span>
         }
         <SuggestAlignment post={post} Container={Container}/>
@@ -143,19 +161,19 @@ class PostActions extends Component {
     )
   }
 }
-const withUpdateOptions = {
-  collection: Posts,
-  fragmentName: 'PostsList',
-};
-
-const setAlignmentOptions = {
-  fragmentName: "PostsList"
-}
-
-
 
 registerComponent('PostActions', PostActions,
   withStyles(styles, {name: "PostActions"}),
   withUser,
-  [withUpdate, withUpdateOptions],
-  [withSetAlignmentPost, setAlignmentOptions])
+  [withUpdate, {
+    collection: Posts,
+    fragmentName: 'PostsList',
+  }],
+  [withUpdate, {
+    collection: Users,
+    fragmentName: 'UsersCurrent'
+  }],
+  [withSetAlignmentPost, {
+    fragmentName: "PostsList"
+  }]
+)

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -69,7 +69,7 @@ class PostActions extends Component {
   handleMakeShortform = () => {
     const { post, updateUser, currentUser } = this.props;
     updateUser({
-      selector: { _id: currentUser._id },
+      selector: { _id: post.userId },
       data: {
         shortformFeedId: post._id
       },

--- a/packages/lesswrong/lib/collections/comments/schema.js
+++ b/packages/lesswrong/lib/collections/comments/schema.js
@@ -1,5 +1,5 @@
 import Users from 'meteor/vulcan:users';
-import { foreignKeyField, resolverOnlyField } from '../../../lib/modules/utils/schemaUtils';
+import { foreignKeyField, resolverOnlyField, denormalizedField } from '../../../lib/modules/utils/schemaUtils';
 import { Posts } from '../posts/collection'
 import { schemaDefaultValue } from '../../collectionUtils';
 
@@ -181,6 +181,24 @@ const schema = {
     canCreate: ['members'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     ...schemaDefaultValue(false),
+  },
+  
+  shortform: {
+    type: Boolean,
+    optional: true,
+    hidden: true,
+    canRead: ['guests'],
+    insertableBy: ['admins'],
+    editableBy: ['admins'],
+    
+    ...denormalizedField({
+      needsUpdate: data => ('postId' in data),
+      getValue: async (comment) => {
+        const post = await Posts.findOne({_id: comment.postId});
+        if (!post) return false;
+        return !!post.shortform;
+      }
+    }),
   },
 
   // The semver-style version of the post that this comment was made against

--- a/packages/lesswrong/lib/collections/comments/views.js
+++ b/packages/lesswrong/lib/collections/comments/views.js
@@ -257,3 +257,6 @@ ensureIndex(Comments, {topLevelCommentId:1});
 
 // Used in findCommentByLegacyAFId
 ensureIndex(Comments, {agentFoundationsId:1});
+
+// Will be used for experimental shortform display on AllPosts page
+ensureIndex(Comments, {shortform:1, postedAt:1, baseScore:1});

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -146,8 +146,8 @@ function UpdatePostShortform (newPost, oldPost) {
       { postId: newPost._id },
       { $set: {
         shortform: shortform
-      },
-      { multi: true }}
+      } },
+      { multi: true }
     );
   }
   return newPost;

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -1,5 +1,6 @@
 import { addCallback, runCallbacks, runCallbacksAsync, newMutation } from 'meteor/vulcan:core';
 import { Posts } from './collection';
+import { Comments } from '../comments/collection';
 import Users from 'meteor/vulcan:users';
 import { performVoteServer } from '../../../server/voteServer.js';
 import Localgroups from '../localgroups/collection.js';
@@ -136,5 +137,18 @@ function PostsNewPostRelation (post) {
   }
   return post
 }
-
 addCallback("posts.new.after", PostsNewPostRelation);
+
+function UpdatePostShortform (newPost, oldPost) {
+  if (!!newPost.shortform !== !!oldPost.shortform) {
+    const shortform = !!newPost.shortform;
+    Comments.update(
+      { postId: newPost._id },
+      { $set: {
+        shortform: shortform
+      } }
+    );
+  }
+  return newPost;
+}
+addCallback("posts.edit.async", UpdatePostShortform );

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -146,7 +146,8 @@ function UpdatePostShortform (newPost, oldPost) {
       { postId: newPost._id },
       { $set: {
         shortform: shortform
-      } }
+      },
+      { multi: true }}
     );
   }
   return newPost;

--- a/packages/lesswrong/lib/collections/posts/fragments.js
+++ b/packages/lesswrong/lib/collections/posts/fragments.js
@@ -75,6 +75,7 @@ registerFragment(`
     hideAuthor
     moderationStyle
     submitToFrontpage
+    shortform
   }
 `);
 

--- a/packages/lesswrong/lib/collections/posts/schema.js
+++ b/packages/lesswrong/lib/collections/posts/schema.js
@@ -447,7 +447,15 @@ const schema = {
   'targetPostRelations.$': {
     type: String,
     optional: true,
-  }
+  },
+  
+  shortform: {
+    type: Boolean,
+    viewableBy: ['guests'],
+    insertableBy: ['admins'],
+    editableBy: ['admins'],
+    ...schemaDefaultValue(false),
+  },
 };
 
 export default schema;

--- a/packages/lesswrong/lib/collections/posts/schema.js
+++ b/packages/lesswrong/lib/collections/posts/schema.js
@@ -449,11 +449,16 @@ const schema = {
     optional: true,
   },
   
+  // A post should have the shortform flag set iff its author's shortformFeedId
+  // field is set to this post's ID.
   shortform: {
     type: Boolean,
+    optional: true,
+    hidden: true,
     viewableBy: ['guests'],
     insertableBy: ['admins'],
     editableBy: ['admins'],
+    denormalized: true,
     ...schemaDefaultValue(false),
   },
 };

--- a/packages/lesswrong/lib/collections/users/callbacks.js
+++ b/packages/lesswrong/lib/collections/users/callbacks.js
@@ -141,13 +141,12 @@ async function subscribeOnSignup (user) {
 addCallback('users.new.async', subscribeOnSignup);
 
 async function handleSetShortformPost (newUser, oldUser) {
-  console.log(`In users.edit.async: shortformFeedId ${oldUser.shortformFeedId} => ${newUser.shortformFeedId}`);
   if (newUser.shortformFeedId !== oldUser.shortformFeedId)
   {
     const post = await Posts.findOne({_id: newUser.shortformFeedId});
     if (!post)
       throw new Error("Invalid post ID for shortform");
-    if (post.userId !== user._id)
+    if (post.userId !== newUser._id)
       throw new Error("Post can only be an author's short-form post if they are the post's author");
     if (post.draft)
       throw new Error("Draft post cannot be a user's short-form post");


### PR DESCRIPTION
Adds a new bit of admin-only UI to PostActions to make a post be the short-form feed for a user. Adds a shortform flag on posts and comments, and callbacks to keep it up to date.

(This will be followed up with UI that makes a shortform page, puts shortform stuff on All Posts, and a front-page comment-box for short-form writing which makes you a shortform post if you don't already have one.)