### PR TITLE
improve Oli's expanding comment experience

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -204,13 +204,16 @@ class CommentsNode extends Component {
   }
 
   isSingleLine = () => {
-    const { forceSingleLine } = this.props
+    const { forceSingleLine, postPage } = this.props
     const { singleLine } = this.state
     if (!singleLine) return false;
     if (forceSingleLine)
       return true;
+    
+    // highlighted new comments on post page should always be expanded (and it needs to live here instead of "beginSingleLine" since the highlight status can change after the fact)
+    const postPageAndNew = this.isNewComment() && postPage 
 
-    return this.isTruncated() && !this.isNewComment();
+    return this.isTruncated() && !postPageAndNew
   }
 
   render() {


### PR DESCRIPTION
I'd recently changed SingleLineComments so that they always were expanded if they were unread. This resulted in sad experiences for Oli when he'd click on one of them and then all the others would suddenly collapse.

Most of the reason I made the change was to improve the reading experience on the Post Page. At some point we should do a more extensive refactor of how SingleLineComments and truncation work, and meanwhile this was the simplest change.