### PR TITLE
Tweaks to Recent Discussion UI

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -157,6 +157,10 @@ class CommentsItem extends Component {
     this.setState({showParent:!this.state.showParent})
   }
 
+  toggleShowAllParents = () => {
+    this.setState({showAllParents:!this.state.showAllParents})
+  }
+
   render() {
     const { comment, currentUser, postPage, nestingLevel=1, showPostTitle, classes, post, collapsed, isParentComment, parentCommentId, scrollIntoView } = this.props
 

--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -67,7 +67,7 @@ const styles = theme => ({
     borderBottom: "none",
     borderTop: "solid 1px rgba(0,0,0,.15)",
     '&.comments-node-root':{
-      marginBottom: -1,
+      marginBottom: 4,
       borderBottom: "solid 1px rgba(0,0,0,.2)",
     }
   },

--- a/packages/lesswrong/components/comments/ShowParentComment.jsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.jsx
@@ -36,17 +36,20 @@ const styles = theme => ({
     [legacyBreakpoints.maxSmall]: {
       padding: "0 10px",
     }
+  },
+  activeArrow: {
+    transform: "rotate(-90deg)"
   }
 })
 
-const ShowParentComment = ({ comment, nestingLevel, active, onClick, placeholderIfMissing=false, classes }) => {
+const ShowParentComment = ({ comment, active, onClick, classes }) => {
 
   if (!comment) return null;
   
   return (
-    <Tooltip title="Show previous comment">
+    <Tooltip title={`${active ? "Hide" : "Show"} previous comment`}>
       <span className={classNames(classes.root, {[classes.active]: active})} onClick={onClick}>
-        <SubdirectoryArrowLeft className={classes.icon}>
+        <SubdirectoryArrowLeft className={classNames(classes.icon, {[classes.activeArrow]: active})}>
           subdirectory_arrow_left
         </SubdirectoryArrowLeft>
       </span>


### PR DESCRIPTION
Addressing a few UI concerns of Ruby's:

– single line comments are now spaced out a bit
– "show parent" buttons now change to say "hide parent" with a rotated arrow to be a bit more clear