### PR TITLE
Add databaseMetadata collection and expectedDatabaseId config setting

### DIFF
--- a/packages/lesswrong/lib/collections/databaseMetadata/collection.js
+++ b/packages/lesswrong/lib/collections/databaseMetadata/collection.js
@@ -9,3 +9,5 @@ export const DatabaseMetadata = createCollection({
   schema
 });
 addUniversalFields({collection: DatabaseMetadata});
+
+ensureIndex(DatabaseMetadata, { name:1 });

--- a/packages/lesswrong/lib/collections/databaseMetadata/collection.js
+++ b/packages/lesswrong/lib/collections/databaseMetadata/collection.js
@@ -1,0 +1,11 @@
+import schema from './schema.js';
+import { createCollection } from 'meteor/vulcan:core';
+import { addUniversalFields, ensureIndex } from '../../collectionUtils'
+
+
+export const DatabaseMetadata = createCollection({
+  collectionName: "DatabaseMetadata",
+  typeName: "DatabaseMetadata",
+  schema
+});
+addUniversalFields({collection: DatabaseMetadata});

--- a/packages/lesswrong/lib/collections/databaseMetadata/schema.js
+++ b/packages/lesswrong/lib/collections/databaseMetadata/schema.js
@@ -1,0 +1,17 @@
+
+// The databaseMetadata collection is a collection of named, mostly-singleton
+// values. (Currently just databaseId, which is used for ensuring you don't
+// connect to a production database without using the corresponding config
+// file.)
+
+const schema = {
+  name: {
+    type: String,
+  },
+  value: {
+    type: Object,
+    blackbox: true
+  },
+};
+
+export default schema;

--- a/packages/lesswrong/lib/index.js
+++ b/packages/lesswrong/lib/index.js
@@ -53,6 +53,9 @@ import './collections/reports/views.js'
 // LWEvents
 import { LWEvents } from './collections/lwevents/index.js';
 
+// DatabaseMetadata
+import './collections/databaseMetadata/collection.js';
+
 // DebouncerEvents
 import './collections/debouncerEvents/collection.js';
 

--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -2,6 +2,8 @@ import { getSetting} from 'meteor/vulcan:core';
 
 export * from './lib/index.js';
 
+import './server/startupSanityChecks.js';
+
 import './server/database-import/database_import_new.js';
 import './server/rss-integration/cron.js';
 import './server/rss-integration/callbacks.js';

--- a/packages/lesswrong/server/startupSanityChecks.js
+++ b/packages/lesswrong/server/startupSanityChecks.js
@@ -12,10 +12,10 @@ Meteor.startup(() => {
   // both must contain IDs and they must match.
   if (expectedDatabaseId || databaseIdObject) {
     if (expectedDatabaseId !== databaseIdObject?.value) {
-      console.error("Database ID in config file and in database don't match.");
-      console.error(`    Database ID: ${databaseIdObject?.value}`);
-      console.error(`    Expected database ID: ${expectedDatabaseId}`);
-      console.error("If you are connecting to a production DB, you must use a matching config file. If you are *not* connecting to a production DB, you should not use a production config file.");
+      console.error("Database ID in config file and in database don't match."); // eslint-disable-line no-console
+      console.error(`    Database ID: ${databaseIdObject?.value}`); // eslint-disable-line no-console
+      console.error(`    Expected database ID: ${expectedDatabaseId}`); // eslint-disable-line no-console
+      console.error("If you are connecting to a production DB, you must use a matching config file. If you are *not* connecting to a production DB, you should not use a production config file."); // eslint-disable-line no-console
       process.exit(1);
     }
   }

--- a/packages/lesswrong/server/startupSanityChecks.js
+++ b/packages/lesswrong/server/startupSanityChecks.js
@@ -1,0 +1,23 @@
+import { DatabaseMetadata } from '../lib/collections/databaseMetadata/collection.js';
+import { registerSetting, getSetting } from 'meteor/vulcan:core';
+import process from 'process';
+
+registerSetting('expectedDatabaseId', null, "Database ID string that this config file should match with");
+
+Meteor.startup(() => {
+  const expectedDatabaseId = getSetting('expectedDatabaseId', null);
+  const databaseIdObject = DatabaseMetadata.findOne({ name: "databaseId" });
+  
+  // If either the database or the settings config file contains an ID, then
+  // both must contain IDs and they must match.
+  if (expectedDatabaseId || databaseIdObject) {
+    if (expectedDatabaseId !== databaseIdObject?.value) {
+      console.error("Database ID in config file and in database don't match.");
+      console.error(`    Database ID: ${databaseIdObject?.value}`);
+      console.error(`    Expected database ID: ${expectedDatabaseId}`);
+      console.error("If you are connecting to a production DB, you must use a matching config file. If you are *not* connecting to a production DB, you should not use a production config file.");
+      process.exit(1);
+    }
+  }
+});
+


### PR DESCRIPTION
This adds a `databaseMetadata` collection, which can contain a database ID, and an `expectedDatabaseId` config setting, which can also contain a database ID. If either is present, both must be present and they must match, or else the server will abort on startup.