### PR TITLE
Posts item updates

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -13,7 +13,6 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Hidden from '@material-ui/core/Hidden';
 import withRecordPostView from '../common/withRecordPostView';
-import withHover from "../common/withHover";
 
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
@@ -297,9 +296,9 @@ class PostsItem2 extends PureComponent {
   render() {
     const { classes, post, sequenceId, chapter, currentUser, index, terms, resumeReading,
       showBottomBorder=true, showQuestionTag=true, showIcons=true, showPostedAt=true,
-      defaultToShowUnreadComments=false, dismissRecommendation, isRead, dense, hover, anchorEl, stopHover } = this.props
+      defaultToShowUnreadComments=false, dismissRecommendation, isRead, dense } = this.props
     const { showComments } = this.state
-    const { PostsItemComments, PostsItemKarma, PostsTitle, PostsUserAndCoauthors, PostsPageActions, PostsItemIcons, PostsItem2MetaInfo, PostsPreviewTooltip, LWPopper } = Components
+    const { PostsItemComments, PostsItemKarma, PostsTitle, PostsUserAndCoauthors, PostsPageActions, PostsItemIcons, PostsItem2MetaInfo, PostsItemTooltipWrapper } = Components
 
     const postLink = Posts.getPageUrl(post, false, sequenceId || chapter?.sequenceId);
 
@@ -317,19 +316,6 @@ class PostsItem2 extends PureComponent {
 
     return (
       <div className={classes.root} ref={this.postsItemRef}>
-        <LWPopper
-          open={hover}
-          anchorEl={anchorEl}
-          onMouseEnter={stopHover}
-          placement="left-start"
-          modifiers={{
-            flip: {
-              enabled: false
-            }
-          }}
-        >
-          <PostsPreviewTooltip post={post} />
-        </LWPopper>
         <div className={classNames(
           classes.background,
           {
@@ -340,75 +326,77 @@ class PostsItem2 extends PureComponent {
             [classes.hasResumeReading]: !!resumeReading,
           }
         )}>
-          <div className={classNames(classes.postsItem, {
-            [classes.dense]: dense
-            })}>
-            <PostsItem2MetaInfo className={classes.karma}>
-              <PostsItemKarma post={post} />
-            </PostsItem2MetaInfo>
+          <PostsItemTooltipWrapper post={post}>
+            <div className={classNames(classes.postsItem, {
+              [classes.dense]: dense
+              })}>
+              <PostsItem2MetaInfo className={classes.karma}>
+                <PostsItemKarma post={post} />
+              </PostsItem2MetaInfo>
 
-            <span className={classes.title}>
-              <PostsTitle postLink={postLink} post={post} expandOnHover={!renderComments} read={isRead} sticky={this.isSticky(post, terms)} showQuestionTag={showQuestionTag}/>
-            </span>
+              <span className={classes.title}>
+                <PostsTitle postLink={postLink} post={post} expandOnHover={!renderComments} read={isRead} sticky={this.isSticky(post, terms)} showQuestionTag={showQuestionTag}/>
+              </span>
 
-            {(resumeReading?.sequence || resumeReading?.collection) &&
-              <div className={classes.nextUnreadIn}>
-                {resumeReading.numRead ? "Next unread in " : "First post in "}<Link to={
-                  resumeReading.sequence
-                    ? Sequences.getPageUrl(resumeReading.sequence)
-                    : Collections.getPageUrl(resumeReading.collection)
-                }>
-                  {resumeReading.sequence ? resumeReading.sequence.title : resumeReading.collection?.title}
-                </Link>
-                {" "}
-                {(resumeReading.numRead>0) && <span>({resumeReading.numRead}/{resumeReading.numTotal} read)</span>}
-              </div>
-            }
+              {(resumeReading?.sequence || resumeReading?.collection) &&
+                <div className={classes.nextUnreadIn}>
+                  {resumeReading.numRead ? "Next unread in " : "First post in "}<Link to={
+                    resumeReading.sequence
+                      ? Sequences.getPageUrl(resumeReading.sequence)
+                      : Collections.getPageUrl(resumeReading.collection)
+                  }>
+                    {resumeReading.sequence ? resumeReading.sequence.title : resumeReading.collection?.title}
+                  </Link>
+                  {" "}
+                  {(resumeReading.numRead>0) && <span>({resumeReading.numRead}/{resumeReading.numTotal} read)</span>}
+                </div>
+              }
 
-            { post.user && !post.isEvent && <PostsItem2MetaInfo className={classes.author}>
-              <PostsUserAndCoauthors post={post} abbreviateIfLong={true} />
-            </PostsItem2MetaInfo>}
+              { post.user && !post.isEvent && <PostsItem2MetaInfo className={classes.author}>
+                <PostsUserAndCoauthors post={post} abbreviateIfLong={true} />
+              </PostsItem2MetaInfo>}
 
-            { post.isEvent && <PostsItem2MetaInfo className={classes.event}>
-              <Components.EventVicinity post={post} />
-            </PostsItem2MetaInfo>}
+              { post.isEvent && <PostsItem2MetaInfo className={classes.event}>
+                <Components.EventVicinity post={post} />
+              </PostsItem2MetaInfo>}
 
-            {showPostedAt && !resumeReading && <Components.PostsItemDate post={post}/>}
+              {showPostedAt && !resumeReading && <Components.PostsItemDate post={post}/>}
 
-            <div className={classes.mobileSecondRowSpacer}/>
+              <div className={classes.mobileSecondRowSpacer}/>
 
-            {<div className={classes.mobileActions}>
-              {!resumeReading && <PostsPageActions post={post} />}
-            </div>}
-
-            {showIcons && <Hidden mdUp implementation="css">
-              <PostsItemIcons post={post}/>
-            </Hidden>}
-
-            {!resumeReading && <div className={classes.commentsIcon}>
-              <PostsItemComments
-                post={post}
-                onClick={() => this.toggleComments(false)}
-                unreadComments={unreadComments}
-              />
-
-            </div>}
-
-            <div className={classes.mobileDismissButton}>
-              {dismissButton}
-            </div>
-
-            {resumeReading &&
-              <div className={classes.sequenceImage}>
-                <img className={classes.sequenceImageImg}
-                  src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
-                    resumeReading.sequence?.gridImageId
-                      || resumeReading.collection?.gridImageId
-                      || "sequences/vnyzzznenju0hzdv6pqb.jpg"
-                  }`}
-                />
+              {<div className={classes.mobileActions}>
+                {!resumeReading && <PostsPageActions post={post} />}
               </div>}
-          </div>
+
+              {showIcons && <Hidden mdUp implementation="css">
+                <PostsItemIcons post={post}/>
+              </Hidden>}
+
+              {!resumeReading && <div className={classes.commentsIcon}>
+                <PostsItemComments
+                  post={post}
+                  onClick={() => this.toggleComments(false)}
+                  unreadComments={unreadComments}
+                />
+
+              </div>}
+
+              <div className={classes.mobileDismissButton}>
+                {dismissButton}
+              </div>
+
+              {resumeReading &&
+                <div className={classes.sequenceImage}>
+                  <img className={classes.sequenceImageImg}
+                    src={`https://res.cloudinary.com/${cloudinaryCloudName}/image/upload/c_fill,dpr_2.0,g_custom,h_96,q_auto,w_292/v1/${
+                      resumeReading.sequence?.gridImageId
+                        || resumeReading.collection?.gridImageId
+                        || "sequences/vnyzzznenju0hzdv6pqb.jpg"
+                    }`}
+                  />
+                </div>}
+            </div>
+          </PostsItemTooltipWrapper>
 
           {<div className={classes.actions}>
             {dismissButton}
@@ -442,6 +430,5 @@ registerComponent(
   withStyles(styles, { name: "PostsItem2" }),
   withUser,
   withRecordPostView,
-  withErrorBoundary,
-  withHover
+  withErrorBoundary
 );

--- a/packages/lesswrong/components/posts/PostsItemTooltipWrapper.jsx
+++ b/packages/lesswrong/components/posts/PostsItemTooltipWrapper.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { registerComponent, Components } from 'meteor/vulcan:core';
+import withHover from "../common/withHover";
+
+const PostsItemTooltipWrapper = ({hover, anchorEl, stopHover, children, post}) => {
+  const { LWPopper, PostsPreviewTooltip } = Components
+  return <React.Fragment>
+      <LWPopper
+        open={hover}
+        anchorEl={anchorEl}
+        onMouseEnter={stopHover}
+        placement="left-start"
+        modifiers={{
+          flip: {
+            enabled: false
+          }
+        }}
+      >
+        <PostsPreviewTooltip post={post} />
+      </LWPopper>
+      { children }
+    </React.Fragment>
+}
+
+registerComponent('PostsItemTooltipWrapper', PostsItemTooltipWrapper, withHover)

--- a/packages/lesswrong/components/posts/PostsTitle.jsx
+++ b/packages/lesswrong/components/posts/PostsTitle.jsx
@@ -33,6 +33,7 @@ const styles = theme => ({
   },
   expandOnHover: {
     [theme.breakpoints.up('md')]: {
+      width: "100%",
       '&:hover': {
         overflow: "visible",
         textOverflow: "unset",
@@ -92,10 +93,10 @@ const PostsTitle = ({currentUser, post, postLink, classes, sticky, read, expandO
     classes.root,
     {
       [classes.read]: read,
-      [classes.expandOnHover]: expandOnHover,
       [classes.wrap]: wrap
     }
   )}>
+    <div className={classNames({[classes.expandOnHover]: expandOnHover})}/>
     {post.unlisted && <span className={classes.tag}>[Unlisted]</span>}
 
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}

--- a/packages/lesswrong/components/posts/PostsTitle.jsx
+++ b/packages/lesswrong/components/posts/PostsTitle.jsx
@@ -96,7 +96,7 @@ const PostsTitle = ({currentUser, post, postLink, classes, sticky, read, expandO
       [classes.wrap]: wrap
     }
   )}>
-    <div className={classNames({[classes.expandOnHover]: expandOnHover})}/>
+    <span className={classNames({[classes.expandOnHover]: expandOnHover})}/>
     {post.unlisted && <span className={classes.tag}>[Unlisted]</span>}
 
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -138,6 +138,7 @@ importComponent("MoveToDraft", () => require('../components/posts/MoveToDraft.js
 importComponent("SuggestAlignment", () => require('../components/posts/SuggestAlignment.jsx'));
 importComponent("PostsItemMeta", () => require('../components/posts/PostsItemMeta.jsx'));
 importComponent("PostsItem2", () => require('../components/posts/PostsItem2.jsx'));
+importComponent("PostsItemTooltipWrapper", () => require('../components/posts/PostsItemTooltipWrapper.jsx'));
 importComponent("PostsItem2MetaInfo", () => require('../components/posts/PostsItem2MetaInfo.jsx'));
 importComponent("PostsTitle", () => require('../components/posts/PostsTitle.jsx'));
 importComponent("PostsPreviewTooltip", () => require('../components/posts/PostsPreviewTooltip.jsx'));


### PR DESCRIPTION
Fixes:
– the thing where the new hoverPreview was visible when hovering over expanded comments in the PostsItem2 (now, the hover target area is only the top row of the component)
– when the PostsTitle expands, it no longer extends it's grey background beyond the edge of the component