### PR TITLE
remove incorrect field from AFSuggestPostsItem

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsItem.jsx
@@ -20,7 +20,6 @@ class AFSuggestPostsItem extends Component {
       selector: {_id: post._id},
       data: {
         reviewForAlignmentUserId: currentUser._id,
-        moveToAlignmentUserId: currentUser._id,
         afDate: new Date(),
         af: true,
       }


### PR DESCRIPTION
This partially fixes the Move to Alignment sunshine-sidebar bug. Unfortunately there's a weird _additional_ bug, wherein clicking the button triggers this error:

```
VM2632 modules.js:168846 Error: Invalid query operator '$near' detected
    at err (VM2632 modules.js:139714)
    at assert (VM2632 modules.js:139619)
    at Query._processOperator (VM2632 modules.js:142251)
    at VM2632 modules.js:142239
    at each (VM2632 modules.js:139736)
    at VM2632 modules.js:142238
    at each (VM2632 modules.js:139736)
    at Query._compile (VM2632 modules.js:142226)
    at new Query (VM2632 modules.js:142214)
    at belongsToSet (VM2683 vulcan_lib.js:353)
    at handleUpdateMutation (VM2688 vulcan_core.js:3282)
    at VM2688 vulcan_core.js:3209
    at Array.forEach (<anonymous>)
    at updateEachQueryResultOfType (VM2688 vulcan_core.js:3192)
    at VM2688 vulcan_core.js:3135
    at VM2632 modules.js:107601
    at tryFunctionOrLogError (VM2632 modules.js:100849)
    at VM2632 modules.js:107600
    at InMemoryCache.performTransaction (VM2632 modules.js:146107)
    at DataStore.markMutationResult (VM2632 modules.js:107593)
    at Object.next (VM2632 modules.js:106488)
    at notifySubscription (VM2632 modules.js:102319)
    at onNotify (VM2632 modules.js:102354)
    at SubscriptionObserver.next (VM2632 modules.js:102408)
    at VM2632 modules.js:106284
    at Set.forEach (<anonymous>)
    at Object.next (VM2632 modules.js:106283)
    at notifySubscription (VM2632 modules.js:102319)
    at onNotify (VM2632 modules.js:102354)
    at SubscriptionObserver.next (VM2632 modules.js:102408)
    at Object.next (VM2632 modules.js:144798)
    at notifySubscription (VM2632 modules.js:102319)
    at onNotify (VM2632 modules.js:102354)
    at SubscriptionObserver.next (VM2632 modules.js:102408)
    at VM2632 modules.js:144714
    at Array.forEach (<anonymous>)
    at VM2632 modules.js:144714
    at Array.forEach (<anonymous>)
    at Object.next (VM2632 modules.js:144712)
    at notifySubscription (VM2632 modules.js:102319)
    at onNotify (VM2632 modules.js:102354)
    at SubscriptionObserver.next (VM2632 modules.js:102408)
    at VM2632 modules.js:144350
    at VM2630 meteor.js:1234
```

And while the button works, it won't appear to work until page refresh.

Oli says he knows how to fix this but didn't seem to consider it that urgent.