### PR TITLE
Sunshine sidebar users are sorted by createdAt

### DIFF
--- a/packages/lesswrong/lib/collections/users/views.js
+++ b/packages/lesswrong/lib/collections/users/views.js
@@ -92,6 +92,7 @@ Users.addView("sunshineNewUsers", function () {
       sort: {
         commentCount: -1,
         postCount: -1,
+        createdAt: -1,
       }
     }
   }


### PR DESCRIPTION
Sunshine sidebar users used to be sorted by `createdAt`, then it was changed to sort by whether they've commented and/or posted, but this accidentally lost the createdAt tiebreak from the default view. Put that back, so that when the list of unprocessed users is longer than the maximum list size (which it is, because we don't have a snooze-review button), we can see newly created accounts that haven't posted.