### PR TITLE
Daily view: within days sort by baseScore, not score

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -251,7 +251,7 @@ Posts.addView("old", terms => ({
 
 Posts.addView("daily", terms => ({
   options: {
-    sort: {score: -1}
+    sort: {baseScore: -1}
   }
 }));
 ensureIndex(Posts,


### PR DESCRIPTION
On the all-posts page, sorting by Daily first groups by day, then sorts by something. Before, it was sorting within days by `score`, which is a sort of time-discounted karma. But this doesn't make sense because age is already accounted for in the grouping, so it winds up just being confusing--older days are sorted by karma, while recent days are sorted sort-of by karma but with glitches.

Change the within-day sort to baseScore, so it's no longer confusing.