### PR TITLE
Two small fixes for CKEditor

### DIFF
--- a/packages/lesswrong/components/async/CKCommentEditor.jsx
+++ b/packages/lesswrong/components/async/CKCommentEditor.jsx
@@ -8,7 +8,7 @@ const CKCommentEditor = ({ data, onSave, onInit }) => {
   return <div>
     <CKEditor
       editor={ CommentEditor }
-      data="<p>Hello from CKEditor 5!</p>"
+      data={data}
       onInit={ editor => {
           // Uncomment the line below and the import above to activate the debugger
           // CKEditorInspector.attach(editor)

--- a/packages/lesswrong/components/async/CKPostEditor.jsx
+++ b/packages/lesswrong/components/async/CKPostEditor.jsx
@@ -28,6 +28,7 @@ const styles = theme => ({
 })
 
 const refreshDisplayMode = ( editor, sidebarElement ) => {
+  if (!sidebarElement) return null
   const annotations = editor.plugins.get( 'Annotations' );
 
   if ( window.innerWidth < 1000 ) {


### PR DESCRIPTION
Fixes a crash that can sometimes happen when you submit a post, and makes comment editors properly initialize with the comment data when editing