### PR TITLE
Fix wrapSpoilerTags

### DIFF
--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -36,11 +36,11 @@ const spoilerStyles = theme => ({
   },
   '& p.spoiler-v2': {
     margin: 0,
-    padding: '0.5em 0em'
+    padding: '0.5em 8px'
   },
   '& .spoilers:hover': {
     color: 'unset',
-    backgroundColor: 'unset',
+    backgroundColor: "rgba(0,0,0,.2)",
     textShadow: 'unset',
     transition: `
       color 0.1s ease-out 0.1s,


### PR DESCRIPTION
This one was surprisingly difficult, largely because of differences between the API I was expecting (jQuery) and the API provided by cheerio (a weird partial reimplementation of jQuery, where not everything works), leading to several false starts. Alas. But it works now.