### PR TITLE
Form UI rework + migrating icons away from font

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -84,7 +84,7 @@ export const styles = theme => ({
     fontSize: 12,
   },
   replyForm: {
-    marginTop: 15,
+    marginTop: 2,
     padding: 10,
     border: "solid 1px rgba(0,0,0,.2)",
   },

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -85,6 +85,7 @@ export const styles = theme => ({
   },
   replyForm: {
     marginTop: 2,
+    marginBottom: 8,
     padding: 10,
     border: "solid 1px rgba(0,0,0,.2)",
   },

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles'
 import { Link } from '../../../lib/reactRouterWrapper.js';
-import Icon from '@material-ui/core/Icon';
+import LinkIcon from '@material-ui/icons/Link';
 import { Comments } from "../../../lib/collections/comments";
 import classNames from 'classnames';
 import { useNavigation, useLocation } from '../../../lib/routeUtil';
@@ -48,7 +48,7 @@ const CommentsItemDate = ({comment, post, showPostTitle, classes, scrollOnClick,
 
   const date = <span>
     <Components.FormatDate date={comment.postedAt} format={comment.answer && "MMM DD, YYYY"}/>
-    <Icon className={classNames("material-icons", classes.icon)}> link </Icon>
+    <LinkIcon className={classNames("material-icons", classes.icon)}/>
     {showPostTitle && post.title && <span className={classes.postTitle}> {post.draft && "[Draft]"} {post.title}</span>}
   </span>
 

--- a/packages/lesswrong/components/common/SearchBar.jsx
+++ b/packages/lesswrong/components/common/SearchBar.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import { InstantSearch, SearchBox, connectMenu } from 'react-instantsearch-dom';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
-import Icon from '@material-ui/core/Icon'
+import SearchIcon from '@material-ui/icons/Search';
+import CloseIcon from '@material-ui/icons/Close';
 import Portal from '@material-ui/core/Portal';
 import { addCallback, removeCallback } from 'meteor/vulcan:lib';
 import { withLocation } from '../../lib/routeUtil';
@@ -193,11 +194,11 @@ class SearchBar extends Component {
             {alignmentForum && <VirtualMenu attribute="af" defaultRefinement="true" />}
             {userRefinement && <VirtualMenu attribute='authorSlug' defaultRefinement={userRefinement} />}
             <div onClick={this.handleSearchTap}>
-              <Icon className={classes.searchIcon}>search</Icon>
+              <SearchIcon className={classes.searchIcon}/>
               { inputOpen && <SearchBox reset={null} focusShortcuts={[]} autoFocus={true} /> }
             </div>
             { searchOpen && <div className={classes.searchBarClose} onClick={this.closeSearch}>
-              <Icon className={classes.closeSearchIcon}>close</Icon>
+              <CloseIcon className={classes.closeSearchIcon}/>
             </div>}
             <div>
               { searchOpen && <Portal container={searchResultsArea.current}>

--- a/packages/lesswrong/components/editor/EditUrl.jsx
+++ b/packages/lesswrong/components/editor/EditUrl.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { registerComponent } from 'meteor/vulcan:core';
-import Icon from '@material-ui/core/Icon';
 import { withStyles } from '@material-ui/core/styles';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import classNames from 'classnames'
 import Input from '@material-ui/core/Input';
+import LinkIcon from '@material-ui/icons/Link'
+import LinkOffIcon from '@material-ui/icons/LinkOff';
 
 const styles = theme => ({
   root: {
@@ -57,10 +58,10 @@ class EditUrl extends Component {
     const { classes, document, path, defaultValue, label, hintText, placeholder } = this.props;
     
     const startAdornmentInactive = <InputAdornment className={classes.button} onClick={this.toggleEditor} position="start">
-      <Icon>link</Icon>
+      <LinkIcon/>
     </InputAdornment>
     const startAdornmentActive = <InputAdornment className={classes.button} onClick={this.toggleEditor} position="start">
-      <Icon>link_off</Icon></InputAdornment>
+      <LinkOffIcon/></InputAdornment>
     
     return (
       <div className={classes.root}>

--- a/packages/lesswrong/components/messaging/ConversationPage.jsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.jsx
@@ -15,6 +15,9 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import { Link } from '../../lib/reactRouterWrapper.js';
 
 const styles = theme => ({
+  conversationSection: {
+    maxWidth: 550,
+  },
   conversationTitle: {
     ...theme.typography.commentStyle,
     marginTop: theme.spacing.unit,
@@ -51,22 +54,24 @@ class ConversationPage extends Component {
 
     return (
       <SingleColumnSection>
-        <Typography variant="body2" className={classes.backButton}><Link to="/inbox"> Go back to Inbox </Link></Typography>
-        <Typography variant="display2" className={classes.conversationTitle}>
-          { Conversations.getTitle(conversation, currentUser)}
-        </Typography>
-        <ConversationDetails conversation={conversation}/>
-        {this.renderMessages(results, currentUser)}
-        <div className={classes.editor}>
-          <WrappedSmartForm
-            collection={Messages}
-            prefilledProps={ {conversationId: conversation._id} }
-            mutationFragment={getFragment("messageListFragment")}
-            errorCallback={(message) => {
-              //eslint-disable-next-line no-console
-              console.error("Failed to send", message)
-            }}
-          />
+        <div className={classes.conversationSection}>
+          <Typography variant="body2" className={classes.backButton}><Link to="/inbox"> Go back to Inbox </Link></Typography>
+          <Typography variant="display2" className={classes.conversationTitle}>
+            { Conversations.getTitle(conversation, currentUser)}
+          </Typography>
+          <ConversationDetails conversation={conversation}/>
+          {this.renderMessages(results, currentUser)}
+          <div className={classes.editor}>
+            <WrappedSmartForm
+              collection={Messages}
+              prefilledProps={ {conversationId: conversation._id} }
+              mutationFragment={getFragment("messageListFragment")}
+              errorCallback={(message) => {
+                //eslint-disable-next-line no-console
+                console.error("Failed to send", message)
+              }}
+            />
+          </div>
         </div>
       </SingleColumnSection>
     )

--- a/packages/lesswrong/components/posts/ShowOrHideHighlightButton.jsx
+++ b/packages/lesswrong/components/posts/ShowOrHideHighlightButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent, } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
-import Icon from '@material-ui/core/Icon';
+import SubdirectoryArrowLeftIcon from '@material-ui/icons/SubdirectoryArrowLeft';
 
 const styles = theme => ({
   button: {
@@ -28,15 +28,11 @@ const ShowOrHideHighlightButton = ({open, className, classes}) =>
     { open
       ? <Components.MetaInfo>
           Hide Highlight
-          <Icon className={classNames(classes.button, classes.hideButton)}>
-            subdirectory_arrow_left
-          </Icon>
+          <SubdirectoryArrowLeftIcon className={classNames(classes.button, classes.hideButton)}/>
         </Components.MetaInfo>
       : <Components.MetaInfo>
           Show Highlight
-          <Icon className={classNames(classes.button, classes.showButton)}>
-            subdirectory_arrow_left
-          </Icon>
+          <SubdirectoryArrowLeftIcon className={classNames(classes.button, classes.showButton)}/>
         </Components.MetaInfo>
     }
   </span>

--- a/packages/lesswrong/components/search/UsersSearchInput.jsx
+++ b/packages/lesswrong/components/search/UsersSearchInput.jsx
@@ -2,7 +2,7 @@ import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import Input from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import Icon from '@material-ui/core/Icon'
+import PersonAddIcon from '@material-ui/icons/PersonAdd';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
@@ -19,7 +19,7 @@ const UsersSearchInput = ({ inputProps, classes }) => {
     className={classes.input}
     startAdornment={
       <InputAdornment position="start">
-        <Icon>person_add</Icon>
+        <PersonAddIcon/>
       </InputAdornment>
     }
   />

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItem.jsx
@@ -3,7 +3,8 @@ import React, { Component } from 'react';
 import { Comments } from '../../lib/collections/comments';
 import Users from 'meteor/vulcan:users';
 import { Link } from '../../lib/reactRouterWrapper.js'
-import Icon from '@material-ui/core/Icon';
+import ClearIcon from '@material-ui/icons/Clear';
+import DoneIcon from '@material-ui/icons/Done';
 import { withStyles } from '@material-ui/core/styles';
 import classnames from 'classnames';
 import Typography from '@material-ui/core/Typography';
@@ -88,20 +89,14 @@ class SunshineCommentsItem extends Component {
                   title="Spam/Eugin (delete immediately)"
                   to={Users.getProfileUrl(comment.user)}
                   onClick={this.handleDelete}>
-                    <Icon
-                      className={classnames("material-icons", classes.icon)}>
-                        clear
-                    </Icon>
+                    <ClearIcon className={classnames("material-icons", classes.icon)}/>
                     <div className="sunshine-sidebar-posts-item-delete-overlay"/>
                 </Link>
                 <span
                   className={classnames(classes.postAction, "new-comment", "review")}
                   title="Mark as Reviewed"
                   onClick={this.handleReview}>
-                  <Icon
-                    className={classnames("material-icons", classes.icon)}>
-                      done
-                  </Icon>
+                  <DoneIcon className={classnames("material-icons", classes.icon)}/>
                 </span>
               </div>
             </Components.SunshineListItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsItem.jsx
@@ -8,7 +8,10 @@ import withUser from '../common/withUser';
 import withHover from '../common/withHover'
 import PropTypes from 'prop-types';
 import withErrorBoundary from '../common/withErrorBoundary'
-
+import PlusOneIcon from '@material-ui/icons/PlusOne';
+import UndoIcon from '@material-ui/icons/Undo';
+import StarIcon from '@material-ui/icons/Star';
+import ClearIcon from '@material-ui/icons/Clear';
 class SunshineCuratedSuggestionsItem extends Component {
 
   handleCurate = () => {
@@ -92,18 +95,18 @@ class SunshineCuratedSuggestionsItem extends Component {
         { hover && <Components.SidebarActionMenu>
           { !post.suggestForCuratedUserIds || !post.suggestForCuratedUserIds.includes(currentUser._id) ?
             <Components.SidebarAction title="Endorse Curation" onClick={this.handleSuggestCurated}>
-              plus_one
+              <PlusOneIcon/>
             </Components.SidebarAction>
             :
             <Components.SidebarAction title="Unendorse Curation" onClick={this.handleUnsuggestCurated}>
-              undo
+              <UndoIcon/>
             </Components.SidebarAction>
           }
           <Components.SidebarAction title="Curate Post" onClick={this.handleCurate}>
-            star
+            <StarIcon/>
           </Components.SidebarAction>
           <Components.SidebarAction title="Remove from Curation Suggestions" onClick={this.handleDisregardForCurated}>
-            clear
+            <ClearIcon/>
           </Components.SidebarAction>
         </Components.SidebarActionMenu>}
       </Components.SunshineListItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsItem.jsx
@@ -9,7 +9,8 @@ import Users from 'meteor/vulcan:users';
 import PropTypes from 'prop-types';
 import withUser from '../common/withUser'
 import withErrorBoundary from '../common/withErrorBoundary'
-
+import DoneIcon from '@material-ui/icons/Done';
+import ClearIcon from '@material-ui/icons/Clear';
 class SunshineNewCommentsItem extends Component {
 
   handleReview = () => {
@@ -51,10 +52,10 @@ class SunshineNewCommentsItem extends Component {
           <Components.SunshineCommentsItemOverview comment={comment}/>
             {hover && <Components.SidebarActionMenu>
               <Components.SidebarAction title="Mark as Reviewed" onClick={this.handleReview}>
-                done
+                <DoneIcon/>
               </Components.SidebarAction>
               <Components.SidebarAction title="Spam/Eugin (delete immediately)" onClick={this.handleDelete} warningHighlight>
-                clear
+                <ClearIcon/>
               </Components.SidebarAction>
             </Components.SidebarActionMenu>}
         </Components.SunshineListItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.jsx
@@ -7,8 +7,11 @@ import Typography from '@material-ui/core/Typography';
 import withUser from '../common/withUser';
 import withHover from '../common/withHover'
 import PropTypes from 'prop-types';
-import withErrorBoundary from '../common/withErrorBoundary'
-
+import withErrorBoundary from '../common/withErrorBoundary';
+import DoneIcon from '@material-ui/icons/Done';
+import ClearIcon from '@material-ui/icons/Clear';
+import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+import GroupIcon from '@material-ui/icons/Group';
 class SunshineNewPostsItem extends Component {
 
   handleReview = () => {
@@ -99,16 +102,16 @@ class SunshineNewPostsItem extends Component {
         </div>
         { hover && <Components.SidebarActionMenu>
           <Components.SidebarAction title="Leave on Personal Blog" onClick={this.handleReview}>
-            done
+            <DoneIcon />
           </Components.SidebarAction>
           {post.submitToFrontpage && <Components.SidebarAction title="Move to Frontpage" onClick={this.handlePromote('frontpage')}>
-            thumb_up
+            <ThumbUpIcon />
           </Components.SidebarAction>}
           {getSetting('forumType') === 'EAForum' && post.submitToFrontpage && <Components.SidebarAction title="Move to Community" onClick={this.handlePromote('community')}>
-            group
+            <GroupIcon />
           </Components.SidebarAction>}
           <Components.SidebarAction title="Move to Drafts" onClick={this.handleDelete} warningHighlight>
-            clear
+            <ClearIcon />
           </Components.SidebarAction>
         </Components.SidebarActionMenu>}
       </Components.SunshineListItem>

--- a/packages/lesswrong/lib/collections/posts/custom_fields.js
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.js
@@ -10,6 +10,11 @@ import { getWithLoader } from '../../loaders.js';
 import moment from 'moment';
 
 export const formGroups = {
+  default: {
+    name: "default",
+    order: 0,
+    paddingStyle: true
+  },
   adminOptions: {
     name: "adminOptions",
     order: 25,
@@ -32,12 +37,14 @@ export const formGroups = {
     order:10,
     name: "options",
     defaultStyle: true,
+    paddingStyle: true,
     flexStyle: true
   },
   content: { //TODO – should this be 'contents'? is it needed?
     order:20,
     name: "Content",
     defaultStyle: true,
+    paddingStyle: true,
   },
   canonicalSequence: {
     order:30,
@@ -73,7 +80,8 @@ addFieldsDict(Posts, {
     order: 10,
     placeholder: "Title",
     control: 'EditTitle',
-    editableBy: [Users.owns, 'sunshineRegiment', 'admins']
+    editableBy: [Users.owns, 'sunshineRegiment', 'admins'],
+    group: formGroups.default,
   },
 
   // Legacy: Boolean used to indicate that post was imported from old LW database

--- a/packages/lesswrong/lib/collections/users/custom_fields.js
+++ b/packages/lesswrong/lib/collections/users/custom_fields.js
@@ -14,6 +14,11 @@ export const hashPetrovCode = (code) => {
 
 export const MAX_NOTIFICATION_RADIUS = 300
 export const formGroups = {
+  default: {
+    name: "default",
+    order: 0,
+    paddingStyle: true
+  },
   moderationGroup: {
     order:60,
     name: "moderation",
@@ -176,7 +181,8 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
-    order: 65,
+    order: 43,
+    group: formGroups.default,
     control: "select",
     form: {
       // TODO – maybe factor out??
@@ -204,6 +210,7 @@ addFieldsDict(Users, {
     defaultValue: false,
     canRead: ['guests'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
+    group: formGroups.default,
     canCreate: ['members'],
     control: 'checkbox',
     label: "Hide Intercom"
@@ -220,11 +227,13 @@ addFieldsDict(Users, {
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
     control: 'checkbox',
+    group: formGroups.default,
     label: "Activate Markdown Editor"
   },
 
   email: {
     order: 20,
+    group: formGroups.default,
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
   },
   hideNavigationSidebar: {
@@ -300,6 +309,7 @@ addFieldsDict(Users, {
     canCreate: ['members'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     canRead: ['guests'],
+    group: formGroups.default,
     order: 40,
     searchable: true,
     form: {
@@ -585,6 +595,11 @@ addFieldsDict(Users, {
   displayName: {
     canUpdate: ['sunshineRegiment', 'admins'],
     canCreate: ['sunshineRegiment', 'admins'],
+    group: formGroups.default,
+  },
+
+  username: {
+    hidden: true
   },
 
   // frontpagePostCount: count of how many posts of yours were posted on the frontpage
@@ -647,6 +662,7 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     canCreate: ['members'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
+    group: formGroups.default,
     hidden: !getSetting('hasEvents', true),
     label: "Group Location",
     control: 'LocationFormComponent',
@@ -755,7 +771,9 @@ addFieldsDict(Users, {
     canCreate: ['members'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     optional: true, 
-    order: 43,
+    order: 44,
+    group: formGroups.default,
+    hidden: true,
     label: "Hide the frontpage map"
   },
 
@@ -879,6 +897,7 @@ addFieldsDict(Users, {
   fullName: {
     type: String,
     optional: true,
+    group: formGroups.default,
     canRead: ['guests'],
     canUpdate: [Users.owns, 'sunshineRegiment'],
     hidden: !['LessWrong', 'AlignmentForum'].includes(getSetting('forumType')),
@@ -976,6 +995,7 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     tooltip: "Get early access to new in-development features",
+    group: formGroups.default,
     label: "Opt into experimental features"
   },
   petrovPressedButtonDate: {

--- a/packages/lesswrong/styles/_forms.scss
+++ b/packages/lesswrong/styles/_forms.scss
@@ -157,28 +157,11 @@ div.ReactTags__suggestions mark{
   display: none;
 }
 
-.form-component-clear{
-  position: absolute;
-  top: 11px;
-  right: 0px;
-  background: $light-grey;
-  color: #fff;
-  border-radius: 100%;
-  height: 16px;
-  width: 16px;
-  border: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.form-component-clear {
   span{
-    font-size: 8px;
-    display: block;
-    line-height: 1;
-  }
-  &:hover{
-    text-decoration: none;
-    background: #bbb;
-    color: #fff;
+    position:relative;
+    top:20px;
+    padding: 10px;
   }
 }
 

--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -133,7 +133,7 @@
 
 .sequences-editor-title-wrapper {
   position: absolute;
-  bottom: 5px;
+  bottom: 10px;
   left: 50%;
   z-index: 1;
   width:0;

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -278,7 +278,8 @@ export const ckEditorStyles = theme => {
 
 export const editorStyles = (theme, styleFunction) => ({
     '& .public-DraftStyleDefault-block': {
-      ...pBodyStyle
+      marginTop: '1em',
+      marginBottom: '1em',  
     },
     '& code .public-DraftStyleDefault-block': {
       marginTop: 0,

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -278,8 +278,7 @@ export const ckEditorStyles = theme => {
 
 export const editorStyles = (theme, styleFunction) => ({
     '& .public-DraftStyleDefault-block': {
-      marginTop: '1em',
-      marginBottom: '1em',
+      ...pBodyStyle
     },
     '& code .public-DraftStyleDefault-block': {
       marginTop: 0,

--- a/packages/vulcan-forms/lib/components/FormGroup.jsx
+++ b/packages/vulcan-forms/lib/components/FormGroup.jsx
@@ -43,18 +43,18 @@ const groupLayoutStyles = theme => ({
     border: `solid 1px ${theme.palette.grey[400]}`,
     marginBottom: theme.spacing.unit,
   },
-  formSectionFields: {
+  formSectionBody: {
+    paddingTop: theme.spacing.unit,
+    paddingBottom: theme.spacing.unit,
+    borderTop: `solid 1px ${theme.palette.grey[300]}`,
+  },
+  formSectionPadding: {
     paddingRight: theme.spacing.unit*2,
     paddingLeft: theme.spacing.unit*2,
     [theme.breakpoints.down('md')]: {
       paddingLeft: theme.spacing.unit/2,
       paddingRight: theme.spacing.unit/2,
     },
-  },
-  formSectionBody: {
-    paddingTop: theme.spacing.unit,
-    paddingBottom: theme.spacing.unit,
-    borderTop: `solid 1px ${theme.palette.grey[300]}`,
   },
   flex: {
     display: "flex",
@@ -63,19 +63,20 @@ const groupLayoutStyles = theme => ({
   }
 });
 
-const FormGroupLayout = ({ children, label, heading, collapsed, hasErrors, groupStyling, flexStyle, classes }) => {
+const FormGroupLayout = ({ children, label, heading, collapsed, hasErrors, groupStyling, paddingStyling, flexStyle, classes }) => {
   return <div className={classNames(
-    {[classes.formSection]: groupStyling},
+    { [classes.formSectionPadding]: paddingStyling,
+      [classes.formSection]: groupStyling},
     `form-section-${Utils.slugify(label)}`)}
   >
     {heading}
     <div
       className={classNames(
-        classes.formSectionFields,
         {
           'form-section-collapsed': collapsed && !hasErrors,
           [classes.formSectionBody]: groupStyling,
           [classes.flex]: flexStyle,
+          [classes.formSectionPadding]: groupStyling,
         }
       )}
     >
@@ -132,7 +133,7 @@ class FormGroup extends PureComponent {
     });
 
   render() {
-    const { name, fields, formComponents, label, defaultStyle, flexStyle, formProps } = this.props;
+    const { name, fields, formComponents, label, defaultStyle, flexStyle, paddingStyle, formProps } = this.props;
     const { collapsed } = this.state;
     const FormComponents = mergeWithComponents(formComponents);
     const groupStyling = !(name === 'default' || defaultStyle)
@@ -144,6 +145,7 @@ class FormGroup extends PureComponent {
         collapsed={collapsed}
         heading={groupStyling ? this.renderHeading(FormComponents) : null}
         groupStyling={groupStyling}
+        paddingStyling={paddingStyle}
         hasErrors={this.hasErrors()}
         flexStyle={flexStyle}
       >

--- a/packages/vulcan-forms/lib/stylesheets/style.scss
+++ b/packages/vulcan-forms/lib/stylesheets/style.scss
@@ -190,31 +190,6 @@ div.ReactTags__suggestions mark{
   }
 }
 
-.form-component-clear{
-  position: absolute;
-  top: 11px;
-  right: 0px;
-  background: $light-grey;
-  color: #fff;
-  border-radius: 100%;
-  height: 16px;
-  width: 16px;
-  border: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  span{
-    font-size: 8px;
-    display: block;
-    line-height: 1;
-  }
-  &:hover{
-    text-decoration: none;
-    background: $medium-grey;
-    color: #fff;
-  }
-}
-
 .form-nested-item{
   border: 1px solid $light-grey;
   padding: 10px;


### PR DESCRIPTION
Removes the right/left padding from default form groups. Instead, you now have the option of passing default form groups a "paddingStyle" attribute if it's appropriate for the form you're building.

Unrelatedly migrates a bunch of icons from the old style to the new style