### PR TITLE
Fix import of intl-locales-supported and update it

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "import": "0.0.6",
     "intercom-client": "^2.10.2",
     "intl": "^1.2.4",
-    "intl-locales-supported": "^1.0.0",
+    "intl-locales-supported": "1.4.5",
     "jsdom": "^13.1.0",
     "juice": "^1.11.0",
     "logrocket": "^1.0.0",

--- a/packages/vulcan-lib/lib/modules/intl_polyfill.js
+++ b/packages/vulcan-lib/lib/modules/intl_polyfill.js
@@ -5,8 +5,7 @@ intl polyfill. See https://github.com/andyearnshaw/Intl.js/
 */
 
 import { getSetting } from './settings.js';
-
-var areIntlLocalesSupported = require('intl-locales-supported');
+import areIntlLocalesSupported from 'intl-locales-supported';
 
 var localesMyAppSupports = [
   getSetting('locale', 'en')

--- a/packages/vulcan-lib/lib/server/intl_polyfill.js
+++ b/packages/vulcan-lib/lib/server/intl_polyfill.js
@@ -5,10 +5,10 @@ intl polyfill. See https://github.com/andyearnshaw/Intl.js/
 */
 
 import { getSetting, registerSetting } from '../modules/settings.js';
+import areIntlLocalesSupported from 'intl-locales-supported';
 
 registerSetting('locale', 'en');
 
-var areIntlLocalesSupported = require('intl-locales-supported');
 
 var localesMyAppSupports = [
   getSetting('locale', 'en')


### PR DESCRIPTION
Fixes a crash-on-start which was a byproduct of `intl-locales-supported` moving to Typescript, and accidentally changing their API in a minor version, combined with Vulcan code importing it in a nonstandard way. Vulcan imports with `require('intl-locales-supported')` and expects to get a function. v1.0 of that package did a `module.exports = areIntlLocalesSupported`. v1.4.5 did something that compiles to `export default function areIntlLocalesSupported...`, which makes the require call return an object with a field named default, instead of a function.

Change the import to modern style, and pin v1.4.5. Requires an `npm install`.