### PR TITLE
Save timezone in a cookie

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -62,13 +62,19 @@ const styles = theme => ({
 })
 
 class Layout extends PureComponent {
-  state = {
-    timezone: null,
-    toc: null,
-    postsRead: {}
-  };
-
-  searchResultsAreaRef = React.createRef();
+  constructor (props) {
+    super(props);
+    const { cookies } = this.props;
+    const savedTimezone = cookies?.get('timezone');
+    
+    this.state = {
+      timezone: savedTimezone,
+      toc: null,
+      postsRead: {}
+    };
+  
+    this.searchResultsAreaRef = React.createRef();
+  }
 
   setToC = (document, sectionData) => {
     if (document) {
@@ -118,8 +124,10 @@ class Layout extends PureComponent {
   }
 
   componentDidMount() {
+    const { cookies } = this.props;
     const newTimezone = moment.tz.guess();
     if(this.state.timezone !== newTimezone) {
+      cookies.set('timezone', newTimezone);
       this.setState({
         timezone: newTimezone
       });


### PR DESCRIPTION
Saves the time zone in a cookie. This prevents post-load changes on the allPosts page, and also saves the compute cost of some rerendering (about 100ms on the front page, development mode).