### PR TITLE
Multi line hover preview bug

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -150,10 +150,10 @@ const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, anchorEl, hove
       <LWPopper 
         open={hover} 
         anchorEl={anchorEl} 
-        placement="bottom"
+        placement="bottom-start"
         modifiers={{
           flip: {
-            behavior: ["bottom", "top", "bottom"],
+            behavior: ["bottom-start", "top-end", "bottom-start"],
             boundariesElement: 'viewport'
           }
         }}
@@ -181,7 +181,7 @@ const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post,
         placement="bottom"
         modifiers={{
           flip: {
-            behavior: ["bottom", "top", "bottom"],
+            behavior: ["bottom-start", "top-end", "bottom-start"],
             boundariesElement: 'viewport'
           } 
         }}
@@ -214,7 +214,7 @@ const DefaultPreview = ({classes, href, innerHTML, anchorEl, hover, onsite=false
   const { LWPopper } = Components
   return (
     <span>
-      <LWPopper open={hover} anchorEl={anchorEl} placement="bottom">
+      <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
         <Card>
           <div className={classes.hovercard}>
             {href}

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -178,7 +178,7 @@ const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post,
       <LWPopper 
         open={hover} 
         anchorEl={anchorEl} 
-        placement="bottom"
+        placement="bottom-start"
         modifiers={{
           flip: {
             behavior: ["bottom-start", "top-end", "bottom-start"],


### PR DESCRIPTION
Left-aligns hover-previews, rather than center-aligns, so that it's always technically possible to mouse over them (even when split awkwardly over two lines)

This will be important once we put bookmark-buttons on hover previews

![image](https://user-images.githubusercontent.com/3246710/66514223-8b50da00-ea91-11e9-9715-972b359a11bd.png)
