### PR TITLE
Improve how we handle spoiler tags

### DIFF
--- a/packages/lesswrong/server/draftConvert.jsx
+++ b/packages/lesswrong/server/draftConvert.jsx
@@ -104,7 +104,7 @@ export const draftToHTML = convertToHTML({
      return <hr className="dividerBlock" />
     }
     if (type === 'spoiler') {
-     return <p className="new-spoiler" />
+     return <p className="spoiler-v2" /> // this is the second iteration of a spoiler-tag that we've implemented. Changing the name for backwards-and-forwards compatibility
     }
     if (type === 'unstyled') {
       if (block.text === ' ' || block.text === '') return <br />;

--- a/packages/lesswrong/server/draftConvert.jsx
+++ b/packages/lesswrong/server/draftConvert.jsx
@@ -104,7 +104,7 @@ export const draftToHTML = convertToHTML({
      return <hr className="dividerBlock" />
     }
     if (type === 'spoiler') {
-     return <p className="spoiler" />
+     return <p className="new-spoiler" />
     }
     if (type === 'unstyled') {
       if (block.text === ' ' || block.text === '') return <br />;

--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -54,7 +54,7 @@ const cheerioWrapAll = (toWrap, wrapper, $) => {
   return section;                 // This is what jQuery would return, IIRC.
 }
 
-const spoilerClass = 'new-spoiler'
+const spoilerClass = 'spoiler-v2'
 function wrapSpoilerTags(html) {
   const $ = cheerio.load(html)
   $(`.${spoilerClass}`).not(`.${spoilerClass}+.${spoilerClass}`).each(function(){

--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -11,6 +11,7 @@ turndownService.remove('style') // Make sure we don't add the content of style t
 
 import markdownIt from 'markdown-it'
 import markdownItMathjax from './markdown-mathjax.js'
+import cheerio from 'cheerio';
 import markdownItContainer from 'markdown-it-container'
 import markdownItFootnote from 'markdown-it-footnote'
 
@@ -21,6 +22,8 @@ mdi.use(markdownItFootnote)
 
 import { mjpage }  from 'mathjax-node-page'
 
+
+
 function mjPagePromise(html, beforeSerializationCallback) {
   // Takes in HTML and replaces LaTeX with CommonHTML snippets
   // https://github.com/pkra/mathjax-node-page
@@ -30,9 +33,42 @@ function mjPagePromise(html, beforeSerializationCallback) {
   })
 }
 
+// Adapted from: https://github.com/cheeriojs/cheerio/issues/748
+const cheerioWrapAll = (toWrap, wrapper, $) => {
+  if (toWrap.length < 1) {
+    return toWrap;
+  } 
+
+  if (toWrap.length < 2 && $.wrap) { // wrap not defined in npm version,
+    return $.wrap(wrapper);      // and git version fails testing.
+  }
+
+  const section = $(wrapper);
+  let  marker = $('<div>');
+  marker = marker.insertBefore(toWrap.first()); // in jQuery marker would remain current
+  toWrap.each(function(k, v) {                  // in Cheerio, we update with the output.
+    section.append($(v));
+  });
+  section.insertBefore(marker); 
+  marker.remove();
+  return section;                 // This is what jQuery would return, IIRC.
+}
+
+const spoilerClass = 'new-spoiler'
+function wrapSpoilerTags(html) {
+  const $ = cheerio.load(html)
+  $(`.${spoilerClass}`).not(`.${spoilerClass}+.${spoilerClass}`).each(function(){
+    const nodes = $(this).nextUntil(`:not(.${spoilerClass})`).addBack();
+    cheerioWrapAll(nodes, '<div class="spoilers" />', $)
+  });
+  return $.html()
+}
+
+
 export async function draftJSToHtmlWithLatex(draftJS) {
   const draftJSWithLatex = await Utils.preProcessLatex(draftJS)
-  return draftToHTML(convertFromRaw(draftJSWithLatex))
+  const html = draftToHTML(convertFromRaw(draftJSWithLatex))
+  return wrapSpoilerTags(html)
 }
 
 export function htmlToMarkdown(html) {

--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -54,7 +54,7 @@ const cheerioWrapAll = (toWrap, wrapper, $) => {
   return section;                 // This is what jQuery would return, IIRC.
 }
 
-const spoilerClass = 'spoiler-v2'
+const spoilerClass = 'spoiler-v2' // this is the second iteration of a spoiler-tag that we've implemented. Changing the name for backwards-and-forwards compatibility
 function wrapSpoilerTags(html) {
   const $ = cheerio.load(html)
   $(`.${spoilerClass}`).not(`.${spoilerClass}+.${spoilerClass}`).each(function(){

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -14,24 +14,47 @@ const spoilerStyles = theme => ({
     minHeight: theme.typography.commentStyle.fontSize,
     '& .public-DraftStyleDefault-block': {
       margin: 0,
-    },
-  },
-  '& .spoiler:before': {
-    content: '"spoiler (hover/select to reveal)"',
-    color: 'white',
-    position: 'absolute',
-    left: 20
-  },
-  '& .spoiler:after': {
-    content: '"\\00a0"',
+    }
   },
   '&:hover .spoiler': {
     color: 'white',
   },
-  '&:hover .spoiler:before': {
+  '& div.spoilers': {
     color: 'black',
-    content: '""'
+    backgroundColor: 'currentColor',
+    transition: 'none',
+    textShadow: 'none',
+    margin: '1em 0',
+    overflow: 'auto',
   },
+  '& .spoilers *': {
+    color: 'inherit',
+    border: 'none',
+  },
+  '& p.new-spoiler': {
+    margin: 0,
+    padding: '0.5em 0em'
+  },
+  '& .spoilers:hover': {
+    color: 'unset',
+    backgroundColor: 'unset',
+    textShadow: 'unset',
+    transition: `
+      color 0.1s ease-out 0.1s,
+      background-color 0.1s ease-out 0.1s,
+      text-shadow 0.1s ease-out 0.1s;
+    `
+  },
+  '& .spoilers::selection, & .spoilers ::selection': {
+    color: `#fff`,
+    backgroundColor: `#000`
+  },
+  '& .spoilers:not(:hover)::selection, & .spoilers:not(:hover) ::selection': {
+    backgroundColor: 'transparent'
+  },
+  '& .spoilers > p:hover ~ p': {
+    backgroundColor: 'currentColor'
+  }
 })
 
 export const postBodyStyles = (theme, fontSize) => {

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -19,6 +19,9 @@ const spoilerStyles = theme => ({
   '&:hover .spoiler': {
     color: 'white',
   },
+  // Note: ".spoiler" is the old class Oli originally used. ".spoilers" is a new class 
+  // that is applied in make_editable_callbacks.js to groups of adjaecent spoiler paragraphs.
+  // (see the make_editable_callbacks.js file for details)
   '& div.spoilers': {
     color: 'black',
     backgroundColor: 'currentColor',

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -34,7 +34,7 @@ const spoilerStyles = theme => ({
     color: 'inherit',
     border: 'none',
   },
-  '& p.new-spoiler': {
+  '& p.spoiler-v2': {
     margin: 0,
     padding: '0.5em 0em'
   },


### PR DESCRIPTION
This for now just improves the handling of spoiler tags added with draft-js and leaves everything else the same. Implemented by just wrapping those adjacent spoiler tags into a wrapping element and then copying the greaterwrong CSS for handling spoiler tags.