### PR TITLE
ckEditor Styling Tweaks

### DIFF
--- a/packages/lesswrong/components/async/CKCommentEditor.jsx
+++ b/packages/lesswrong/components/async/CKCommentEditor.jsx
@@ -1,11 +1,18 @@
 import React from 'react'
 import CKEditor from '@ckeditor/ckeditor5-react';
 import { CommentEditor } from '@lesswrong/lesswrong-editor';
+import { withStyles } from '@material-ui/core/styles';
 // Uncomment the import and the line below to activate the debugger
 // import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 
-const CKCommentEditor = ({ data, onSave, onInit }) => {
-  return <div>
+const styles = theme => ({
+  root: {
+    '--ck-focus-ring': 'unset'
+  }
+})
+
+const CKCommentEditor = ({ classes, data, onSave, onInit }) => {
+  return <div className={classes.root}>
     <CKEditor
       editor={ CommentEditor }
       data={data}
@@ -24,4 +31,4 @@ const CKCommentEditor = ({ data, onSave, onInit }) => {
     />
   </div>
 }
-export default CKCommentEditor
+export default withStyles(styles)(CKCommentEditor)

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -256,6 +256,9 @@ export const ckEditorStyles = theme => {
             content: '"\\25B6"'
           }
         },
+        '& .ck-comment__input': {
+          paddingLeft: theme.spacing.unit*2
+        },
         '& .ck-annotation__main, & .ck-comment__input, & .ck-thread__input': {
           width : "100%"
         },

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -221,6 +221,60 @@ export const postHighlightStyles = theme => {
   return deepmerge(postBodyStyles(theme), postHighlightStyles, {isMergeableObject:isPlainObject})
 }
 
+export const ckEditorStyles = theme => {
+  return {
+    '& .ck': {
+      '--ck-spacing-standard': `${theme.spacing.unit}px`,
+      '&.ck-content': {
+        marginLeft: -theme.spacing.unit,
+        '--ck-focus-outer-shadow-geometry': "none",
+        '--ck-focus-ring': "solid 1px rgba(0,0,0,0)",
+        '--ck-focus-outer-shadow': "none",
+        '--ck-inner-shadow': "none"
+      },
+      '&.ck-sidebar, &.ck-presence-list': { //\u25B6
+        '& li': {
+          // By default ckEditor elements get the styles from postBodyStyles li elements
+          marginBottom: 'unset',
+          fontFamily: 'unset',
+          fontSize: 'unset',
+          fontWeight: 'unset',
+          lineHeight: 'unset'
+        },
+        '& .ck-comment:after': {
+          display:"none"
+        },
+        '& .ck-annotation__info-name, & .ck-annotation__info-time, & .ck-comment__input, & .ck-thread__comment-count, & .ck-annotation__main p, & .ck-annotation__info-name, & .ck-annotation__info-time, & .ck-presence-list__counter': {
+          ...commentBodyStyles(theme),
+        },
+        '& .ck-thread__comment-count': {
+          paddingLeft: theme.spacing.unit*2,
+          color: theme.palette.grey[600],
+          margin: 0,
+          paddingBottom: ".5em",
+          '&:before': {
+            content: '"\\25B6"'
+          }
+        },
+        '& .ck-annotation__main, & .ck-comment__input, & .ck-thread__input': {
+          width : "100%"
+        },
+        '& .ck-comment__wrapper': {
+          borderTop: 'solid 1px rgba(0,0,0,.15)',
+        },
+        '& .ck-annotation__info-name, & .ck-annotation__info-time': {
+          color: theme.palette.grey[600],
+          fontSize: "1rem"
+        },
+        '& .ck-annotation__user, & .ck-thread__user': {
+          display: "none"
+        },
+        '--ck-color-comment-count': theme.palette.primary.main,
+      } 
+    }
+  }
+}
+
 export const editorStyles = (theme, styleFunction) => ({
     '& .public-DraftStyleDefault-block': {
       marginTop: '1em',
@@ -228,11 +282,12 @@ export const editorStyles = (theme, styleFunction) => ({
     },
     '& code .public-DraftStyleDefault-block': {
       marginTop: 0,
-      marginBottom: 0,
+      marginBottom: 0,  
     },
     '& blockquote .public-DraftStyleDefault-block': {
       marginTop: 0,
       marginBottom: 0,
     },
-    ...styleFunction(theme)
+    ...styleFunction(theme),
+    ...ckEditorStyles(theme)
 })


### PR DESCRIPTION
First pass attempt the style ckEditor to match our theme. Oli and I had some disagreements about the best way to interface with ckEditor's theme (in most cases I found it much easier to just work directly with the css classes, rather than trying to use ckEditor's variables). 

I expect some followup discussion about the best way to proceed here.