### PR TITLE
Subscription Icons

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.jsx
@@ -41,21 +41,21 @@ const CommentsMenu = ({children, classes, className, comment, post, showEdit, ic
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
       >
+        <EditCommentMenuItem comment={comment} showEdit={showEdit}/>
         <MenuItem>
-          <SubscribeTo document={comment}
-            subscribeMessage="Subscribe to Comment Replies"
-            unsubscribeMessage="Unsubscribe from Comment Replies"
+          <SubscribeTo document={comment} showIcon
+            subscribeMessage="Subscribe to comment replies"
+            unsubscribeMessage="Unsubscribe from comment replies"
           />
         </MenuItem>
         {comment?.user?._id && (comment?.user?._id !== currentUser._id) &&
           <MenuItem>
-            <SubscribeTo document={comment.user}
+            <SubscribeTo document={comment.user} showIcon
               subscribeMessage={"Subscribe to posts by "+Users.getDisplayName(comment.user)}
               unsubscribeMessage={"Unsubscribe from posts by "+Users.getDisplayName(comment.user)}
             />
           </MenuItem>
         }
-        <EditCommentMenuItem comment={comment} showEdit={showEdit}/>
         <ReportCommentMenuItem comment={comment}/>
         <CommentsPermalinkMenuItem comment={comment} post={post} />
         <MoveToAlignmentMenuItem comment={comment} post={post}/>

--- a/packages/lesswrong/components/comments/CommentsItem/ReportCommentMenuItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/ReportCommentMenuItem.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Users from 'meteor/vulcan:users';
 import withUser from '../../common/withUser';
 import withDialog from '../../common/withDialog'
-import Report from '@material-ui/icons/Report';
+import ReportOutlinedIcon from '@material-ui/icons/ReportOutlined';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 
 class ReportCommentMenuItem extends PureComponent {
@@ -31,7 +31,7 @@ class ReportCommentMenuItem extends PureComponent {
 
     return <MenuItem onClick={this.showReport}>
       <ListItemIcon>
-        <Report />
+        <ReportOutlinedIcon />
       </ListItemIcon>
       Report
     </MenuItem>

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.jsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.jsx
@@ -79,6 +79,7 @@ const LocalGroupPage = ({ classes, documentId: groupId, currentUser }) => {
         <SectionTitle title={`${group.inactive ? "[Inactive] " : " "}${group.name}`}>
           {currentUser && <SectionButton>
             <SubscribeTo
+              showIcon
               document={group}
               subscribeMessage="Subscribe to group"
               unsubscribeMessage="Unsubscribe from group"

--- a/packages/lesswrong/components/notifications/SubscribeTo.jsx
+++ b/packages/lesswrong/components/notifications/SubscribeTo.jsx
@@ -4,6 +4,18 @@ import { Subscriptions } from '../../lib/collections/subscriptions/collection'
 import { defaultSubscriptionTypeTable } from '../../lib/collections/subscriptions/mutations'
 import { userIsDefaultSubscribed } from '../../lib/subscriptionUtil.js';
 import { useCurrentUser } from '../common/withUser';
+import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
+import NotificationsIcon from '@material-ui/icons/Notifications';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import { withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+
+const styles = theme => ({
+  root: {
+    display: "flex",
+    alignItems: "center"
+  }
+})
 
 const SubscribeTo = ({
   document,
@@ -12,6 +24,8 @@ const SubscribeTo = ({
   flash, // From withMessages HoC
   subscribeMessage, unsubscribeMessage,
   className="",
+  classes,
+  showIcon
 }) => {
   const currentUser = useCurrentUser();
   
@@ -81,8 +95,9 @@ const SubscribeTo = ({
     return null;
   }
 
-  return <a className={className} onClick={onSubscribe}>
-    { isSubscribed() ? unsubscribeMessage : subscribeMessage }
+  return <a className={classNames(className, classes.root)} onClick={onSubscribe}>
+    {showIcon && <ListItemIcon>{isSubscribed() ? <NotificationsIcon /> : <NotificationsNoneIcon /> }</ListItemIcon>}
+    { isSubscribed() ? unsubscribeMessage : subscribeMessage}
   </a>
 }
 
@@ -91,7 +106,8 @@ registerComponent('SubscribeTo', SubscribeTo,
   [withCreate, {
     collection: Subscriptions,
     fragmentName: 'SubscriptionState',
-  }]
+  }],
+  withStyles(styles, {name: "SubscribeTo"})
 );
 
 

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.jsx
@@ -134,24 +134,6 @@ class PostActions extends Component {
     
     return (
       <div className={classes.actions}>
-        {currentUser && post.group && <MenuItem>
-          <SubscribeTo document={post.group}
-            subscribeMessage={"Subscribe to "+post.group.name}
-            unsubscribeMessage={"Unsubscribe from "+post.group.name}/>
-        </MenuItem>}
-        
-        {currentUser && postAuthor && postAuthor._id !== currentUser._id && <MenuItem>
-          <SubscribeTo document={postAuthor}
-            subscribeMessage={"Subscribe to posts by "+Users.getDisplayName(postAuthor)}
-            unsubscribeMessage={"Unsubscribe from posts by "+Users.getDisplayName(postAuthor)}/>
-        </MenuItem>}
-        
-        {currentUser && <MenuItem>
-          <SubscribeTo document={post}
-            subscribeMessage="Subscribe to Comments"
-            unsubscribeMessage="Unsubscribe from Comments"/>
-        </MenuItem>}
-
         { Posts.canEdit(currentUser,post) && <Link to={{pathname:'/editPost', search:`?${qs.stringify({postId: post._id, eventForm: post.isEvent})}`}}>
           <MenuItem>
             <ListItemIcon>
@@ -170,6 +152,24 @@ class PostActions extends Component {
             </MenuItem>
           </Link>
         }
+        {currentUser && post.group && <MenuItem>
+          <SubscribeTo document={post.group} showIcon
+            subscribeMessage={"Subscribe to "+post.group.name}
+            unsubscribeMessage={"Unsubscribe from "+post.group.name}/>
+        </MenuItem>}
+        
+        {currentUser && postAuthor && postAuthor._id !== currentUser._id && <MenuItem>
+          <SubscribeTo document={postAuthor} showIcon
+            subscribeMessage={"Subscribe to posts by "+Users.getDisplayName(postAuthor)}
+            unsubscribeMessage={"Unsubscribe from posts by "+Users.getDisplayName(postAuthor)}/>
+        </MenuItem>}
+        
+        {currentUser && <MenuItem>
+          <SubscribeTo document={post} showIcon
+            subscribeMessage="Subscribe to comments"
+            unsubscribeMessage="Unsubscribe from comments"/>
+        </MenuItem>}
+
         <BookmarkButton post={post} menuItem/>
         <ReportPostMenuItem post={post}/>
         { post.isRead

--- a/packages/lesswrong/components/posts/ReportPostMenuItem.jsx
+++ b/packages/lesswrong/components/posts/ReportPostMenuItem.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Users from 'meteor/vulcan:users';
 import withUser from '../common/withUser';
 import withDialog from '../common/withDialog'
-import Report from '@material-ui/icons/Report';
+import ReportOutlinedIcon from '@material-ui/icons/ReportOutlined';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 
 class ReportPostMenuItem extends PureComponent {
@@ -30,7 +30,7 @@ class ReportPostMenuItem extends PureComponent {
 
     return <MenuItem onClick={this.showReport}>
       <ListItemIcon>
-        <Report />
+        <ReportOutlinedIcon />
       </ListItemIcon>
       Report
     </MenuItem>


### PR DESCRIPTION
Adds an optional icon for the subscribe buttons, which changes from "outlined" to "filled" depending on subscription status.

Also re-arranges the subscription icons slightly so they aren't above "edit" menu items.