### PR TITLE
SunshineSidebar Underbelly, PostAction tweaks

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -107,11 +107,28 @@ class PostActions extends Component {
     })
   }
 
+  handleApproveUser = async () => {
+    const { currentUser, post, updateUser } = this.props
+    await updateUser({
+      selector: {_id: post.userId},
+      data: {reviewedByUserId: currentUser._id}
+    })
+  }
+
   render() {
     const { classes, post, currentUser } = this.props
     const { MoveToDraft, SuggestCurated, SuggestAlignment, ReportPostMenuItem, DeleteDraft } = Components
     return (
-      <div className={classes.actions}>
+      <div className={classes.actions}>        
+        { Posts.canEdit(currentUser,post) && <Link to={{pathname:'/editPost', search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`}}>
+          <MenuItem>
+            <ListItemIcon>
+              <EditIcon />
+            </ListItemIcon>
+            Edit
+          </MenuItem>
+        </Link>}
+        <ReportPostMenuItem post={post}/>
         { post.isRead
           ? <div onClick={this.handleMarkAsUnread}>
               <MenuItem>
@@ -124,17 +141,9 @@ class PostActions extends Component {
               </MenuItem>
             </div>
         }
-        
-        { Posts.canEdit(currentUser,post) && <Link to={{pathname:'/editPost', search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`}}>
-          <MenuItem>
-            <ListItemIcon>
-              <EditIcon />
-            </ListItemIcon>
-            Edit
-          </MenuItem>
-        </Link>}
-        <ReportPostMenuItem post={post}/>
-
+        <SuggestCurated post={post}/>
+        <MoveToDraft post={post}/>
+        <DeleteDraft post={post}/>
         { Users.canDo(currentUser, "posts.edit.all") &&
           <span>
             { !post.meta &&
@@ -166,6 +175,14 @@ class PostActions extends Component {
                  </MenuItem>
                </div>
             }
+
+            { post.authorIsUnreviewed &&
+               <div onClick={this.handleApproveUser}>
+                 <MenuItem>
+                   Approve New User
+                 </MenuItem>
+               </div>
+            }
           </span>
         }
         <SuggestAlignment post={post}/>
@@ -182,9 +199,6 @@ class PostActions extends Component {
             </MenuItem>
           </div>
         }
-        <SuggestCurated post={post}/>
-        <MoveToDraft post={post}/>
-        <DeleteDraft post={post}/>
       </div>
     )
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
@@ -51,8 +51,8 @@ class SunshineNewUsersItem extends Component {
   }
 
   render () {
-    const { user, hover, anchorEl, classes, currentUser } = this.props
-    const showNewUserContent = currentUser && currentUser.sunshineShowNewUserContent
+    const { user, hover, anchorEl, classes, currentUser, allowContentPreview=true } = this.props
+    const showNewUserContent = allowContentPreview && currentUser?.sunshineShowNewUserContent
 
     const { SunshineListItem, SidebarHoverOver, MetaInfo, SidebarActionMenu, SidebarAction, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList } = Components
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 class SunshineNewUsersList extends Component {
   render () {
-    const { results, totalCount } = this.props
+    const { results, totalCount, allowContentPreview } = this.props
     const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem } = Components
     if (results && results.length && Users.canDo(this.props.currentUser, "posts.moderate.all")) {
       return (
@@ -16,7 +16,7 @@ class SunshineNewUsersList extends Component {
           </SunshineListTitle>
           {this.props.results.map(user =>
             <div key={user._id} >
-              <SunshineNewUsersItem user={user}/>
+              <SunshineNewUsersItem user={user} allowContentPreview={allowContentPreview}/>
             </div>
           )}
         </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -27,9 +27,10 @@ const styles = theme => ({
     background: "white",
   },
   toggle: {
-    position:"relative",
+    position:"absolute",
     zIndex: theme.zIndexes.sunshineSidebar,
     float: "right",
+    right: 0,
     margin: 12,
     cursor: "pointer",
     color: theme.palette.grey[400]
@@ -37,16 +38,21 @@ const styles = theme => ({
 })
 
 class SunshineSidebar extends Component {
-  state = { showSidebar: true }
+  state = { showSidebar: true, showUnderbelly: false }
 
   toggleSidebar = () => {
     this.setState({showSidebar: !this.state.showSidebar})
   }
 
+  toggleUnderbelly = () => {
+    // The stuff that was probably spam and hidden away from us so we wouldn't have to look at it, but sometimes turns out to be important
+    this.setState({showUnderbelly: !this.state.showUnderbelly})
+  }
+
   render () {
     const { currentUser, classes } = this.props
-    const { showSidebar } = this.state
-    const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList } = Components
+    const { showSidebar, showUnderbelly } = this.state
+    const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList, SunshineListTitle } = Components
 
     return (
       <div className={classNames(classes.root, {[classes.showSidebar]:showSidebar})}>
@@ -58,18 +64,38 @@ class SunshineSidebar extends Component {
             className={classes.toggle}
             onClick={this.toggleSidebar}
           />}
-        { showSidebar && Users.canDo(currentUser, 'posts.moderate.all') && <div>
-          <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
-          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}}/>
-          <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
-          {!!currentUser.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
-          <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions"}}/>
+        { showSidebar && <div>
+            {Users.canDo(currentUser, 'posts.moderate.all') && <div>
+            <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
+            <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}}/>
+            <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
+            {!!currentUser.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
+            <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions"}}/>
+          </div>}        
+          { currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
+            <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
+            <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
+            <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
+          </div>}
         </div>}
-        { showSidebar && currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
-          <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
-          <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
-          <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
+        { showUnderbelly ? <div>
+            <KeyboardArrowDownIcon
+              className={classes.toggle}
+              onClick={this.toggleUnderbelly}/>
+            <SunshineListTitle>Hide the Underbelly</SunshineListTitle>
+          </div>
+          :
+          <div>
+            <KeyboardArrowLeftIcon
+              className={classes.toggle}
+              onClick={this.toggleUnderbelly}
+            />
+            <SunshineListTitle>Show the Underbelly</SunshineListTitle>
+          </div>}
+        { showUnderbelly && <div>
+          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true, includeBioOnlyUsers: true}} allowContentPreview={false}/>
         </div>}
+
       </div>
     )
   }

--- a/packages/lesswrong/lib/collections/users/views.js
+++ b/packages/lesswrong/lib/collections/users/views.js
@@ -67,8 +67,8 @@ Users.addView("usersWithBannedUsers", function () {
   }
 })
 
-Users.addView("sunshineNewUsers", function () {
-  let reCaptchaSelector = {signUpReCaptchaRating: {$gt: 0.3}}
+Users.addView("sunshineNewUsers", function (terms) {
+  let reCaptchaSelector = terms.ignoreRecaptcha ? {} : {signUpReCaptchaRating: {$gt: 0.3}}
   if (!getSetting('requireReCaptcha')) {
     reCaptchaSelector = {
       $or: [
@@ -77,13 +77,14 @@ Users.addView("sunshineNewUsers", function () {
       ]
     }
   }
+  const bioSelector = terms.includeBioOnlyUsers ? {$exists: true} : {}
   return {
     selector: {
       $or: [
         { voteCount: {$gt: 12}},
         { commentCount: {$gt: 0}},
         { postCount: {$gt: 0}, ...reCaptchaSelector},
-        { bio: {$exists: true}},
+        { bio: {...bioSelector}},
       ],
       reviewedByUserId: {$exists: false},
       banned: {$exists: false},


### PR DESCRIPTION
This creates a new section of the SunshineSidebar that's hidden by default, called the Underbelly. The purpose is to hide information we shouldn't normally act on, while still making it accessible in weirder situations.

Main use case is reviewing users who failed reCaptcha but are legit.

Right now, I've moved Users who's only content is their bio into the underbelly since we don't normally use it. (Not quite sure the right way to integrate this with EA forum)

Additional Features
– Added an "approve new user" to the PostActions menu, on posts that have "authorIsUnreviewed" set to true. So if a sunshine sees a post that fell through the cracks somehow they can easily review the author. (Note that this will take a page refresh)
– while doing that, I reorganized the PostActions menu slightly since I was finding it hard to work with