### PR TITLE
UsersProfile gets currentShowLowKarma from query

### DIFF
--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'meteor/vulcan:i18n';
 import { Link } from 'react-router-dom';
 import { withLocation, withNavigation } from '../../lib/routeUtil';
 import Users from "meteor/vulcan:users";
+import { DEFAULT_LOW_KARMA_THRESHOLD } from '../../lib/collections/posts/views'
 import StarIcon from '@material-ui/icons/Star'
 import DescriptionIcon from '@material-ui/icons/Description'
 import MessageIcon from '@material-ui/icons/Message'
@@ -219,6 +220,7 @@ class UsersProfile extends Component {
     const currentSorting = query.sortedBy || query.view ||  "new"
     const currentFilter = query.filter ||  "all"
     const ownPage = currentUser && currentUser._id === user._id
+    const currentShowLowKarma = (parseInt(query.karmaThreshold) !== DEFAULT_LOW_KARMA_THRESHOLD)
 
     return (
       <div className={classNames("page", "users-profile", classes.profilePage)}>
@@ -289,7 +291,7 @@ class UsersProfile extends Component {
             hidden={false}
             currentSorting={currentSorting}
             currentFilter={currentFilter}
-            currentShowLowKarma={true}
+            currentShowLowKarma={currentShowLowKarma}
             sortings={sortings}
           />}
           <PostsList2 terms={terms} />


### PR DESCRIPTION
Fixes issue #2474 by allowing you to uncheck 'show low karma posts' on a user's profile page.

- AllPostsList, where the equivalent checkbox works correctly, has the ‘Show Low Karma’ checkbox switches `query.karmaThreshold` between `DEFAULT_LOW_KARMA_THRESHOLD` and `MAX_LOW_KARMA_THRESHOLD`, and decides whether it's checked based on `query.karmaThreshold`. 
I’ve implemented a similar behavior in UserProfile, but defaulting to showing low karma (where AllPostsList defaults to not doing so).

Question: what if `query.karmaThreshold` is some other value that `DEFAULT_LOW_KARMA_THRESHOLD` or `MAX_LOW_KARMA_THRESHOLD`? A user can change the url by hand easily enough. For now I went with the conservative option of just matching the behavior we have in AllPostsList.

Also, I noticed that for the AllPostsList, we persist the users’ preference on whether to show low karma posts to the backend.For the moment, I haven’t tried to do that, as I’m not sure if that kind of persistence is desirable here.

Lastly, the contributing guidelines say that if you fix a bug you should write a test for it. Maybe I'm missing something obvious here, but I can't find the tests for UserProfile at all. If you point me to them, I'll try to add one. 
