### PR TITLE
Update packages list to reflect removed vulcan:routing

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -10,7 +10,6 @@
 
 vulcan:core                       # core components and wrappers
 vulcan:forms                      # auto-generated forms
-vulcan:routing                    # routing and server-side rendering
 vulcan:users                      # user management and permissions
 
 ############ Features Packages ############

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -93,13 +93,11 @@ vulcan:accounts@1.13.0
 vulcan:admin@1.13.0
 vulcan:core@1.13.0
 vulcan:debug@1.13.0
-vulcan:email@1.13.0
 vulcan:events@1.13.0
 vulcan:forms@1.13.0
 vulcan:i18n@1.13.0
 vulcan:i18n-en-us@1.13.0
 vulcan:lib@1.13.0
-vulcan:routing@1.13.0
 vulcan:ui-bootstrap@1.13.0
 vulcan:users@1.13.0
 webapp@1.7.3-rc181.1


### PR DESCRIPTION
A previous PR removed vulcan:routing but left it in .meteor/packages, which, depending on your environment, may result in picking up and trying to use an outdated version from the path, and crashing on startup.