### PR TITLE
image resizing works in ckeditor

### DIFF
--- a/packages/lesswrong/server/draftConvert.jsx
+++ b/packages/lesswrong/server/draftConvert.jsx
@@ -26,7 +26,7 @@ export const htmlToDraft = convertFromHTML({
     // }
   },
   htmlToBlock: (nodeName, node, lastList, inBlock) => {
-    if ((nodeName === 'figure' && node.firstChild.nodeName === 'IMG') || (nodeName === 'img' && inBlock !== 'atomic')) {
+    if ((nodeName === 'figure' && node.firstChild?.nodeName === 'IMG') || (nodeName === 'img' && inBlock !== 'atomic')) {
         return 'atomic';
     }
     // if (nodeName === 'blockquote') {

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -59,6 +59,11 @@ const theme = createLWTheme({
       fontFamily: serifStack,
       linkUnderlinePosition: "72%",
     },
+    caption: {
+      // captions should be relative to their surrounding content, so they are unopinionated about fontFamily and use ems instead of rems
+      fontFamily: "unset",
+      fontSize: '.85em'
+    },
     body2: {
       fontSize: "1.16rem"
     },

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -101,6 +101,14 @@ const baseBodyStyles = theme => ({
   '& a, & a:hover, & a:active': {
     color: theme.palette.primary.main
   },
+  '& figure': {
+    margin: '1em auto',
+    textAlign: "center"
+  },
+  '& figcaption': {
+    ...theme.typography.caption,
+    ...theme.typography.postStyle
+  }
 })
 
 export const postBodyStyles = (theme) => {
@@ -231,7 +239,14 @@ export const ckEditorStyles = theme => {
         '--ck-inner-shadow': "none",
         '& p': {
           ...pBodyStyle
-        }
+        },
+        '.ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected, .ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected': {
+          outline: "none"
+        },
+        '& .image>figcaption': {
+          ...theme.typography.caption,
+          backgroundColor: "unset",
+        },
       },
       '&.ck-sidebar, &.ck-presence-list': { //\u25B6
         '& li': {

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -8,8 +8,12 @@ Utils.sanitize = function(s) {
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
       'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
       'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
-      'tbody', 'tr', 'th', 'td', 'pre', 'img'
-    ]
+      'tbody', 'tr', 'th', 'td', 'pre', 'img', 'figure', 'figcaption'
+    ],
+    allowedAttributes:  {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      'figure': ['style']
+    }
   });
 };
 

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -13,6 +13,12 @@ Utils.sanitize = function(s) {
     allowedAttributes:  {
       ...sanitizeHtml.defaults.allowedAttributes,
       'figure': ['style']
+    },
+    allowedStyles: {
+      ...sanitizeHtml.defaults.allowedStyles,
+      'figure': {
+        'width': [/^\d+(?:px|em|%)$/]
+      }
     }
   });
 };


### PR DESCRIPTION
– sanitization no longer removes figures, and lets figures set their style attribute (allows for ckeditor image resizing)

– removed some of the ckEditor styling on images so that they look more similar between the editor and postPage