### PR TITLE
[hotfix] TimeframeList - store timeframe and before on state to match after

### DIFF
--- a/packages/lesswrong/components/posts/PostsTimeframeList.jsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeList.jsx
@@ -31,6 +31,15 @@ class PostsTimeframeList extends PureComponent {
     this.state = {
       // after goes backwards in time when we load more time blocks
       after: props.after,
+      // See below for reasoning behind inclusion
+      before: props.before,
+      // Must include timeframe in state if we include after. Although timeframe
+      // as stored in state is the same as the timeframe passed down from props
+      // 99.999% of the time...
+      // > Ok, it's setting the after prop at the same time as the timeframe,
+      // but the state is dirty and takes a few milliseconds to catch up,
+      // during which time the PTL has asked for 1200 days worth of posts.
+      timeframe: props.timeframe,
       dim: props.dimWhenLoading,
     };
   }
@@ -41,10 +50,15 @@ class PostsTimeframeList extends PureComponent {
     // previous updates to the `after` state and redim for reloading.
     if (
       prevProps.after !== this.props.after ||
+       // Next two presumeably redundant, but included for completeness
+      prevProps.before !== this.props.before ||
+      prevProps.timeframe !== this.props.timeframe ||
       !_.isEqual(prevProps.postListParameters, this.props.postListParameters)
     ) {
       this.setState({
         after: this.props.after,
+        before: this.props.before,
+        timeframe: this.props.timeframe,
         dim: this.props.dimWhenLoading,
       })
     }
@@ -72,8 +86,8 @@ class PostsTimeframeList extends PureComponent {
   }
 
   render() {
-    const { classes, postListParameters, timeframe, before } = this.props
-    const { after, dim } = this.state
+    const { classes, postListParameters } = this.props
+    const { timeframe, after, before, dim } = this.state
     const { PostsTimeBlock } = Components
 
     const timeBlock = timeframeToTimeBlock[timeframe]


### PR DESCRIPTION
PostsTimeframeList was
> setting the after prop at the same time as the timeframe, but the state is dirty and takes a few milliseconds to catch up, during which time the PTL has asked for 1200 days worth of posts.

Now we store the relevant information on the state so the updates are synchronous.