### PR TITLE
Small fixes to submitToFrontpage

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -15,11 +15,9 @@ import qs from 'qs'
 
 const metaName = getSetting('forumType') === 'EAForum' ? 'Community' : 'Meta'
 
-const NotFPSubmittedWarning = () => <Tooltip
-  title='user did not select "Moderators may promote to Frontpage" option'
->
-  <WarningIcon />
-</Tooltip>
+const NotFPSubmittedWarning = ({className}) => <div className={className}>
+  {' '}<WarningIcon fontSize='inherit' />
+</div>
 
 const styles = theme => ({
   root: {
@@ -34,6 +32,10 @@ const styles = theme => ({
       maxWidth: '80%'
     }
   },
+  promoteWarning: {
+    fontSize: 20,
+    marginLeft: 4,
+  }
 })
 
 class PostActions extends Component {
@@ -158,18 +160,30 @@ class PostActions extends Component {
           <span>
             { !post.meta &&
               <div onClick={this.handleMoveToMeta}>
-                <MenuItem>
-                  Move to {metaName}
-                  {getSetting('forumType') === 'EAForum' && !post.submitToFrontpage && <NotFPSubmittedWarning />}
-                </MenuItem>
+                <Tooltip title={
+                  getSetting('forumType') === 'EAForum' && post.submitToFrontpage ?
+                    '' :
+                    'user did not select "Moderators may promote to Frontpage" option'
+                }>
+                  <MenuItem>
+                    Move to {metaName}
+                    {getSetting('forumType') === 'EAForum' && !post.submitToFrontpage && <NotFPSubmittedWarning className={classes.promoteWarning} />}
+                  </MenuItem>
+                </Tooltip>
               </div>
             }
             { !post.frontpageDate &&
               <div onClick={this.handleMoveToFrontpage}>
-                <MenuItem>
-                  Move to Frontpage
-                  {!post.submitToFrontpage && <NotFPSubmittedWarning />}
-                </MenuItem>
+                <Tooltip title={
+                  post.submitToFrontpage ?
+                    '' :
+                    'user did not select "Moderators may promote to Frontpage" option'
+                }>
+                  <MenuItem>
+                    Move to Frontpage
+                    {!post.submitToFrontpage && <NotFPSubmittedWarning className={classes.promoteWarning} />}
+                  </MenuItem>
+                </Tooltip>
               </div>
             }
             { (post.frontpageDate || post.meta || post.curatedDate) &&

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -1,15 +1,25 @@
 import React, { Component } from 'react'
 import { withStyles } from '@material-ui/core/styles';
-import { registerComponent, Components, withUpdate, withMutation } from 'meteor/vulcan:core';
+import { registerComponent, Components, withUpdate, withMutation, getSetting } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users'
 import withUser from '../../common/withUser'
 import { Posts } from '../../../lib/collections/posts';
 import withSetAlignmentPost from "../../alignment-forum/withSetAlignmentPost";
 import MenuItem from '@material-ui/core/MenuItem';
 import { Link } from '../../../lib/reactRouterWrapper.js';
+import Tooltip from '@material-ui/core/Tooltip';
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import EditIcon from '@material-ui/icons/Edit'
+import WarningIcon from '@material-ui/icons/Warning'
 import qs from 'qs'
+
+const metaName = getSetting('forumType') === 'EAForum' ? 'Community' : 'Meta'
+
+const NotFPSubmittedWarning = () => <Tooltip
+  title='user did not select "Moderators may promote to Frontpage" option'
+>
+  <WarningIcon />
+</Tooltip>
 
 const styles = theme => ({
   root: {
@@ -149,7 +159,8 @@ class PostActions extends Component {
             { !post.meta &&
               <div onClick={this.handleMoveToMeta}>
                 <MenuItem>
-                  Move to Meta
+                  Move to {metaName}
+                  {getSetting('forumType') === 'EAForum' && !post.submitToFrontpage && <NotFPSubmittedWarning />}
                 </MenuItem>
               </div>
             }
@@ -157,6 +168,7 @@ class PostActions extends Component {
               <div onClick={this.handleMoveToFrontpage}>
                 <MenuItem>
                   Move to Frontpage
+                  {!post.submitToFrontpage && <NotFPSubmittedWarning />}
                 </MenuItem>
               </div>
             }

--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.jsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.jsx
@@ -55,9 +55,6 @@ const styles = theme => ({
       paddingRight: theme.spacing.unit*3,
     }
   },
-  checkboxRoot: {
-    display: 'flex',
-  },
   checkboxLabel: {
     fontWeight:500,
     fontFamily: theme.typography.commentStyle.fontFamily,

--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.jsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.jsx
@@ -2,8 +2,40 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
 import Checkbox from '@material-ui/core/Checkbox';
-import { registerComponent } from 'meteor/vulcan:core';
+import { registerComponent, getSetting } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles';
+
+const forumDefaultCheckboxLabels = {
+  LessWrong: 'Moderators may promote to Frontpage',
+  AlignmentForum: 'Moderators may promote to Frontpage',
+  EAForum: 'Moderators may promote to Frontpage or Community'
+}
+
+const defaultCheckboxLabel = forumDefaultCheckboxLabels[getSetting('forumType')]
+
+const defaultTooltipLWAF = ({classes}) => <div className={classes.tooltip}>
+  <p>LW moderators will consider this post for frontpage</p>
+  <p className={classes.guidelines}>Things to aim for:</p>
+  <ul>
+    <li className={classes.guidelines}>
+      Usefulness, novelty and fun
+    </li>
+    <li className={classes.guidelines}>
+      Timeless content (minimize reference to current events)
+    </li>
+    <li className={classes.guidelines}>
+      Explain rather than persuade
+    </li>
+  </ul>
+</div>
+
+const forumDefaultTooltip = {
+  LessWrong: defaultTooltipLWAF,
+  AlignmentForum: defaultTooltipLWAF,
+  EAForum: () => "Uncheck this box if you want your post to stay on your personal blog."
+}
+
+const defaultTooltip = forumDefaultTooltip[getSetting('forumType')]
 
 const styles = theme => ({
   submitToFrontpageWrapper: {
@@ -23,12 +55,16 @@ const styles = theme => ({
       paddingRight: theme.spacing.unit*3,
     }
   },
+  checkboxRoot: {
+    display: 'flex',
+  },
   checkboxLabel: {
     fontWeight:500,
     fontFamily: theme.typography.commentStyle.fontFamily,
     fontSize: 16,
     color: "rgba(0,0,0,0.4)",
-    verticalAlign: 'middle'
+    verticalAlign: 'middle',
+    lineHeight: '1.25em'
   },
   tooltip: {
     '& ul': {
@@ -66,31 +102,15 @@ class SubmitToFrontpageCheckbox extends Component {
   }
 
   render() {
-    const { classes, label="Moderators may promote", tooltip } = this.props
+    const { classes, label=defaultCheckboxLabel, tooltip } = this.props
 
-    const displayedTooltip = tooltip || <div className={classes.tooltip}>
-      <p>LW moderators will consider this post for frontpage</p>
-      <p className={classes.guidelines}>Things to aim for:</p>
-      <ul>
-        <li className={classes.guidelines}>
-          Usefulness, novelty and fun
-        </li>
-        <li className={classes.guidelines}>
-          Timeless content (minimize reference to current events)
-        </li>
-        <li className={classes.guidelines}>
-          Explain rather than persuade
-        </li>
-      </ul>
-    </div>
+    const displayedTooltip = tooltip || defaultTooltip({classes})
 
     return <div className={classes.submitToFrontpageWrapper}>
       <Tooltip title={displayedTooltip}>
         <div className={classes.submitToFrontpage}>
-          <div>
-            <Checkbox checked={this.getCurrentValue()} onClick={this.handleClick}/>
-            <span className={classes.checkboxLabel}>{label}</span>
-          </div>
+          <Checkbox checked={this.getCurrentValue()} onClick={this.handleClick}/>
+          <span className={classes.checkboxLabel}>{label}</span>
         </div>
       </Tooltip>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, withUpdate } from 'meteor/vulcan:core';
+import { Components, registerComponent, withUpdate, getSetting } from 'meteor/vulcan:core';
 import React, { Component } from 'react';
 import { Posts } from '../../lib/collections/posts';
 import Users from 'meteor/vulcan:users';
@@ -22,12 +22,16 @@ class SunshineNewPostsItem extends Component {
     })
   }
 
-  handleFrontpage = () => {
+  handlePromote = destination => () => {
     const { currentUser, post, updatePost } = this.props
+    destinationData = {
+      'frontpage': {frontpageDate: new Date()},
+      'community': {meta: true}
+    }[destination]
     updatePost({
       selector: { _id: post._id},
       data: {
-        frontpageDate: new Date(),
+        ...destinationData,
         reviewedByUserId: currentUser._id,
         authorIsUnreviewed: false
       },
@@ -97,8 +101,11 @@ class SunshineNewPostsItem extends Component {
           <Components.SidebarAction title="Leave on Personal Blog" onClick={this.handleReview}>
             done
           </Components.SidebarAction>
-          {post.submitToFrontpage && <Components.SidebarAction title="Move to Frontpage" onClick={this.handleFrontpage}>
+          {post.submitToFrontpage && <Components.SidebarAction title="Move to Frontpage" onClick={this.handlePromote('frontpage')}>
             thumb_up
+          </Components.SidebarAction>}
+          {getSetting('forumType') === 'EAForum' && post.submitToFrontpage && <Components.SidebarAction title="Move to Community" onClick={this.handlePromote('community')}>
+            group
           </Components.SidebarAction>}
           <Components.SidebarAction title="Move to Drafts" onClick={this.handleDelete} warningHighlight>
             clear

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
@@ -24,7 +24,7 @@ class SunshineNewPostsItem extends Component {
 
   handlePromote = destination => () => {
     const { currentUser, post, updatePost } = this.props
-    destinationData = {
+    const destinationData = {
       'frontpage': {frontpageDate: new Date()},
       'community': {meta: true}
     }[destination]

--- a/packages/lesswrong/lib/collections/users/helpers.js
+++ b/packages/lesswrong/lib/collections/users/helpers.js
@@ -39,6 +39,20 @@ Users.canEditUsersBannedUserIds = (currentUser, targetUser) => {
   )
 }
 
+const postHasModerationGuidelines = post => {
+  // Because of a bug in Vulcan that doesn't adequately deal with nested fields
+  // in document validation, we check for originalContents instead of html here,
+  // which causes some problems with empty strings, but should overall be fine
+  return post.moderationGuidelines?.originalContents || post.moderationStyle
+}
+
+const isPersonalBlogpost = post => {
+  if (getSetting('forumType') === 'EAForum') {
+    return !(post.frontpageDate || post.meta)
+  }
+  return !post.frontpageDate
+}
+
 Users.canModeratePost = (user, post) => {
   if (Users.canDo(user,"posts.moderate.all")) {
     return true
@@ -46,25 +60,29 @@ Users.canModeratePost = (user, post) => {
   if (!user || !post) {
     return false
   }
+  // Users who can moderate their personal posts can moderate any post that
+  // meets all of the following:
+  //  1) they own
+  //  2) has moderation guidelins
+  //  3) is not on the frontpage
+  if (
+    Users.canDo(user, "posts.moderate.own.personal") &&
+    Users.owns(user, post) &&
+    postHasModerationGuidelines &&
+    isPersonalBlogpost
+  ) {
+    return true
+  }
+  // Users who can moderate all of their own posts (even those on the frontpage)
+  // can moderate any post that meets all of the following:
+  //  1) they own
+  //  2) has moderation guidelines
+  // We have now checked all the possible conditions for posting, if they fail
+  // this, check they cannot moderate this post
   return !!(
-    (
-      Users.canDo(user,"posts.moderate.own") &&
-      Users.owns(user, post) &&
-      // Because of a bug in Vulcan that doesn't adequately deal with nested fields in document validation,
-      // we check for originalContents instead of html here, which causes some problems with empty strings, but 
-      // should overall be fine
-    ((post.moderationGuidelines?.originalContents) || post.moderationStyle)
-    )
-    ||
-    (
-      Users.canDo(user, "posts.moderate.own.personal") &&
-      Users.owns(user, post) &&
-      // Because of a bug in Vulcan that doesn't adequately deal with nested fields in document validation,
-      // we check for originalContents instead of html here, which causes some problems with empty strings, but 
-      // should overall be fine
-      ((post.moderationGuidelines?.originalContents) || post.moderationStyle) &&
-      !post.frontpageDate
-    )
+    Users.canDo(user,"posts.moderate.own") &&
+    Users.owns(user, post) &&
+    postHasModerationGuidelines(post)
   )
 }
 

--- a/packages/lesswrong/lib/collections/users/helpers.js
+++ b/packages/lesswrong/lib/collections/users/helpers.js
@@ -68,8 +68,8 @@ Users.canModeratePost = (user, post) => {
   if (
     Users.canDo(user, "posts.moderate.own.personal") &&
     Users.owns(user, post) &&
-    postHasModerationGuidelines &&
-    isPersonalBlogpost
+    postHasModerationGuidelines(post) &&
+    isPersonalBlogpost(post)
   ) {
     return true
   }

--- a/packages/lesswrong/themes/eaTheme.js
+++ b/packages/lesswrong/themes/eaTheme.js
@@ -237,11 +237,6 @@ const theme = createLWTheme({
         color: grey[800]
       }
     },
-    PostLinkPreviewWithPost: {
-      indicator: {
-        bottom: 3
-      }
-    },
     CommentPermalink: {
       root: {
         marginBottom: 24


### PR DESCRIPTION
 - Moderators may promote get's a few extra words[1] and css styling is changed
 - EA Forum gets a "move to community" button in the classification sidebar
 - If you want to classify a post through the post menu items, there's now a warning if the user doesn't want that
 - Not related to submitToFrontpage, the EA Forum gets a check so that people can moderate their personal blog without moderating the Community page

[1] My guess is that y'all would have had the full "Moderators may submit to frontpage" if it weren't for how ugly it looked to have it wrap below the checkbox. I fixed it so it doesn't wrap below the checkbox, so I have submitted the suggested new wording, feel free to revert it.