### PR TITLE
Fill in topLevelCommentId in a callback instead of client-side

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.jsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.jsx
@@ -42,11 +42,10 @@ const CommentsNewForm = ({prefilledProps = {}, post, parentComment, successCallb
   };
 
   if (parentComment) {
-    prefilledProps = Object.assign(prefilledProps, {
+    prefilledProps = {
+      ...prefilledProps,
       parentCommentId: parentComment._id,
-      // if parent comment has a topLevelCommentId use it; if it doesn't then it *is* the top level comment
-      topLevelCommentId: parentComment.topLevelCommentId || parentComment._id
-    });
+    };
   }
 
   const SubmitComponent = withDialog(({submitLabel = "Submit", openDialog}) => {
@@ -130,7 +129,6 @@ CommentsNewForm.propTypes = {
   post: PropTypes.object.isRequired,
   type: PropTypes.string, // "comment" or "reply"
   parentComment: PropTypes.object, // if reply, the comment being replied to
-  topLevelCommentId: PropTypes.string, // if reply
   successCallback: PropTypes.func, // a callback to execute when the submission has been successful
   cancelCallback: PropTypes.func,
   router: PropTypes.object,

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -354,9 +354,13 @@ addCallback('comment.create.before', HandleReplyToAnswer);
 
 async function SetTopLevelCommentId (comment, context)
 {
+  let visited = {};
   let rootComment = comment;
   while (rootComment.parentCommentId) {
     rootComment = await Comments.findOne({_id: rootComment.parentCommentId});
+    if (visited[rootComment._id])
+      throw new Error("Cyclic parent-comment relations detected!");
+    visited[rootComment._id] = true;
   }
   
   if (rootComment && rootComment._id !== comment._id) {

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -352,6 +352,22 @@ function HandleReplyToAnswer (comment, properties)
 }
 addCallback('comment.create.before', HandleReplyToAnswer);
 
+async function SetTopLevelCommentId (comment, context)
+{
+  let rootComment = comment;
+  while (rootComment.parentCommentId) {
+    rootComment = await Comments.findOne({_id: rootComment.parentCommentId});
+  }
+  
+  if (rootComment && rootComment._id !== comment._id) {
+    return {
+      ...comment,
+      topLevelCommentId: rootComment._id
+    };
+  }
+}
+addCallback('comment.create.before', SetTopLevelCommentId);
+
 async function updateTopLevelCommentLastCommentedAt (comment) {
   Comments.update({ _id: comment.topLevelCommentId }, { $set: {lastSubthreadActivity: new Date()}})
   return comment;

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -356,11 +356,11 @@ async function SetTopLevelCommentId (comment, context)
 {
   let visited = {};
   let rootComment = comment;
-  while (rootComment.parentCommentId) {
+  while (rootComment?.parentCommentId) {
     rootComment = await Comments.findOne({_id: rootComment.parentCommentId});
-    if (visited[rootComment._id])
+    if (rootComment && visited[rootComment._id])
       throw new Error("Cyclic parent-comment relations detected!");
-    visited[rootComment._id] = true;
+    visited[rootComment?._id] = true;
   }
   
   if (rootComment && rootComment._id !== comment._id) {

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -352,12 +352,14 @@ function HandleReplyToAnswer (comment, properties)
 }
 addCallback('comment.create.before', HandleReplyToAnswer);
 
-async function SetTopLevelCommentId (comment, context)
+function SetTopLevelCommentId (comment, context)
 {
   let visited = {};
   let rootComment = comment;
   while (rootComment?.parentCommentId) {
-    rootComment = await Comments.findOne({_id: rootComment.parentCommentId});
+    // This relies on Meteor fibers (rather than being async/await) because
+    // Vulcan callbacks aren't async-safe.
+    rootComment = Comments.findOne({_id: rootComment.parentCommentId});
     if (rootComment && visited[rootComment._id])
       throw new Error("Cyclic parent-comment relations detected!");
     visited[rootComment?._id] = true;


### PR DESCRIPTION
This is a bug we inherited from Vulcan's example-forum, which made `topLevelCommentId` a form field instead of filling it in server side.