### PR TITLE
Speed up logged-out SSR

### DIFF
--- a/packages/vulcan-users/lib/modules/permissions.js
+++ b/packages/vulcan-users/lib/modules/permissions.js
@@ -146,16 +146,21 @@ Users.canDo = (user, actionOrActions) => {
  * @param {Object} document - The document to check (post, comment, user object, etc.)
  */
 Users.owns = function (user, document) {
-  try {
-    if (!!document.userId) {
-      // case 1: document is a post or a comment, use userId to check
-      return user._id === document.userId;
-    } else {
-      // case 2: document is a user, use _id or slug to check
-      return document.slug ? user.slug === document.slug : user._id === document._id;
-    }
-  } catch (e) {
-    return false; // user not logged in
+  if (!user) {
+    // not logged in
+    return false;
+  }
+  if (!document) {
+    // no document specified
+    return false;
+  }
+  
+  if (!!document.userId) {
+    // case 1: document is a post or a comment, use userId to check
+    return user._id === document.userId;
+  } else {
+    // case 2: document is a user, use _id or slug to check
+    return document.slug ? user.slug === document.slug : user._id === document._id;
   }
 };
 


### PR DESCRIPTION
The way Users.owns was written, if the user is null (logged out), it will dereference null, throw an exception, and then immediately catch it. This is a mildly expensive operation, and Users.owns gets called a lot of times. The practical upshot of which is that, for logged out users, the server was spending 350ms of front-page server-side rendering time just in Users.owns, throwing and catching internal exceptions.

Convert that into a proper null check, reducing the time spent in this function to approximately zero.


