### PR TITLE
Fix editor switching bugs

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -357,10 +357,11 @@ class EditorFormComponent extends Component {
   renderEditorWarning = () => {
     const { classes, currentUser, document, fieldName, value } = this.props
     const { type } = (value && value.originalContents) || (document[fieldName] && document[fieldName].originalContents) || {}
+    const defaultType = this.getUserDefaultEditor(currentUser)
     return <Typography variant="body2" color="error">
       This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(this.getUserDefaultEditor(currentUser))}> Click here </a>
-      to switch to {this.getUserDefaultEditor(currentUser)} editor (your default editor).
+      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(defaultType)}> Click here </a>
+      to switch to {defaultType} editor (your default editor).
     </Typography>
   }
 

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -132,7 +132,7 @@ class EditorFormComponent extends Component {
         ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(value.originalContents.data) : null
       }
     }
-
+    
     // Otherwise, just set it to the value of the document
     const { draftJS, html, markdown, ckEditorMarkup } = document[fieldName] || {}
     return {
@@ -357,9 +357,9 @@ class EditorFormComponent extends Component {
   renderEditorWarning = () => {
     const { classes, currentUser, document, fieldName, value } = this.props
     const { type } = (value && value.originalContents) || (document[fieldName] && document[fieldName].originalContents) || {}
-    return <Typography variant="body2" color="primary">
+    return <Typography variant="body2" color="error">
       This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride()}> Click here </a>
+      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(type)}> Click here </a>
       to switch to {this.getUserDefaultEditor(currentUser)} editor (your default editor).
     </Typography>
   }

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -359,7 +359,7 @@ class EditorFormComponent extends Component {
     const { type } = (value && value.originalContents) || (document[fieldName] && document[fieldName].originalContents) || {}
     return <Typography variant="body2" color="error">
       This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(type)}> Click here </a>
+      <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(this.getUserDefaultEditor(currentUser))}> Click here </a>
       to switch to {this.getUserDefaultEditor(currentUser)} editor (your default editor).
     </Typography>
   }


### PR DESCRIPTION
– makes the "you last edited in a different editor" red, so that the "click here" button can actually stand out as a click-target. (I'm not attached to this color scheme, it was just the easiest one I could do that worked with minimal changes)

– I added the editor type to the handleEditorOverride function, so that it'd actually fetch the corresponding editor data instead of deleting everything. But this seems like a weird thing to have existed in the first place and I notice I'm confused. @Discordius thoughts?