### PR TITLE
Make the user resolvers respect the checkAccess function

### DIFF
--- a/packages/lesswrong/lib/index.js
+++ b/packages/lesswrong/lib/index.js
@@ -109,12 +109,12 @@ import './collections/posts/helpers.js';
 import Revisions from './collections/revisions/collection.js'
 //
 // Users
+import './collections/users/permissions.js';
 import './collections/users/helpers.js';
 import './collections/users/custom_fields.js';
 import './collections/users/recommendationSettings.js';
 import './collections/users/karmaChangesGraphQL.js';
 import './collections/users/views.js';
-import './collections/users/permissions.js';
 
 // Comments
 import { Comments } from './collections/comments'

--- a/packages/vulcan-core/lib/modules/default_resolvers.js
+++ b/packages/vulcan-core/lib/modules/default_resolvers.js
@@ -69,7 +69,7 @@ export function getDefaultResolvers(options) {
         debug({ selector, options });
 
         const docs = await Connectors.find(collection, selector, options);
-
+        
         // if collection has a checkAccess function defined, remove any documents that doesn't pass the check
         const viewableDocs = collection.checkAccess
           ? _.filter(docs, doc => collection.checkAccess(currentUser, doc))


### PR DESCRIPTION
So, turns out that for import-order reasons, the users collection has a completely separate resolver file, that doesn't share any code with the default resolvers, causing it to not respect the checkAccess function. This hasn't been an issue until now, until I tried to fix the problem where we don't want to show deleted users, and that not working reliably for some reason. 

Ideally we would factor out all the resolver code to also use the default resolvers, but this is the minimal fix that addresses the current problem. 