### PR TITLE
Prevent duplicate queries after SSR

### DIFF
--- a/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
+++ b/packages/vulcan-lib/lib/client/apollo-client/apolloClient.js
@@ -15,6 +15,7 @@ export const createApolloClient = () => {
   const newClient = new ApolloClient({
     link: ApolloLink.from([stateLink, ...staticLinks]),
     cache,
+    ssrForceFetchDelay: 500,
   });
   // register the client
   apolloClient = newClient;


### PR DESCRIPTION
When you load the front page (or any page, really), the response you get from the server includes an initial state for the Apollo cache, which is sufficient to rerender the page without any further involvement from the server. However, Apollo would re-fetch the results anyways, performing a duplicate query and doubling the server-side cost of most things. We couldn't fix this in Apollo 1, but in Apollo 2, we can, with the `ssrForceFetchDelay` option.

This changes the behavior of the `network-only` and `cache-and-network` fetch modes so that, if a component uses them during the first 500ms since Apollo initialized, it will skip the network request and use the cache.

(My very-noisy measurement is that this reduces client-side Javascript front page execution time by 8%, server-side by much more. This was one of the prerequisites for putting Recent Discussion and post comments into SSR.)