### PR TITLE
Maybe fix curation emails

### DIFF
--- a/packages/lesswrong/server/emailComponents/NewPostEmail.jsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.jsx
@@ -27,6 +27,7 @@ const styles = theme => ({
 
 const NewPostEmail = ({document, classes, reason}) => {
   const { EmailPostAuthors, EmailFormatDate } = Components;
+  if (!document) return null;
   return (<React.Fragment>
     <div className={classes.heading}>
       <h1>


### PR DESCRIPTION
In `NewPostEmail`, there was a missing check for null. The post is never null, but the `withDocument` can in principle be in a loading state. Prior to the Apollo major version upgrade, this never happened; prerendering got the document and provided it on the first pass. After the Apollo major version upgrade, it seems this broke.

This should have been very obvious in Sentry; `sendPostByEmail` in `notificationCallbacks.js` calls `Sentry.captureException` once per failed email, which should be a lot. But somehow, this only generates a single Sentry error, so it blended in; I was able to find it by searching by time range for exactly when the email should've gone out. (Here it is: https://sentry.io/organizations/lesswrong/issues/1167078516/events/22a7a559afb444709a3cae38aa9f1806/?end=2019-10-02T18%3A53%3A40&environment=production&project=1301611&start=2019-10-02T18%3A52%3A21 . Note that the metadata is mostly incorrect, an artifact of Sentry interacting poorly with Meteor fibers.) So it looks like Sentry may have been discarding the errors because they looked too similar to each other, which is... very bad.