### PR TITLE
Component splitting fixes

### DIFF
--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -164,7 +164,7 @@ importComponent("PostsItemDate", () => require('../components/posts/PostsItemDat
 
 importComponent("UserPageTitle", () => require('../components/titles/UserPageTitle.jsx'));
 importComponent("SequencesPageTitle", () => require('../components/titles/SequencesPageTitle.jsx'));
-importComponent("PostsPageTitle", () => require('../components/titles/PostsPageTitle.jsx'));
+importComponent("PostsPageHeaderTitle", () => require('../components/titles/PostsPageTitle.jsx'));
 
 importComponent("ShortformPage", () => require('../components/shortform/ShortformPage.jsx'));
 importComponent("ShortformThreadList", () => require('../components/shortform/ShortformThreadList.jsx'));

--- a/packages/vulcan-lib/lib/modules/components.js
+++ b/packages/vulcan-lib/lib/modules/components.js
@@ -277,5 +277,5 @@ export const mergeWithComponents = myComponents => {
     }
   }
   
-  return new Proxy({}, componentsProxyHandler);
+  return new Proxy({}, mergedComponentsProxyHandler );
 }


### PR DESCRIPTION
Overlaps https://github.com/LessWrong2/Lesswrong2/pull/2317 but also handles the comment box (which was tricker).