### PR TITLE
Fix Vulcan callback handling

### DIFF
--- a/packages/vulcan-lib/lib/modules/callbacks.js
+++ b/packages/vulcan-lib/lib/modules/callbacks.js
@@ -189,7 +189,7 @@ export const runCallbacksAsync = function () {
   } else {
     // OpenCRUD backwards compatibility
     // the first argument is the name of the hook or an array of functions
-    hook = arguments[0];
+    hook = formatHookName(arguments[0]);
     // successive arguments are passed to each iteration
     args = Array.prototype.slice.call(arguments).slice(1);
   }

--- a/packages/vulcan-lib/lib/server/mutators.js
+++ b/packages/vulcan-lib/lib/server/mutators.js
@@ -329,7 +329,7 @@ export const updateMutator = async ({
       // eslint-disable-next-line no-await-in-loop
       autoValue = await schema[fieldName].onEdit(
         dataToModifier(clone(data)),
-        document,
+        oldDocument,
         currentUser,
         document
       );
@@ -355,7 +355,7 @@ export const updateMutator = async ({
     await runCallbacks(
       `${collectionName.toLowerCase()}.edit.before`,
       dataToModifier(data),
-      document,
+      oldDocument,
       currentUser,
       document
     )
@@ -364,7 +364,7 @@ export const updateMutator = async ({
     await runCallbacks(
       `${collectionName.toLowerCase()}.edit.sync`,
       dataToModifier(data),
-      document,
+      oldDocument,
       currentUser,
       document
     )


### PR DESCRIPTION
Fixes two bugs in Vulcan's callback handling that were preventing some callbacks from being run properly: 

* Passing in the newDocument instead of the old document for sync callbacks
* Not formatting the async-hooknames correctly, such that mixed-case async hooks would not properly run