### PR TITLE
Increase body parser memory limit

### DIFF
--- a/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
+++ b/packages/vulcan-lib/lib/server/apollo-server/apollo_server.js
@@ -52,7 +52,7 @@ export const setupGraphQLMiddlewares = (apolloServer, config, apolloApplyMiddlew
   // parse request (order matters)
   WebApp.connectHandlers.use(
     config.path,
-    bodyParser.json({ limit: getSetting('apolloServer.jsonParserOptions.limit') })
+    bodyParser.json({ limit: '50mb' })
   );
   WebApp.connectHandlers.use(config.path, bodyParser.text({ type: 'application/graphql' }));
 


### PR DESCRIPTION
I don't think we should have this in a setting, and the setting was also not registered. 

This fixes editing of some very large posts. 