### PR TITLE
go over icon changes

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
@@ -25,12 +25,13 @@ const styles = theme => ({
   link: {
   },
   icon: {
-    fontSize: "0.9rem !important",
+    fontSize: "0.9rem",
     transform: "rotate(-45deg)",
     verticalAlign: "middle",
-    color: "rgba(0,0,0,0.5) !important",
-    margin: "0 3px",
-    paddingBottom: 2,
+    color: "rgba(0,0,0,0.5)",
+    margin: "0 2px",
+    position: "relative",
+    top: -2
   },
 });
 
@@ -48,7 +49,7 @@ const CommentsItemDate = ({comment, post, showPostTitle, classes, scrollOnClick,
 
   const date = <span>
     <Components.FormatDate date={comment.postedAt} format={comment.answer && "MMM DD, YYYY"}/>
-    <LinkIcon className={classNames("material-icons", classes.icon)}/>
+    <LinkIcon className={classes.icon}/>
     {showPostTitle && post.title && <span className={classes.postTitle}> {post.draft && "[Draft]"} {post.title}</span>}
   </span>
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.jsx
@@ -54,14 +54,14 @@ const CommentsItemDate = ({comment, post, showPostTitle, classes, scrollOnClick,
   </span>
 
   return (
-    <div className={classNames(classes.root, {
+    <span className={classNames(classes.root, {
       [classes.date]: !comment.answer,
       [classes.answerDate]: comment.answer,
     })}>
       {scrollOnClick ? <a href={url} onClick={handleLinkClick}>{ date } </a>
         : <Link to={url}>{ date }</Link>
       }
-    </div>
+    </span>
   );
 }
 

--- a/packages/lesswrong/components/posts/ShowOrHideHighlightButton.jsx
+++ b/packages/lesswrong/components/posts/ShowOrHideHighlightButton.jsx
@@ -6,8 +6,8 @@ import SubdirectoryArrowLeftIcon from '@material-ui/icons/SubdirectoryArrowLeft'
 
 const styles = theme => ({
   button: {
-    color: "rgba(0,0,0,.5) !important",
-    fontSize: "12px !important",
+    color: "rgba(0,0,0,.5)",
+    fontSize: "12px",
     left: 4,
     transition: "all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms",
   },

--- a/packages/lesswrong/components/search/UsersSearchInput.jsx
+++ b/packages/lesswrong/components/search/UsersSearchInput.jsx
@@ -8,8 +8,8 @@ import { withStyles } from '@material-ui/core/styles';
 const styles = theme => ({
   input: {
     // this needs to be here because of Bootstrap. I am sorry :(
-    padding: "6px 0 7px !important",
-    fontSize: "13px !important"
+    padding: "6px 0 7px",
+    fontSize: "13px"
   }
 })
 

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersItem.jsx
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import withUser from '../common/withUser';
 import withHover from '../common/withHover'
 import ClearIcon from '@material-ui/icons/Clear';
+import DoneIcon from '@material-ui/icons/Done';
 import withErrorBoundary from '../common/withErrorBoundary'
 
 class AFSuggestUsersItem extends Component {
@@ -72,7 +73,7 @@ class AFSuggestUsersItem extends Component {
             </div>
             { hover && <C.SidebarActionMenu>
               <C.SidebarAction title="Approve for AF" onClick={this.handleReview}>
-                done
+                <DoneIcon />
               </C.SidebarAction>
               <C.SidebarAction warningHighlight={true} title="Ignore" onClick={this.handleIgnore}>
                 <ClearIcon/>

--- a/packages/lesswrong/components/sunshineDashboard/SidebarAction.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarAction.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { registerComponent } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles';
-import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
 import PropTypes from 'prop-types';
 
 const styles = (theme) => ({
   root: {
     marginRight: theme.spacing.unit*2,
-    fontSize:"1.5em",
     cursor:"pointer",
     opacity:.4,
     "&:hover": {
@@ -35,10 +33,10 @@ const styles = (theme) => ({
 
 const SidebarAction = ({children, classes, title, warningHighlight, onClick}) => {
   return <Tooltip title={title} placement="bottom" classes={{tooltip: classes.tooltip}} enterDelay={200}>
-          <Icon onClick={onClick} className={classes.root}>
+          <div onClick={onClick} className={classes.root}>
             {children}
             {warningHighlight && <div className={classes.warningHighlight}/>}
-          </Icon>
+          </div>
         </Tooltip>
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.jsx
@@ -11,6 +11,8 @@ import withHover from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import red from '@material-ui/core/colors/red';
 import { withStyles } from '@material-ui/core/styles';
+import DoneIcon from '@material-ui/icons/Done';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 
 const styles = theme => ({
   negativeKarma: {
@@ -104,10 +106,10 @@ class SunshineNewUsersItem extends Component {
           }
           { hover && <SidebarActionMenu>
             <SidebarAction title="Review" onClick={this.handleReview}>
-              done
+              <DoneIcon />
             </SidebarAction>
             <SidebarAction warningHighlight={true} title="Purge User (delete and ban)" onClick={this.handlePurge}>
-              delete_forever
+              <DeleteForeverIcon />
             </SidebarAction>
           </SidebarActionMenu>}
         </SunshineListItem>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.jsx
@@ -8,7 +8,8 @@ import withHover from '../common/withHover'
 import PropTypes from 'prop-types'
 import withErrorBoundary from '../common/withErrorBoundary'
 import withUser from '../common/withUser'
-
+import DoneIcon from '@material-ui/icons/Done';
+import DeleteIcon from '@material-ui/icons/Delete';
 class SunshineReportedItem extends Component {
 
   handleReview = () => {
@@ -88,10 +89,10 @@ class SunshineReportedItem extends Component {
         </SidebarInfo>
         {hover && <SidebarActionMenu>
           <SidebarAction title="Mark as Reviewed" onClick={this.handleReview}>
-            done
+            <DoneIcon/>
           </SidebarAction>
           <SidebarAction title="Spam/Eugin (delete immediately)" onClick={this.handleDelete} warningHighlight>
-            delete
+            <DeleteIcon/>
           </SidebarAction>
         </SidebarActionMenu>
         }


### PR DESCRIPTION
I took a look at each spot where I had previously changed something from `"<Icon>[text]</Icon>"` to "<NameOfIcon/>", looking for any issues that may have come up.

Classes of things that came up:

– places where previously it'd been necessary to specify "!important" on icon-styles were no longer necessary, and I removed that after doublechecking it rendered correctly

– Sunshine viewable <SidebarAction> was still rendering things inside a nested "`<Icon>`" component, which worked okay but I removed to avoid any potential future issues of colliding styles, while also removing the overriding fontSize.

– after removing the nested `<Icon>` from `<SidebarAction>`, I found a few sunshineSidebar icons that I hadn't actually switched from old `<icon>text</icon>` style icons. I then did so, and manually checked that each SunshineSidebar element worked (except for Alignment Users which were slightly annoying to check for, but where wI doublechecked the code)

– in the process of reviewing each sunshineSidebar item, noticed that the SunshineComments (which I don't normally see) were rendering weird because CommentsItemDate was a `<div>` instead of a `<span>`. I changed it to `<span>`, and then checked that it still rendered properly each place it was used (which it did)