### PR TITLE
commentPreview bug fixing

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -239,12 +239,10 @@ class CommentsNode extends Component {
   isSingleLine = () => {
     const { forceSingleLine, forceNotSingleLine, postPage, currentUser } = this.props
     const { singleLine } = this.state
+    
     if (!singleLine || currentUser?.noSingleLineComments) return false;
-    if (forceSingleLine)
-      return true;
-
-    if (forceNotSingleLine)
-      return false
+    if (forceSingleLine) return true;
+    if (forceNotSingleLine) return false
     
     // highlighted new comments on post page should always be expanded (and it needs to live here instead of "beginSingleLine" since the highlight status can change after the fact)
     const postPageAndNew = this.isNewComment() && postPage 

--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -237,11 +237,14 @@ class CommentsNode extends Component {
   }
 
   isSingleLine = () => {
-    const { forceSingleLine, postPage, currentUser } = this.props
+    const { forceSingleLine, forceNotSingleLine, postPage, currentUser } = this.props
     const { singleLine } = this.state
     if (!singleLine || currentUser?.noSingleLineComments) return false;
     if (forceSingleLine)
       return true;
+
+    if (forceNotSingleLine)
+      return false
     
     // highlighted new comments on post page should always be expanded (and it needs to live here instead of "beginSingleLine" since the highlight status can change after the fact)
     const postPageAndNew = this.isNewComment() && postPage 

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -56,9 +56,8 @@ const PostLinkPreviewLegacy = ({href, targetLocation, innerHTML}) => {
 registerComponent('PostLinkPreviewLegacy', PostLinkPreviewLegacy);
 
 const PostLinkPreviewVariantCheck = ({ href, innerHTML, post, targetLocation, comment, commentId, error }) => {
-
-  if (targetLocation.params.commentId) {
-    return <PostLinkCommentPreview commentId={targetLocation.params.commentId} href={href} innerHTML={innerHTML} post={post} />
+  if (targetLocation.query.commentId) {
+    return <PostLinkCommentPreview commentId={targetLocation.query.commentId} href={href} innerHTML={innerHTML} post={post} />
   }
   if (targetLocation.hash) {
     const commentId = targetLocation.hash.split("#")[1] 
@@ -171,6 +170,7 @@ const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post,
             post={post}
             showPostTitle
             hoverPreview
+            forceNotSingleLine
           />
         </Card>
       </LWPopper>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -207,7 +207,7 @@ const DefaultPreview = ({classes, href, innerHTML, anchorEl, hover, onsite=false
       {onsite ?
         <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} /> 
         :
-        <a to={href} dangerouslySetInnerHTML={{__html: innerHTML}} />}
+        <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} />}
     </span>
   );
 }


### PR DESCRIPTION
This fixes two issues with the new comment previews:

1. Comment previews were (in some cases) defaulting to rendering as a SingleLine instead of full comment
2. comment permalinks (a la "?commenId=blahblah") weren't working because I was calling them from params instead of query.
3. I had accidentally passed the "to" field into an 'a' tag instead of 'href', so defaultLinkPreviews weren't actually working as links