### PR TITLE
Make Post title and username break

### DIFF
--- a/packages/lesswrong/components/editor/EditTitle.jsx
+++ b/packages/lesswrong/components/editor/EditTitle.jsx
@@ -13,7 +13,6 @@ const styles = theme => ({
     width: "100%",
     resize: "none",
     textAlign: "left",
-    height: 100,
     marginTop: 0,
     borderBottom: "solid 1px rgba(0,0,0,.2)",
     '&:focused': {
@@ -48,6 +47,7 @@ class EditTitle extends Component {
           [path]: event.target.value
         })
       }}
+      multiline
     />
   }
 }

--- a/packages/lesswrong/components/users/UsersMenu.jsx
+++ b/packages/lesswrong/components/users/UsersMenu.jsx
@@ -17,6 +17,7 @@ import withDialog from '../common/withDialog'
 const styles = theme => ({
   root: {
     marginTop: 5,
+    wordBreak: 'break-all'
   },
   userButtonContents: {
     textTransform: 'none',


### PR DESCRIPTION
This improves rendering on small devices for users with big usernames by having their username line-break, and also makes the post-title break again, which stopped for someone reason at some point in the last few weeks