### PR TITLE
revert accidental devel PR

### DIFF
--- a/packages/lesswrong/components/async/CKPostEditor.jsx
+++ b/packages/lesswrong/components/async/CKPostEditor.jsx
@@ -58,8 +58,6 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
   const sidebarRef = useRef(null)
   const presenceListRef = useRef(null)
 
-  const initData = typeof(data) === "string" ? data : ""
-
   return <div>
     {/* We load Mathjax by inserting a script tag into the header. Not the most elegant, but should be fine */}
     <Helmet> 
@@ -72,7 +70,7 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
     <div ref={sidebarRef} className={classes.sidebar} onClick={(e) => e.preventDefault()}/>
 
     {layoutReady && <CKEditor
-      data={initData}
+      data={data || ""}
       onChange={onChange}
       editor={ collaboration ? PostEditorCollaboration : PostEditor }
       onInit={ editor => {
@@ -105,7 +103,7 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
         presenceList: {
           container: presenceListRef.current
         },
-        initialData: initData
+        initialData: data
       }}
     />}
   </div>

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -130,9 +130,9 @@ class EditorFormComponent extends Component {
     {
       return {
         draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(value.originalContents.data) : null,
-        markdownValue: editorType === "markdown" ? this.initializeText(value.originalContents.data, editorType) : null,
-        htmlValue: editorType === "html" ? this.initializeText(value.originalContents.data, editorType) : null,
-        ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(value.originalContents.data, editorType) : null
+        markdownValue: editorType === "markdown" ? this.initializeText(value.originalContents.data) : null,
+        htmlValue: editorType === "html" ? this.initializeText(value.originalContents.data) : null,
+        ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(value.originalContents.data) : null
       }
     }
     
@@ -140,9 +140,9 @@ class EditorFormComponent extends Component {
     const { draftJS, html, markdown, ckEditorMarkup } = document[fieldName] || {}
     return {
       draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(draftJS) : null,
-      markdownValue: editorType === "markdown" ? this.initializeText(markdown, editorType) : null,
-      htmlValue: editorType === "html" ? this.initializeText(html, editorType) : null,
-      ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(ckEditorMarkup, editorType) : null
+      markdownValue: editorType === "markdown" ? this.initializeText(markdown) : null,
+      htmlValue: editorType === "html" ? this.initializeText(html) : null,
+      ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(ckEditorMarkup) : null
     }
   }
 
@@ -190,9 +190,9 @@ class EditorFormComponent extends Component {
     return EditorState.createEmpty();
   }
 
-  initializeText = (originalContents, editorType) => {
+  initializeText = (originalContents) => {
     const { document, name } = this.props
-    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix(editorType)})
+    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix()})
     if (savedState) {
       return savedState;
     }
@@ -348,8 +348,8 @@ class EditorFormComponent extends Component {
 
   // Get an editor-type-specific prefix to use on localStorage keys, to prevent
   // drafts written with different editors from having conflicting names.
-  getLSKeyPrefix = (editorType) => {
-    switch(editorType || this.getCurrentEditorType()) {
+  getLSKeyPrefix = () => {
+    switch(this.getCurrentEditorType()) {
       case "draftJS":  return "";
       case "markdown": return "md_";
       case "html":     return "html_";
@@ -470,9 +470,6 @@ class EditorFormComponent extends Component {
     const { Loading } = Components
     const CKEditor = this.ckEditor
     const value = ckEditorValue || ckEditorReference?.getData()
-    if (typeof(value) === "string") {
-
-    } 
   
     if (!this.state.ckEditorLoaded || !CKEditor) {
       return <Loading />


### PR DESCRIPTION
I accidentally pushed a commit directly to devel instead of making a PR
This commit undoes the changes from that commit.

The commit was intending to fix the issue where ckEditor sometimes gets access to old drafts from DraftJs. This was because when you switch editors, at the time it checks for drafts, it hasn't actually updated the editorType yet. (This may have been causing other errors?)

I fixed that by a) manually passing through the new editorType, and b) to be safe, also in CkPostEditor manually checking that "data" was a string.