### PR TITLE
Fix broken `/about` route

### DIFF
--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -95,9 +95,9 @@ switch (getSetting('forumType')) {
   default:
     // Default is Vanilla LW
     addRoute({name: 'home', path: '/', componentName: 'Home2'});
-    addRoute({name:'about',   path:'/about', componentName: 'PostsSingleRoute', _id:"bJ2haLkcGeLtTWaD5"});
-    addRoute({name:'about',   path:'/faq', componentName: 'PostsSingleRoute', _id:"2rWKkWuPrgTMpLRbp"});
-    addRoute({ name: 'Meta', path: '/meta', componentName: 'Meta', title: "Meta"})
+    addRoute({name: 'about', path: '/about', componentName: 'PostsSingleRoute', _id:"bJ2haLkcGeLtTWaD5"});
+    addRoute({name: 'faq', path: '/faq', componentName: 'PostsSingleRoute', _id:"2rWKkWuPrgTMpLRbp"});
+    addRoute({name: 'Meta', path: '/meta', componentName: 'Meta', title: "Meta"})
 }
 
 addRoute({ name: 'home2', path: '/home2', componentName: 'Home2', title: "Home2 Beta" });


### PR DESCRIPTION
In Vulcan, if you create a route with a name that collides with an existing route, this silently replaces removes that route. This is a bug in Vulcan, but we weren't triggering it before. Recently we added a `/faq` route, but it was created using a copy-paste that was incompletely edited, so it had a name conflict with the existing `about` route.