### PR TITLE
Add theming to emails

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsList.jsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.jsx
@@ -7,11 +7,15 @@ class RecommendationsList extends Component {
   render() {
     const { recommendations, recommendationsLoading } = this.props;
     const { PostsItem2, PostsLoading, SectionFooter, LoginPopupButton } = Components;
+    
+    const nameWithArticle = getSetting('siteNameWithArticle')
+    const capitalizedName = nameWithArticle.charAt(0).toUpperCase() + nameWithArticle.slice(1)
+
     if (recommendationsLoading || !recommendations)
       return <PostsLoading/>
     
     const improvedRecommendationsTooltip = <div>
-      {getSetting('forumType', 'LessWrong') !== 'LessWrong' && 'The '}{getSetting('title')} keeps track of what recommended posts logged-in users have read. Login to get recommended posts you haven't read before.
+      {capitalizedName} keeps track of what recommended posts logged-in users have read. Login to get recommended posts you haven't read before.
     </div>
 
     return <div>
@@ -32,4 +36,3 @@ registerComponent('RecommendationsList', RecommendationsList,
   withRecommendations,
   withUser
 );
-

--- a/packages/lesswrong/lib/registerSettings.js
+++ b/packages/lesswrong/lib/registerSettings.js
@@ -25,7 +25,7 @@ registerSetting('forum.outsideLinksPointTo', 'link', 'Whether to point RSS links
 registerSetting('forum.requirePostsApproval', false, 'Require posts to be approved manually');
 registerSetting('twitterAccount', null, 'Twitter account associated with the app');
 registerSetting('siteUrl', null, 'Main site URL');
-registerSetting('siteNameWithArticle', 'LessWrong', 'Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum. Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.')
+registerSetting('siteNameWithArticle', 'LessWrong', 'Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum". Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.')
 
 // posts/schema.js
 registerSetting('forum.postExcerptLength', 30, 'Length of posts excerpts in words');

--- a/packages/lesswrong/lib/registerSettings.js
+++ b/packages/lesswrong/lib/registerSettings.js
@@ -25,6 +25,7 @@ registerSetting('forum.outsideLinksPointTo', 'link', 'Whether to point RSS links
 registerSetting('forum.requirePostsApproval', false, 'Require posts to be approved manually');
 registerSetting('twitterAccount', null, 'Twitter account associated with the app');
 registerSetting('siteUrl', null, 'Main site URL');
+registerSetting('siteNameWithArticle', 'LessWrong', 'Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum. Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary')
 
 // posts/schema.js
 registerSetting('forum.postExcerptLength', 30, 'Length of posts excerpts in words');

--- a/packages/lesswrong/lib/registerSettings.js
+++ b/packages/lesswrong/lib/registerSettings.js
@@ -25,7 +25,7 @@ registerSetting('forum.outsideLinksPointTo', 'link', 'Whether to point RSS links
 registerSetting('forum.requirePostsApproval', false, 'Require posts to be approved manually');
 registerSetting('twitterAccount', null, 'Twitter account associated with the app');
 registerSetting('siteUrl', null, 'Main site URL');
-registerSetting('siteNameWithArticle', 'LessWrong', 'Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum. Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary')
+registerSetting('siteNameWithArticle', 'LessWrong', 'Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum. Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.')
 
 // posts/schema.js
 registerSetting('forum.postExcerptLength', 30, 'Length of posts excerpts in words');

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerComponent } from 'meteor/vulcan:core';
+import { registerComponent, getSetting } from 'meteor/vulcan:core';
 import { Utils } from 'meteor/vulcan:lib';
 import { withStyles } from '@material-ui/core/styles';
 import { emailBodyStyles } from '../../themes/stylePiping'
@@ -13,6 +13,7 @@ const styles = theme => ({
 // wrapper.handlebars in Vulcan-Starter.
 const EmailWrapper = ({user, unsubscribeAllLink, children, classes}) => {
   const accountLink = `${Utils.getSiteUrl()}account`
+  const siteNameWithArticle = getSetting('siteNameWithArticle')
   
   return (
     <body bgcolor="white" leftmargin="0" topmargin="0" marginWidth="0" marginHeight="0">
@@ -34,7 +35,8 @@ const EmailWrapper = ({user, unsubscribeAllLink, children, classes}) => {
                 </tr>
                 <tr><td>
                   <br/><br/>
-    <a href={unsubscribeAllLink}>Unsubscribe</a> (from all emails from LessWrong) {/* TODO; */}
+                  <a href={unsubscribeAllLink}>Unsubscribe</a>
+                  (from all emails from {siteNameWithArticle})
                   or <a href={accountLink}>Change your notifications settings</a><br/><br/>
                 </td></tr>
               </table>

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
@@ -1,41 +1,52 @@
 import React from 'react';
 import { registerComponent } from 'meteor/vulcan:core';
 import { Utils } from 'meteor/vulcan:lib';
+import { withStyles } from '@material-ui/core/styles';
+import { emailBodyStyles } from '../../themes/stylePiping'
+
+const styles = theme => ({
+  root: emailBodyStyles(theme)
+})
 
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-const EmailWrapper = ({user, unsubscribeAllLink, children}) => {
+const EmailWrapper = ({user, unsubscribeAllLink, children, classes}) => {
   const accountLink = `${Utils.getSiteUrl()}account`
   
   return (
     <body bgcolor="white" leftmargin="0" topmargin="0" marginWidth="0" marginHeight="0">
       <br/>
-      
+
       {/* 100% wrapper */}
-      <table border="0" width="100%" height="100%" cellPadding="0" cellSpacing="0" bgcolor="#ffffff">
-        <tr>
-          <td className="wrapper" align="center" valign="top" bgcolor="#ffffff" style={{"backgroundColor": "#ffffff"}}>
-      
-            {/* 600px container (white background) */}
-            <table border="0" width="600" cellPadding="0" cellSpacing="0" className="container" bgcolor="#ffffff">
-              <tr>
-                <td className="main-container container-padding" bgcolor="#ffffff">
-                  <br/>
-                  {children}
-                </td>
-              </tr>
-              <tr><td>
-                <a href={unsubscribeAllLink}>Unsubscribe</a> (from all emails from LessWrong)
-                or <a href={accountLink}>Change your notifications settings</a><br/><br/>
-              </td></tr>
-            </table>
-          </td>
-        </tr>
-      </table>
+      <div className={classes.root}>
+        <table border="0" width="100%" height="100%" cellPadding="0" cellSpacing="0" bgcolor="#ffffff">
+          <tr>
+            <td className="wrapper" align="center" valign="top" bgcolor="#ffffff" style={{"backgroundColor": "#ffffff"}}>
+
+              {/* 600px container (white background) */}
+              <table border="0" width="600" cellPadding="0" cellSpacing="0" className="container" bgcolor="#ffffff">
+                <tr>
+                  <td className="main-container container-padding" bgcolor="#ffffff">
+                    <br/>
+                    {children}
+                  </td>
+                </tr>
+                <tr><td>
+                  <br/><br/>
+    <a href={unsubscribeAllLink}>Unsubscribe</a> (from all emails from LessWrong) {/* TODO; */}
+                  or <a href={accountLink}>Change your notifications settings</a><br/><br/>
+                </td></tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
       <br/><br/>
     </body>
   );
 }
 
-registerComponent("EmailWrapper", EmailWrapper);
+registerComponent("EmailWrapper", EmailWrapper,
+  withStyles(styles, {name: 'EmailWrapper'})
+);

--- a/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.jsx
+++ b/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.jsx
@@ -12,13 +12,13 @@ const styles = theme => ({
 
 const PrivateMessagesEmail = ({conversation, messages, participantsById, classes}) => {
   const { EmailUsername, EmailFormatDate } = Components;
-  const sitename = getSetting('title');
+  const siteNameWithArticle = getSetting('siteNameWithArticle')
   const conversationLink = Conversations.getPageUrl(conversation, true);
   
   return (<React.Fragment>
     <p>
       You received {messages.length>1 ? "private messages" : "a private message"}.
-      {" "}<a href={conversationLink}>View this conversation on {sitename}</a>.
+      {" "}<a href={conversationLink}>View this conversation on {siteNameWithArticle}</a>.
     </p>
     
     {messages.map((message,i) => <div className={classes.message} key={i}>

--- a/packages/lesswrong/server/emails/renderEmail.js
+++ b/packages/lesswrong/server/emails/renderEmail.js
@@ -58,9 +58,6 @@ const emailGlobalCss = `
   }
   
   /* Global styles that apply eg inside of posts */
-  a {
-    color: #5f9b65;
-  }
   blockquote {
     border-left: solid 3px #e0e0e0;
     padding: .75em 2em;
@@ -209,7 +206,7 @@ export async function sendEmail(renderedEmail)
     
     Email.send(renderedEmail); // From meteor's 'email' package
   } else {
-    console.log("//////// Pretending to send email (not production and enableDevelopmentEmails is false)"); //eslint-disable-line
+    console.log("//////// Pretending to send email"); //eslint-disable-line
     console.log("to: " + renderedEmail.to); //eslint-disable-line
     console.log("subject: " + renderedEmail.subject); //eslint-disable-line
     console.log("//////// HTML version"); //eslint-disable-line

--- a/packages/lesswrong/server/emails/renderEmail.js
+++ b/packages/lesswrong/server/emails/renderEmail.js
@@ -206,7 +206,7 @@ export async function sendEmail(renderedEmail)
     
     Email.send(renderedEmail); // From meteor's 'email' package
   } else {
-    console.log("//////// Pretending to send email"); //eslint-disable-line
+    console.log("//////// Pretending to send email (not production and enableDevelopmentEmails is false)"); //eslint-disable-line
     console.log("to: " + renderedEmail.to); //eslint-disable-line
     console.log("subject: " + renderedEmail.subject); //eslint-disable-line
     console.log("//////// HTML version"); //eslint-disable-line

--- a/packages/lesswrong/server/notificationCallbacks.js
+++ b/packages/lesswrong/server/notificationCallbacks.js
@@ -308,11 +308,6 @@ async function sendPrivateMessagesEmail(conversationId, messageIds) {
   
   for (const recipientUser of participants)
   {
-    // TODO: Gradual rollout--only email admins with this. Remove later when
-    // this is more tested.
-    if (!Users.isAdmin(recipientUser))
-      continue;
-    
     // If this user is responsible for every message that would be in the
     // email, don't send it to them (you only want emails that contain at
     // least one message that's not your own; your own messages are optional

--- a/packages/lesswrong/server/notificationCallbacks.js
+++ b/packages/lesswrong/server/notificationCallbacks.js
@@ -353,7 +353,7 @@ const privateMessagesDebouncer = new EventDebouncer({
   callback: sendPrivateMessagesEmail
 });
 
-function messageNewNotification(message) {
+async function messageNewNotification(message) {
   const conversationId = message.conversationId;
   const conversation = Conversations.findOne(conversationId);
   
@@ -367,7 +367,7 @@ function messageNewNotification(message) {
   createNotifications(recipients, 'newMessage', 'message', message._id);
   
   // Generate debounced email notifications
-  privateMessagesDebouncer.recordEvent({
+  await privateMessagesDebouncer.recordEvent({
     key: conversationId,
     data: message._id,
     af: conversation.af,

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -52,54 +52,61 @@ const spoilerStyles = (theme) => ({
   }
 })
 
-export const postBodyStyles = (theme) => {
-  return {
+const baseBodyStyles = theme => ({
+  ...theme.typography.body1,
+  ...theme.typography.postStyle,
+  wordBreak: "break-word",
+  '& pre': {
+    ...theme.typography.codeblock
+  },
+  '& code': {
+    ...theme.typography.code
+  },
+  '& blockquote': {
+    ...theme.typography.blockquote,
+    ...theme.typography.body1,
+    ...theme.typography.postStyle
+  },
+  '& li': {
+    ...theme.typography.body1,
+    ...theme.typography.li,
+    ...theme.typography.postStyle
+  },
+  '& h1': {
+    ...theme.typography.display2,
+    ...theme.typography.postStyle
+  },
+  '& h2': {
+    ...theme.typography.display1,
+    ...theme.typography.postStyle,
+  },
+  '& h3': {
+    ...theme.typography.display1,
+    ...theme.typography.postStyle,
+  },
+  '& h4': {
     ...theme.typography.body1,
     ...theme.typography.postStyle,
-    wordBreak: "break-word",
+    fontWeight:600,
+  },
+  '& img': {
+    maxWidth: "100%"
+  },
+  '& sup': {
+    verticalAlign: 'baseline',
+    top: '-0.6em',
+    fontSize: '65%',
+    position: 'relative'
+  },
+  '& a, & a:hover, & a:active': {
+    color: theme.palette.primary.main
+  },
+})
+
+export const postBodyStyles = (theme) => {
+  return {
+    ...baseBodyStyles,
     ...spoilerStyles(theme),
-    '& pre': {
-      ...theme.typography.codeblock
-    },
-    '& code': {
-      ...theme.typography.code
-    },
-    '& blockquote': {
-      ...theme.typography.blockquote,
-      ...theme.typography.body1,
-      ...theme.typography.postStyle
-    },
-    '& li': {
-      ...theme.typography.body1,
-      ...theme.typography.li,
-      ...theme.typography.postStyle
-    },
-    '& h1': {
-      ...theme.typography.display2,
-      ...theme.typography.postStyle
-    },
-    '& h2': {
-      ...theme.typography.display1,
-      ...theme.typography.postStyle,
-    },
-    '& h3': {
-      ...theme.typography.display1,
-      ...theme.typography.postStyle,
-    },
-    '& h4': {
-      ...theme.typography.body1,
-      ...theme.typography.postStyle,
-      fontWeight:600,
-    },
-    '& img': {
-      maxWidth: "100%"
-    },
-    '& sup': {
-      verticalAlign: 'baseline',
-      top: '-0.6em',
-      fontSize: '65%',
-      position: 'relative'
-    },
     // Used for R:A-Z imports as well as markdown-it-footnotes
     '& .footnotes': {
       marginTop: 40,
@@ -121,9 +128,6 @@ export const postBodyStyles = (theme) => {
     // Hiding the footnote-separator that markdown-it adds by default
     '& .footnotes-sep': {
       display: 'none'
-    },
-    '& a, & a:hover, & a:active': {
-      color: theme.palette.primary.main
     },
   }
 }
@@ -167,6 +171,9 @@ export const commentBodyStyles = theme => {
   }
   return deepmerge(postBodyStyles(theme), commentBodyStyles, {isMergeableObject:isPlainObject})
 }
+
+// Currently emails have only the basics
+export const emailBodyStyles = baseBodyStyles
 
 export const postHighlightStyles = theme => {
   const postHighlightStyles = {


### PR DESCRIPTION
Emails on the EA Forum were coming out green. We now pull email theming from the forumTheme file through the stylePiping file.

Also introduce a `siteNameWithArticle` setting. To quote:
> Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum".

**Note that this requires y'all to set this setting for the Alignment Forum**

Finally, I was surprised to learn that only admins are receiving the message notification emails. Given that they're pretty useful for users who don't check the site as often as the most core power users, I suggest through this PR that we enable them for all users.