### PR TITLE
Fix double header on AF

### DIFF
--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.jsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.jsx
@@ -45,7 +45,6 @@ const AlignmentForumHome = ({currentUser, classes}) => {
         <PostsList2 terms={recentPostsTerms} />
       </SingleColumnSection>
       <SingleColumnSection>
-        <SectionTitle title="Recent Discussion"/>
         <RecentDiscussionThreadsList
           terms={{view: 'afRecentDiscussionThreadsList', limit:6}}
           maxAgeHours={24*7}


### PR DESCRIPTION
Alignment Forum has two copies of the Recent Discussion section title. Introduced by an incorrect refactor in https://github.com/LessWrong2/Lesswrong2/commit/7fa2d41b968459279d77589b37765ad39f120a89#diff-e3f6859f8e2781d48964be2176e5f96b .