### PR TITLE
Fix parent-comments sometimes being truncated and not expandable

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -181,8 +181,7 @@ class CommentsItem extends Component {
               currentUser={currentUser}
               documentId={comment.parentCommentId}
               nestingLevel={nestingLevel - 1}
-              expanded={isParentComment}
-              truncated={!isParentComment}
+              truncated={false}
               key={comment.parentCommentId}
             />
           </div>


### PR DESCRIPTION
As a consequence of eliminating RecentCommentsItem, parent-comments gained the ability to be truncated sometimes. But they *didn't* gain the corresponding ability to click to expand, and, being truncated is not a desirable feature in that context. So, parent-comments are now never truncated.