### PR TITLE
Fix sunshine NewUser links in the expand-by-default mode

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.jsx
@@ -1,5 +1,6 @@
 import { Components, registerComponent, withMulti } from 'meteor/vulcan:core';
 import React from 'react';
+import { Posts } from '../../lib/collections/posts';
 import { Comments } from '../../lib/collections/comments';
 import { withStyles } from '@material-ui/core/styles'
 import { commentBodyStyles } from '../../themes/stylePiping'
@@ -21,14 +22,13 @@ const SunshineNewUserCommentsList = ({loading, results, classes, truncated}) => 
 
   if (!results && loading && !truncated) return <Loading />
   if (!results) return null 
-
   return (
     <div>
       {loading && !truncated && <Loading />}
       {results.map(comment=><div className={classes.comment} key={comment._id}>
         <MetaInfo>
-          <Link to={`/posts/${comment.postId}`}>
-            Comment made <FormatDate date={comment.postedAt}/> {comment.status}
+          <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
+            {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>) {comment.status}
           </Link>
         </MetaInfo>
         {!truncated && <div><MetaInfo>{comment.deleted && `[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}
@@ -40,7 +40,7 @@ const SunshineNewUserCommentsList = ({loading, results, classes, truncated}) => 
 
 const withMultiOptions = {
   collection: Comments,
-  fragmentName: 'CommentsList',
+  fragmentName: 'SelectCommentsList',
   fetchPolicy: 'cache-and-network',
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
@@ -28,7 +28,7 @@ const SunshineNewUserPostsList = ({loading, results, classes, truncated}) => {
       {results.map(post=><div className={classes.post} key={post._id}>
         <MetaInfo>
           <Link to={`/posts/${post._id}`}>
-            Post: {post.title}
+            {post.deleted && "[Deleted] "}Post: {post.title}
           </Link>
         </MetaInfo>
         <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.jsx
@@ -28,7 +28,7 @@ const SunshineNewUserPostsList = ({loading, results, classes, truncated}) => {
       {results.map(post=><div className={classes.post} key={post._id}>
         <MetaInfo>
           <Link to={`/posts/${post._id}`}>
-            {post.deleted && "[Deleted] "}Post: {post.title}
+            Post: {post.title}
           </Link>
         </MetaInfo>
         <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -715,7 +715,8 @@ Posts.addView("sunshineNewUsersPosts", function (terms) {
     selector: {
       status: null, // allow sunshines to see posts marked as spam
       userId: terms.userId,
-      authorIsUnreviewed: null
+      authorIsUnreviewed: null,
+      groupId: null,
     },
     options: {
       sort: {


### PR DESCRIPTION
In SunshineNewUserPostsList and SunshineNewUserCommentsList, fixes:
– comments now show a post title, and link properly to the comment in question (instead of just linking to the top-level post)
– shows when comments have been deleted
– Includes events in SunshineNewUserPostsList