### PR TITLE
Fix shortform page width on mobile

### DIFF
--- a/packages/lesswrong/components/shortform/ShortformPage.jsx
+++ b/packages/lesswrong/components/shortform/ShortformPage.jsx
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
   column: {
-    width:680,
+    maxWidth:680,
     margin:"auto"
   }
 })


### PR DESCRIPTION
Bug introduced in https://github.com/LessWrong2/Lesswrong2/pull/2228/files - tried to make the page narrower, but made it fixed-width in a way that made it wider than the screen on mobile.