### PR TITLE
always show shortform icon

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.jsx
@@ -19,9 +19,12 @@ const styles = theme => ({
   }
 });
 
-const CommentShortformIcon = ({comment, post, classes}) => {
+const CommentShortformIcon = ({comment, post, classes, simple}) => {
   // Top level shortform posts should show this icon/button, both to make shortform posts a bit more visually distinct, and to make it easier to grab permalinks for shortform posts.
   if (!comment.shortform || comment.topLevelCommentId) return null
+
+  if (simple) return <NotesIcon className={classes.icon} />
+
   return (
     <Tooltip title="Shortform Permalink">
       <Link to={Comments.getPageUrlFromIds({postId:post._id, postSlug:post.slug, commentId: comment._id})}>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.jsx
@@ -19,8 +19,9 @@ const styles = theme => ({
   }
 });
 
-const CommentShortformIcon = ({comment, post, postPage, classes}) => {
-  if (!comment.shortform || comment.topLevelCommentId || postPage) return null
+const CommentShortformIcon = ({comment, post, classes}) => {
+  // Top level shortform posts should show this icon/button, both to make shortform posts a bit more visually distinct, and to make it easier to grab permalinks for shortform posts.
+  if (!comment.shortform || comment.topLevelCommentId) return null
   return (
     <Tooltip title="Shortform Permalink">
       <Link to={Comments.getPageUrlFromIds({postId:post._id, postSlug:post.slug, commentId: comment._id})}>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -192,7 +192,7 @@ class CommentsItem extends Component {
             { !parentCommentId && !comment.parentCommentId && isParentComment &&
               <div className={classes.usernameSpacing}>○</div>
             }
-            <CommentShortformIcon comment={comment} post={post} postPage={postPage}/>
+            <CommentShortformIcon comment={comment} post={post} />
             { parentCommentId!=comment.parentCommentId &&
               <ShowParentComment
                 comment={comment} nestingLevel={nestingLevel}

--- a/packages/lesswrong/components/comments/SingleLineComment.jsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.jsx
@@ -109,13 +109,15 @@ const SingleLineComment = ({comment, classes, nestingLevel, hover, parentComment
   if (!comment) return null
   const { baseScore } = comment
   const { plaintextMainText } = comment.contents
-  const { CommentBody, ShowParentComment, CommentUserName } = Components
+  const { CommentBody, ShowParentComment, CommentUserName, CommentShortformIcon } = Components
 
   const displayHoverOver = hover && (comment.baseScore > -5) && !isMobile()
 
   return (
     <div className={classes.root}>
       <div className={classNames(classes.commentInfo, {[classes.isAnswer]: comment.answer, [classes.odd]:((nestingLevel%2) !== 0)})}>
+        <CommentShortformIcon comment={comment} simple={true} />
+
         { parentCommentId!=comment.parentCommentId &&
           <ShowParentComment comment={comment} nestingLevel={nestingLevel} />
         }


### PR DESCRIPTION
I think it's important for the shortform Icon to always appear (even on singleLine comments or the "shortform post"), so that users can more easily learn what it means.

I notice a potential hackiness-sense here, where this (as well as a previous edit I made to Components.UsersNameDisplay) are moving towards a pattern of "the 'simple' prop means 'remove tooltips and links and stuff'"

The main purpose of this is so that you can easily re-use stylings of components on SingleLineComment. 

It feels a bit hacky partly because the name doesn't actually tell you what it's for, and partly because if we start using this pattern all over the place it might get harder to change. It's only the second instance of it so far so maybe we can wait for third-time-to-refactor, but seemed like it warranted some attention.

