### PR TITLE
Refactor around `ShowParentComment`

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -162,7 +162,11 @@ class CommentsItem extends Component {
 
           <div className="comments-item-body">
             <div className="comments-item-meta">
-              <ShowParentComment comment={comment} nestingLevel={nestingLevel} onClick={this.toggleShowParent}/>
+              <ShowParentComment
+                comment={comment} nestingLevel={nestingLevel}
+                active={this.state.showParent}
+                onClick={this.toggleShowParent}
+              />
               { (postPage || this.props.collapsed) && <a className={classes.collapse} onClick={this.props.toggleCollapse}>
                 [<span>{this.props.collapsed ? "+" : "-"}</span>]
               </a>

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -73,14 +73,13 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
           <div className="comments-item">
             <div className="comments-item-body recent-comments-item-body ">
               <div className="comments-item-meta recent-comments-item-meta">
-                { comment.parentCommentId ? (
-                    <Icon
+                { comment.parentCommentId
+                  ? <ShowParentComment
+                      comment={comment} nestingLevel={level}
+                      active={this.state.showParent}
                       onClick={this.toggleShowParent}
-                      className={classNames("material-icons","recent-comments-show-parent",{active:this.state.showParent})}
-                    >
-                      subdirectory_arrow_left
-                    </Icon>
-                  ) : level != 1 && <div className={classes.usernameSpacing}>○</div>
+                    />
+                  : (level != 1) && <div className={classes.usernameSpacing}>○</div>
                 }
                 <span className={classNames(classes.author, {[classes.authorAnswer]:comment.answer})}>
                   {comment.answer && "Answer by "}<Components.UsersName user={comment.user}/>

--- a/packages/lesswrong/components/comments/RecentCommentsItem.jsx
+++ b/packages/lesswrong/components/comments/RecentCommentsItem.jsx
@@ -74,7 +74,7 @@ class RecentCommentsItem extends getRawComponent('CommentsItem') {
             <div className="comments-item-body recent-comments-item-body ">
               <div className="comments-item-meta recent-comments-item-meta">
                 { comment.parentCommentId
-                  ? <ShowParentComment
+                  ? <Components.ShowParentComment
                       comment={comment} nestingLevel={level}
                       active={this.state.showParent}
                       onClick={this.toggleShowParent}

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -35,6 +35,15 @@ const ShowParentComment = ({ comment, classes, nestingLevel, onClick }) => {
     return null;
   }
   
+  // As a weird special case for shortform, a comment tree can be rendered
+  // with the root comment shown, a deep-in-tree comment shown, and the
+  // intermediate parents hidden, ie
+  //     [shortform-comment]
+  //       [hidden]
+  //         [hidden]
+  //           [deep reply]
+  // In that case the deep reply has nestingLevel 2, but unlike a true level-2
+  // comment, its parent is not a top-level comment.
   if (nestingLevel > 2) {
     return null;
   }

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -9,7 +9,11 @@ const styles = theme => ({
     paddingRight: theme.spacing.unit,
     paddingTop: theme.spacing.unit,
     paddingBottom: theme.spacing.unit,
-    cursor: "pointer"
+    cursor: "pointer",
+    color: "rgba(0,0,0,.75)",
+  },
+  active: {
+    color: "rgba(0,0,0, .3)",
   },
   icon: {
     fontSize: 12,
@@ -26,7 +30,7 @@ const styles = theme => ({
   }
 })
 
-const ShowParentComment = ({ comment, classes, nestingLevel, onClick }) => {
+const ShowParentComment = ({ comment, nestingLevel, active, onClick, classes }) => {
 
   if (!comment) return null;
   
@@ -56,7 +60,7 @@ const ShowParentComment = ({ comment, classes, nestingLevel, onClick }) => {
 
   return (
     <Tooltip title="Show previous comment">
-      <span className={classes.root} onClick={onClick}>
+      <span className={classNames(classes.root, {[classes.active]: active})} onClick={onClick}>
         <SubdirectoryArrowLeft className={classes.icon}>
           subdirectory_arrow_left
         </SubdirectoryArrowLeft>

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -2,6 +2,7 @@ import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import SubdirectoryArrowLeft from '@material-ui/icons/SubdirectoryArrowLeft';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = theme => ({
   root: {
@@ -45,11 +46,13 @@ const ShowParentComment = ({ comment, classes, nestingLevel, onClick }) => {
   }
 
   return (
-    <span className={classes.root} onClick={onClick}>
-      <SubdirectoryArrowLeft className={classes.icon}>
-        subdirectory_arrow_left
-      </SubdirectoryArrowLeft>
-    </span>
+    <Tooltip title="Show previous comment">
+      <span className={classes.root} onClick={onClick}>
+        <SubdirectoryArrowLeft className={classes.icon}>
+          subdirectory_arrow_left
+        </SubdirectoryArrowLeft>
+      </span>
+    </Tooltip>
   )
 };
 

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import SubdirectoryArrowLeft from '@material-ui/icons/SubdirectoryArrowLeft';
 import Tooltip from '@material-ui/core/Tooltip';
+import classNames from 'classnames';
 
 const styles = theme => ({
   root: {

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -27,15 +27,20 @@ const styles = theme => ({
 
 const ShowParentComment = ({ comment, classes, nestingLevel, onClick }) => {
 
-  // topLevelComment -> never render 
-
-  if (
-    !comment?.topLevelCommentId || 
-    (
-      (nestingLevel === 2) && (comment?.parentCommentId === comment?.topLevelCommentId)
-    ) ||
-    nestingLevel > 2
-  ) {    
+  if (!comment) return null;
+  
+  if (!comment.topLevelCommentId) {
+    // This is a root comment
+    return null;
+  }
+  
+  if (nestingLevel > 2) {
+    return null;
+  }
+  
+  if (nestingLevel === 2
+    && comment.parentCommentId === comment.topLevelCommentId
+  ) {
     return null
   }
 

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -219,21 +219,6 @@ $lw-green: #588f27;
   margin:0;
   width:100%;
 
-  .recent-comments-show-parent {
-    font-size:12px !important;
-    margin-right:5px;
-    cursor:pointer;
-    transform: rotate(90deg);
-    color:rgba(0,0,0,.75);
-    &.active {
-      color:rgba(0,0,0,.3) !important;
-    }
-
-    @include max-small() {
-      padding:10px;
-    }
-  }
-
   &.loading {
     min-height:80px;
     padding:35px;


### PR DESCRIPTION
Puts back a couple lost features: the tooltip, active styling. Makes `RecentCommentsItem` use it, so it's un-diverged from `CommentsItem`. Untangle and document a very complicated boolean expression.