### PR TITLE
Fix overly large reply box in ckEditor comments

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -22,7 +22,7 @@ const postEditorHeightRows = 15;
 const commentEditorHeightRows = 5;
 
 const styles = theme => ({
-  root: {
+  editor: {
     position: 'relative',
   },
   postBodyStyles: {
@@ -60,8 +60,11 @@ const styles = theme => ({
   },
   postEditorHeight: {
     minHeight: postEditorHeight,
-    '& > div > .ck.ck-content': {
+    '& .ck.ck-content': {
       minHeight: postEditorHeight,
+    },
+    '& .ck-sidebar .ck-content': {
+      minHeight: "unset"
     }
   },
   commentEditorHeight: {
@@ -561,14 +564,16 @@ class EditorFormComponent extends Component {
       && document[fieldName].originalContents.type !== this.getUserDefaultEditor(currentUser)
       && this.renderEditorWarning()
 
-    return <div className={classNames(classes.root, this.getBodyStyles())}>
-      { editorWarning }
-      <div>
-        { this.renderEditorComponent(currentEditorType) }
+    return <div>
+        { editorWarning }
+        <div className={classNames(classes.editor, this.getBodyStyles())}>
+          <div>
+            { this.renderEditorComponent(currentEditorType) }
+          </div>
+          { this.renderUpdateTypeSelect() }
+          { this.renderEditorTypeSelect() }
+        </div>
       </div>
-      { this.renderUpdateTypeSelect() }
-      { this.renderEditorTypeSelect() }
-    </div>
   }
 }
 

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -60,7 +60,7 @@ const styles = theme => ({
   },
   postEditorHeight: {
     minHeight: postEditorHeight,
-    '& .ck.ck-content': {
+    '& > div > .ck.ck-content': {
       minHeight: postEditorHeight,
     }
   },


### PR DESCRIPTION
It was accidentally targeting multiple ckEditor type-boxes, and unfortunately the ckEditor css classes didn't offer natural additional specificity. 