### PR TITLE
PostPreview style tweaks

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -75,16 +75,12 @@ registerComponent('PostLinkPreviewVariantCheck', PostLinkPreviewVariantCheck);
 
 const styles = theme => ({
   link: {
-    position: "relative",
-    marginRight: 12,
-  },
-  indicator: {
-    position: "absolute",
-    width: 20,
-    fontSize: 8,
-    display: "inline-block",
-    color: theme.palette.primary.main,
-    cursor: "pointer",
+    '&:after': {
+      content: '"°"',
+      marginLeft: 2,
+      marginRight: 1,
+      color: theme.palette.primary.main
+    }
   }
 })
 
@@ -106,13 +102,11 @@ const PostLinkCommentPreview = ({href, commentId, post, innerHTML}) => {
 }
 registerComponent('PostLinkCommentPreview', PostLinkCommentPreview);
 
-const siteTwoLetter = getSetting('forumType') === 'EAForum' ? 'EA' : 'LW'
-
 const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, anchorEl, hover}) => {
   const { PostsPreviewTooltip, LWPopper } = Components
   const linkElement = <span className={classes.linkElement}>
       <Link className={classes.link} to={href}>
-        <span dangerouslySetInnerHTML={{__html: innerHTML}}></span>{}<span className={classes.indicator}>{siteTwoLetter}</span>
+        <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
       </Link>
     </span>
   if (!post) {
@@ -143,7 +137,7 @@ const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post,
   const { PostsPreviewTooltip, LWPopper } = Components
   const linkElement = <span className={classes.linkElement}>
       <Link className={classes.link} to={href}>
-        <span dangerouslySetInnerHTML={{__html: innerHTML}}></span>{" "}<span className={classes.indicator}>LW</span>
+        <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
       </Link>
     </span>
 

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -75,11 +75,14 @@ registerComponent('PostLinkPreviewVariantCheck', PostLinkPreviewVariantCheck);
 
 const styles = theme => ({
   link: {
+    position: "relative",
+    marginRight: 6,
     '&:after': {
       content: '"°"',
-      marginLeft: 2,
+      marginLeft: 1,
       marginRight: 1,
-      color: theme.palette.primary.main
+      color: theme.palette.primary.main,
+      position: "absolute"
     }
   }
 })
@@ -104,13 +107,9 @@ registerComponent('PostLinkCommentPreview', PostLinkCommentPreview);
 
 const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, anchorEl, hover}) => {
   const { PostsPreviewTooltip, LWPopper } = Components
-  const linkElement = <span className={classes.linkElement}>
-      <Link className={classes.link} to={href}>
-        <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
-      </Link>
-    </span>
+
   if (!post) {
-    return linkElement;
+    return <Link to={href}  dangerouslySetInnerHTML={{__html: innerHTML}}/>;
   }
   return (
     <span>
@@ -127,7 +126,7 @@ const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, anchorEl, hove
       >
         <PostsPreviewTooltip post={post} showAllinfo wide truncateLimit={900} hideOnMedium={false}/>
       </LWPopper>
-      {linkElement}
+      <Link className={classes.link} to={href}  dangerouslySetInnerHTML={{__html: innerHTML}}/>
     </span>
   );
 }
@@ -135,14 +134,10 @@ registerComponent('PostLinkPreviewWithPost', PostLinkPreviewWithPost, withHover,
 
 const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post, anchorEl, hover}) => {
   const { PostsPreviewTooltip, LWPopper } = Components
-  const linkElement = <span className={classes.linkElement}>
-      <Link className={classes.link} to={href}>
-        <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
-      </Link>
-    </span>
 
   if (!comment) {
-    return linkElement;
+    return <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}}/>
+    ;
   }
   return (
     <span>
@@ -159,7 +154,7 @@ const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post,
       >
         <PostsPreviewTooltip post={post} comment={comment} showAllinfo wide truncateLimit={900} hideOnMedium={false}/>
       </LWPopper>
-      {linkElement}
+      <Link className={classes.link} to={href} dangerouslySetInnerHTML={{__html: innerHTML}}/>
     </span>
   );
 }

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Components, registerComponent, useSingle, getSetting } from 'meteor/vulcan:core';
+import { Components, registerComponent, useSingle } from 'meteor/vulcan:core';
 import { Posts } from '../../lib/collections/posts';
 import { Comments } from '../../lib/collections/comments';
 import { Link } from 'react-router-dom';

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
@@ -30,7 +30,7 @@ const styles = theme => ({
   hideOnMedium: {
     // TODO: figure out more elegant way of handling this breakpoint
     // 
-    // This collection of breakpoints attempts to keep the 
+    // This collection of breakpoints attempts to keep the preview fitting on the page even on 13" monitors and half-screen pages, until it starts looking just silly
     '@media only screen and (max-width: 1350px)': {
       width: 280,
     },

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
@@ -49,6 +49,9 @@ const styles = theme => ({
       width: 550,
     },
   },
+  title: {
+    marginBottom: -6
+  },
   tooltipInfo: {
     fontStyle: "italic",
     ...commentBodyStyles(theme),
@@ -56,7 +59,7 @@ const styles = theme => ({
   },
   highlight: {
     ...postHighlightStyles(theme),
-    marginTop: theme.spacing.unit*2.5,
+    marginTop: theme.spacing.unit*3,
     marginBottom: theme.spacing.unit*2.5,
     wordBreak: 'break-word',
     fontSize: "1.1rem",
@@ -134,7 +137,9 @@ const PostsPreviewTooltip = ({ showAllinfo, post, classes, wide=false, hideOnMed
   const renderCommentCount = showAllinfo && (Posts.getCommentCount(post) > 0)
   const renderWordCount = !comment && (wordCount > 0)
   return <Card className={classNames(classes.root, {[classes.wide]: wide, [classes.hideOnMedium]: hideOnMedium})}>
-      <PostsTitle post={post} tooltip={false} wrap/>
+      <div className={classes.title}>
+        <PostsTitle post={post} tooltip={false} wrap/>
+      </div>
       <div className={classes.tooltipInfo}>
         { getPostCategory(post)}
         { showAllinfo && post.user && <span> by <PostsUserAndCoauthors post={post} simple/></span>}

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.jsx
@@ -30,11 +30,19 @@ const styles = theme => ({
   hideOnMedium: {
     // TODO: figure out more elegant way of handling this breakpoint
     // 
-    // the purpose of this breakpoint is to ensure that the PostsItem hover preview
-    // disappears right as it starts to overlap the post item
+    // This collection of breakpoints attempts to keep the 
     '@media only screen and (max-width: 1350px)': {
-      display: "none"
+      width: 280,
     },
+    '@media only screen and (max-width: 1330px)': {
+      width: 260,
+    },
+    '@media only screen and (max-width: 1300px)': {
+      width: 240,
+    },
+    '@media only screen and (max-width: 1270px)': {
+      display: "none"
+    }
   },
   wide: {
     [theme.breakpoints.down('xs')]: {


### PR DESCRIPTION
– replaces "LW" and "EA" with a degree symbol (°)
– adjusts the breakpoints for hiding and shrinking the home page post previews
– adjusts spacing of the titles on tooltips