### PR TITLE
Only report 404s (from unparseable route) on client, not from SSR

### DIFF
--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -185,7 +185,17 @@ class App extends PureComponent {
       }
     }
 
-    if (!currentRoute) {
+    // If the route is unparseable, that's a 404. Only log this in Sentry if
+    // we're on the client, not if this is SSR. This is a compromise between
+    // catching broken links, and spam in Sentry; crawlers and bots that try lots
+    // of invalid URLs generally won't execute Javascript (especially after
+    // getting a 404 status), so this should only log when someone reaches a
+    // 404 with an actual browser.
+    // Unfortunately that also means it doesn't look broken resource links (ie
+    // images), but we can't really distinguish between "post contained a broken
+    // image link and it mattered" and "bot tried a weird URL and it didn't
+    // resolve to anything".
+    if (!currentRoute && Meteor.isClient) {
       Sentry.captureException(new Error(`404 not found: ${location.pathname}`));
     }
     


### PR DESCRIPTION
If the route is unparseable, that's a 404. Only log this in Sentry if we're on the client, not if this is SSR. This is a compromise between catching broken links, and spam in Sentry; crawlers and bots that try lots of invalid URLs generally won't execute Javascript (especially after getting a 404 status), so this should only log when someone reaches a 404 with an actual browser.

Unfortunately that also means it doesn't look broken resource links (ie images), but we can't really distinguish between "post contained a broken image link and it mattered" and "bot tried a weird URL and it didn't resolve to anything".