### PR TITLE
fix various bugs relating to shortform and permissions

### DIFF
--- a/packages/lesswrong/components/comments/CommentWithReplies.jsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.jsx
@@ -4,6 +4,7 @@ import withUser from '../common/withUser';
 import { unflattenComments, addGapIndicators } from '../../lib/modules/utils/unflatten';
 import withRecordPostView from '../common/withRecordPostView';
 import { withStyles } from '@material-ui/core/styles';
+import withErrorBoundary from '../common/withErrorBoundary';
 
 const styles = theme => ({
   showChildren: {
@@ -30,6 +31,9 @@ class CommentWithReplies extends PureComponent {
     const { CommentsNode } = Components
     const { markedAsVisitedAt, maxChildren } = this.state
 
+    if (!comment || !comment.post)
+      return null;
+
     const lastCommentId = comment.latestChildren[0]?._id
 
     const renderedChildren = comment.latestChildren.slice(0, maxChildren)
@@ -39,6 +43,7 @@ class CommentWithReplies extends PureComponent {
     if (extraChildrenCount > 0) {
       nestedComments = addGapIndicators(nestedComments)
     }
+
     const lastVisitedAt = markedAsVisitedAt || comment.post.lastVisitedAt
 
     const showExtraChildrenButton = (extraChildrenCount>0) ? 
@@ -70,4 +75,4 @@ class CommentWithReplies extends PureComponent {
   }
 }
 
-registerComponent('CommentWithReplies', CommentWithReplies, withUser, withRecordPostView, withStyles(styles, {name:"CommentWithReplies"}));
+registerComponent('CommentWithReplies', CommentWithReplies, withUser, withRecordPostView, withStyles(styles, {name:"CommentWithReplies"}), withErrorBoundary);

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
@@ -49,7 +49,7 @@ const CommentsItemDate = ({comment, post, showPostTitle, classes, scrollOnClick,
   const date = <span>
     <Components.FormatDate date={comment.postedAt} format={comment.answer && "MMM DD, YYYY"}/>
     <Icon className={classNames("material-icons", classes.icon)}> link </Icon>
-    {showPostTitle && post.title && <span className={classes.postTitle}> { post.title }</span>}
+    {showPostTitle && post.title && <span className={classes.postTitle}> {post.draft && "[Draft]"} {post.title}</span>}
   </span>
 
   return (

--- a/packages/lesswrong/components/shortform/ShortformPage.jsx
+++ b/packages/lesswrong/components/shortform/ShortformPage.jsx
@@ -16,7 +16,7 @@ const ShortformPage = ({classes}) => {
     <SingleColumnSection>
       <div className={classes.column}>
         <SectionTitle title="Shortform Content [Beta]"/>
-        <ShortformThreadList terms={{view: 'shortform', limit:20, testLimit:30}} />
+        <ShortformThreadList terms={{view: 'shortform', limit:20}} />
       </div>
     </SingleColumnSection>
   )

--- a/packages/lesswrong/lib/collections/comments/fragments.js
+++ b/packages/lesswrong/lib/collections/comments/fragments.js
@@ -61,6 +61,7 @@ registerFragment(`
       _id
       slug
       title
+      draft
     }
   }
 `)
@@ -77,6 +78,7 @@ registerFragment(`
       _id
       slug
       lastVisitedAt
+      draft
     }
   }
 `);

--- a/packages/lesswrong/lib/collections/comments/views.js
+++ b/packages/lesswrong/lib/collections/comments/views.js
@@ -281,6 +281,7 @@ Comments.addView('shortform', function (terms) {
   return {
     selector: {
       shortform: true,
+      deleted: false,
       parentCommentId: viewFieldNullOrMissing,
     },
     options: {sort: {lastSubthreadActivity: -1, postedAt: -1}}

--- a/packages/lesswrong/lib/collections/posts/permissions.js
+++ b/packages/lesswrong/lib/collections/posts/permissions.js
@@ -18,6 +18,7 @@ const membersActions = [
 Users.groups.members.can(membersActions);
 
 const adminActions = [
+  'posts.view.all',
   'posts.view.pending',
   'posts.view.rejected',
   'posts.view.spam',
@@ -31,7 +32,7 @@ Users.groups.admins.can(adminActions);
 // LessWrong Permissions
 
 Posts.checkAccess = (currentUser, post) => {
-  if (Users.isAdmin(currentUser)) {
+  if (Users.canDo(currentUser, 'posts.view.all')) {
     return true
   } else if (Users.owns(currentUser, post) || Users.isSharedOn(currentUser, post)) {
     return true;
@@ -53,6 +54,7 @@ const votingActions = [
 Users.groups.members.can(votingActions);
 
 const sunshineRegimentActions = [
+  'posts.view.all',
   'posts.edit.all',
   'posts.curate.all',
   'posts.suggestCurate',


### PR DESCRIPTION
Notes:

adds withErrorBoundaries for defensive-programming-reasons, and also fixes the immediate issues that caused the defensive programming to be needed

Admins (and now sunshines) can see shortform comments from shortform posts that have been set to draft, but it'll at least be a bit more clear because the post title on the commentsItem will now say "[Draft]"

"testLimit" wasn't used anywhere, pretty sure we don't need, I assume I put it there for some testing related reason and shouldn't have merged it

