### PR TITLE
improve spoiler tags (also incidental purging of the fancy links)

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -10,42 +10,6 @@ const monoStack = [
   'monospace'
 ].join(',')
 
-export const linkStyle = ({theme, underlinePosition="97%", background}) => {
-  return ({
-    color: theme.palette.secondary.main,
-    backgroundImage: `linear-gradient(to right, ${theme.palette.secondary.main} 72%, transparent 72%)`,
-    backgroundSize: "4px 1px",
-    backgroundRepeat: "repeat-x",
-    backgroundPosition:  `0% ${underlinePosition}`,
-    textShadow: `
-      .03em 0 ${background || theme.palette.background.default},
-      -.03em 0 ${background || theme.palette.background.default},
-      0 .03em ${background || theme.palette.background.default},
-      0 -.03em ${background || theme.palette.background.default},
-      .06em 0 ${background || theme.palette.background.default},
-      -.06em 0 ${background || theme.palette.background.default},
-      .09em 0 ${background || theme.palette.background.default},
-      -.09em 0 ${background || theme.palette.background.default},
-      .12em 0 ${background || theme.palette.background.default},
-      -.12em 0 ${background || theme.palette.background.default},
-      .15em 0 ${background || theme.palette.background.default},
-      -.15em 0 ${background || theme.palette.background.default}
-    `,
-    textDecoration: "none",
-
-    "*, *:after, &:after, *:before, &:before": {
-        textShadow: "none"
-    },
-  })
-}
-
-export const removeLinkStyle = {
-  color: "unset",
-  backgroundImage: "unset",
-  textShadow: "unset",
-  textDecoration: "unset"
-}
-
 const createLWTheme = (theme) => {
   // Defines sensible typography defaults that can be
   // cleanly overriden

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -141,13 +141,6 @@ const createLWTheme = (theme) => {
         padding: '1rem',
         whiteSpace: 'pre-wrap',
         margin: "1em 0",
-        '& a, & a:hover, & a:active': {
-          ...linkStyle({
-            theme,
-            underlinePosition: (typography.codeblock && typography.codeblock.linkUnderlinePosition) || "97%",
-            background: (typography.codeblock && typography.codeblock.backgroundColor) || grey[100]
-          }),
-        },
       },
       code: {
         fontFamily: monoStack,

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -32,7 +32,6 @@ const serifStack = [
 const palette = {
   primary: {
     main: '#5f9b65',
-    bright: "#45b250"
   },
   secondary: {
     main: '#5f9b65',

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -32,6 +32,7 @@ const serifStack = [
 const palette = {
   primary: {
     main: '#5f9b65',
+    bright: "#45b250"
   },
   secondary: {
     main: '#5f9b65',

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -124,7 +124,7 @@ export const postBodyStyles = (theme) => {
       display: 'none'
     },
     '& a, & a:hover, & a:active': {
-      color: theme.palette.primary.bright || theme.palette.primary.main
+      color: theme.palette.primary.main
     },
   }
 }

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -2,70 +2,51 @@ import { linkStyle, removeLinkStyle } from './createThemeDefaults'
 import deepmerge from 'deepmerge';
 import isPlainObject from 'is-plain-object';
 
-const spoilerStyles = (theme, originalLinkStyle) => ({
+const hideSpoilers = {
+  backgroundColor: 'black',
+  color: 'black',
+  '& a, & a:hover, & a:focus': {
+    ...removeLinkStyle
+  },
+  '& code': {
+    backgroundColor: 'black',
+  }
+}
+
+const spoilerStyles = (theme) => ({
   '& p.spoiler': {
     margin: 0,
   },
   '& .spoiler': {
-    backgroundColor: 'black',
     padding: 8,
-    color: 'black',
     pointerEvents: 'auto',
     minHeight: theme.typography.commentStyle.fontSize,
     '& .public-DraftStyleDefault-block': {
       margin: 0,
+    },
+    '&:not(:hover)': { // using ':not(:hover)' means we don't need to manually reset elements with special colors or backgrounds, instead they just automatically stay the same if we're not hovering
+      ...hideSpoilers,
     }
-  },
-  '&:hover .spoiler': {
-    color: 'white',
   },
   // Note: ".spoiler" is the old class Oli originally used. ".spoilers" is a new class 
   // that is applied in make_editable_callbacks.js to groups of adjaecent spoiler paragraphs.
   // (see the make_editable_callbacks.js file for details)
   '& div.spoilers': {
-    color: 'black',
-    backgroundColor: 'currentColor',
-    transition: 'none',
-    textShadow: 'none',
     margin: '1em 0',
     overflow: 'auto',
-    '& a, & a:hover, & a:focus': {
-      ...removeLinkStyle
+    '&:not(:hover)': {
+      ...hideSpoilers,
     }
-  },
-  '& .spoilers *': {
-    color: 'inherit',
-    border: 'none',
   },
   '& p.spoiler-v2': {
     margin: 0,
-    padding: '0.5em 0em'
-  },
-  '& .spoilers:hover': {
-    color: 'unset',
-    backgroundColor: 'unset',
-    textShadow: 'unset',
-    transition: `
-      color 0.1s ease-out 0.1s,
-      background-color 0.1s ease-out 0.1s,
-      text-shadow 0.1s ease-out 0.1s;
-    `,
-    '& a, & a:hover, & a:focus': {
-      ...originalLinkStyle
-    }
-  },
-  '& .spoilers::selection, & .spoilers ::selection': {
-    color: `#fff`,
-    backgroundColor: `#000`
+    padding: '0.5em 8px'
   },
   '& .spoilers:not(:hover)::selection, & .spoilers:not(:hover) ::selection': {
     backgroundColor: 'transparent'
   },
   '& .spoilers > p:hover ~ p': {
-    backgroundColor: 'black',
-    '& a, & a:hover, & a:focus': {
-      ...removeLinkStyle
-    }
+    ...hideSpoilers
   }
 })
 
@@ -83,7 +64,7 @@ export const postBodyStyles = (theme) => {
     ...theme.typography.body1,
     ...theme.typography.postStyle,
     wordBreak: "break-word",
-    ...spoilerStyles(theme, postLinkStyles),
+    ...spoilerStyles(theme),
     '& pre': {
       ...theme.typography.codeblock
     },
@@ -167,7 +148,8 @@ export const commentBodyStyles = theme => {
     wordBreak: "break-word",
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
-    ...spoilerStyles(theme, commentLinkStyles),
+
+    ...spoilerStyles(theme),
     '& blockquote': {
       ...theme.typography.commentBlockquote,
       ...theme.typography.body2,
@@ -299,6 +281,15 @@ export const editorStyles = (theme, styleFunction) => ({
     '& blockquote .public-DraftStyleDefault-block': {
       marginTop: 0,
       marginBottom: 0,
+    },
+    // Using '*' selectors is a bit dangerous, as is using '!important'
+    // This is necessary to catch spoiler-selectors on 'code' elemenents, as implemented in draft-js, 
+    // which involved nested spans with manually set style attributes, which can't be overwritten except via 'important'
+    //
+    // This selector isn't necessary on rendered posts/comments, just the draft-js editor.
+    // To minimize potential damage from */important it's only applied here.
+    '& .spoiler:not(:hover) *': {
+      backgroundColor: "black !important"
     },
     ...styleFunction(theme),
     ...ckEditorStyles(theme)

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -36,6 +36,9 @@ const spoilerStyles = (theme) => ({
     overflow: 'auto',
     '&:not(:hover)': {
       ...hideSpoilers,
+    },
+    '&:hover': {
+      background: theme.palette.grey[100]
     }
   },
   '& p.spoiler-v2': {
@@ -51,15 +54,6 @@ const spoilerStyles = (theme) => ({
 })
 
 export const postBodyStyles = (theme) => {
-  const postLinkStyles = linkStyle({
-    theme: theme,
-    underlinePosition: ((theme.typography.postStyle?.linkUnderlinePosition) || "97%"),
-    background: (
-      (theme.typography.body1?.backgroundColor) ||
-      (theme.typography.body1?.background) ||
-      "#fff"
-    )
-  })
   return {
     ...theme.typography.body1,
     ...theme.typography.postStyle,
@@ -130,18 +124,12 @@ export const postBodyStyles = (theme) => {
       display: 'none'
     },
     '& a, & a:hover, & a:active': {
-      ...postLinkStyles
+      color: theme.palette.primary.bright || theme.palette.primary.main
     },
   }
 }
 
 export const commentBodyStyles = theme => {
-  const commentLinkStyles = {
-    color: theme.palette.primary.main,
-    backgroundImage: "none",
-    textShadow: "none",
-    textDecoration: "none",
-  }
   const commentBodyStyles = {
     marginTop: ".5em",
     marginBottom: ".25em",
@@ -177,12 +165,6 @@ export const commentBodyStyles = theme => {
       content: '"spoiler (hover/select to reveal)"',
       color: 'white',
     },
-    '& a, & a:hover, & a:active': {
-      ...commentLinkStyles
-    },
-    '& pre code a, & pre code a:hover, & pre code a:active': {
-      ...commentLinkStyles
-    }
   }
   return deepmerge(postBodyStyles(theme), commentBodyStyles, {isMergeableObject:isPlainObject})
 }

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -37,7 +37,7 @@ const spoilerStyles = (theme) => ({
       ...hideSpoilers,
     },
     '&:hover': {
-      background: theme.palette.grey[100]
+      background: 'rgba(0,0,0,.12)' // This leaves a light grey background over the revealed-spoiler to make it more obvious where it started.
     }
   },
   '& p.spoiler-v2': {

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -1,4 +1,3 @@
-import { linkStyle, removeLinkStyle } from './createThemeDefaults'
 import deepmerge from 'deepmerge';
 import isPlainObject from 'is-plain-object';
 
@@ -6,7 +5,7 @@ const hideSpoilers = {
   backgroundColor: 'black',
   color: 'black',
   '& a, & a:hover, & a:focus': {
-    ...removeLinkStyle
+    color: 'black'
   },
   '& code': {
     backgroundColor: 'black',


### PR DESCRIPTION
This PR simplifies how spoiler tags work, while ensuring that they work on codeblocks

It makes a somewhat opinionated decision to not fully support the old spoiler styles (you now have to hover over each individual block to see it, rather than seeing all of it at once), because I thought the upkeep of maintaining the old style wasn't worth it.

...

The Great Sundering of the Fancy Links

I also noticed that Jim's recent update to spoiler backgrounds (leaving the "hovered over" spoiler light-grey to distinguish it from nearby non-spoiler text), didn't work nicely with our dotted-line-links. In a fit of rage, I removed the dotted line links, because they just really didn't seem like they were worth all the headache they've caused.

I experimented with some alternate link-colorings that slightly increased their visibility (because, without the dotted line, the primary.main color wasn't quite visible enough). I tried a new color, but it was too bright. I considered bolding, but I don't like how it changes the emphasis of the sentence.

"very slightly bold" would be okay, but is hard to do without reintroducing as many problems.

In the end, I think "primary.main" is actually just an okay color. It's slightly harder to spot, but not much, and meanwhile might even be net-positive since the normal reading flow is simpler (i.e. links are visible when you look for them but don't super jump out at you)