### PR TITLE
Fix incremental update of denormalized-count fields (broken in Vulcan/Apollo upgrade)

### DIFF
--- a/packages/lesswrong/lib/modules/utils/schemaUtils.js
+++ b/packages/lesswrong/lib/modules/utils/schemaUtils.js
@@ -210,22 +210,22 @@ export function denormalizedCountOfReferences({ collectionName, fieldName,
     // need to increment a count, we may need to do both with them cancelling
     // out, or we may need to both but on different documents.
     addCallback(`${foreignCollectionCallbackPrefix}.update.after`,
-      async (newDoc, {document, currentUser, collection}) => {
+      async (newDoc, {oldDocument, currentUser, collection}) => {
         const countingCollection = getCollection(collectionName);
-        if (filterFn(newDoc) && !filterFn(document)) {
+        if (filterFn(newDoc) && !filterFn(oldDocument)) {
           // The old doc didn't count, but the new doc does. Increment on the new doc.
           await countingCollection.update(newDoc[foreignFieldName], {
             $inc: { [fieldName]: 1 }
           });
-        } else if (!filterFn(newDoc) && filterFn(document)) {
+        } else if (!filterFn(newDoc) && filterFn(oldDocument)) {
           // The old doc counted, but the new doc doesn't. Decrement on the old doc.
-          await countingCollection.update(document[foreignFieldName], {
+          await countingCollection.update(oldDocument[foreignFieldName], {
             $inc: { [fieldName]: -1 }
           });
-        } else if(filterFn(newDoc) && document[foreignFieldName] !== newDoc[foreignFieldName]) {
+        } else if(filterFn(newDoc) && oldDocument[foreignFieldName] !== newDoc[foreignFieldName]) {
           // The old and new doc both count, but the reference target has changed.
           // Decrement on one doc and increment on the other.
-          await countingCollection.update(document[foreignFieldName], {
+          await countingCollection.update(oldDocument[foreignFieldName], {
             $inc: { [fieldName]: -1 }
           });
           await countingCollection.update(newDoc[foreignFieldName], {


### PR DESCRIPTION
In the last Vulcan/Apollo upgrade, the meaning of the `document` argument to `<collection>.update.after` changed from referring to the old document (without the update applied), to referring to the new document. This broke the callback in `denormalizedCountOfReferences`, which tries to compare the old and new versions of a document to see if the new one counts while the old one didn't, and uses this to update users' post counts. The API change meant that it was comparing the new version of the document to itself, instead, so posts didn't get added to users' post count when edited to no longer be drafts.

Tested: Without this patch, post counts don't increment/decrement when undrafting and re-drafting posts; with this patch, they do.

After applying, we'll want to run
```
Vulcan.recomputeDenormalizedValues({collectionName: "Users"})
```
