### PR TITLE
Change order of fields on Edit Account page

### DIFF
--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -632,7 +632,8 @@ addFieldsDict(Users, {
     label: "Group Location",
     control: 'LocationFormComponent',
     blackbox: true,
-    optional: true
+    optional: true,
+    order: 42,
   },
 
   location: {
@@ -767,7 +768,8 @@ addFieldsDict(Users, {
     optional: true,
     canRead: ['guests'],
     canUpdate: [Users.owns, 'sunshineRegiment'],
-    hidden: !['LessWrong', 'AlignmentForum'].includes(getSetting('forumType'))
+    hidden: !['LessWrong', 'AlignmentForum'].includes(getSetting('forumType')),
+    order: 39,
   },
 
   noCollapseCommentsPosts: {


### PR DESCRIPTION
The sort-order of fields is on the Edit Account page is now slightly less ridiculous.