### PR TITLE
OmegaIcon on PostsItemIcons

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemIcons.jsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.jsx
@@ -20,14 +20,19 @@ const styles = theme => ({
     marginRight: 4,
   },
   icon: {
-    fontSize: "1.2rem",
-    color: theme.palette.grey[500],
-    position: "relative",
-    top: 3,
+    // note: the specificity seems necessary to successfully override the OmegaIcon styling.
+    // not sure if this is best way to do this
+    '&&': {
+      fontSize: "1.2rem",
+      color: theme.palette.grey[500],
+      position: "relative",
+      top: 3,
+    }
   },
   alignmentIcon: {
-    fontSize: "1rem",
-    top: 0,
+    '&&':{
+      top: 0,
+    }
   },
 });
 


### PR DESCRIPTION
Note: this is definitely a place where I suspect that the correct solution is to revamp how the OmegaIcon actually works so that it doesn't require weird special cases everywhere. I'm wary of getting sucked into that rabbit hole. If people think it's highish priority I can do that tho.