### PR TITLE
Fix error message and hover-color of all-posts-page settings icon

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -15,6 +15,7 @@ const styles = theme => ({
       padding: 0,
     }
   },
+  settingsIcon: {},
   title: {
     cursor: "pointer",
     '&:hover $settingsIcon, &:hover $sortedBy': {


### PR DESCRIPTION
[This commit](https://github.com/LessWrong2/Lesswrong2/commit/cbea1c9bd8d88c3a4eff075b9d79a8d3da431481#diff-cfbff8e7785fd5fe676d53f66d057485) removed the `settingsIcon` class from `AllPostsPage` when it still had references pointed to it, which resulted in console errors on that page and a minor bit of broken styling (its color no longer changed with hover-over). Put the class back to fix that.