### PR TITLE
Ck editor won't use DraftJS saved data

### DIFF
--- a/packages/lesswrong/components/async/CKPostEditor.jsx
+++ b/packages/lesswrong/components/async/CKPostEditor.jsx
@@ -58,6 +58,8 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
   const sidebarRef = useRef(null)
   const presenceListRef = useRef(null)
 
+  const initData = typeof(data) === "string" ? data : ""
+
   return <div>
     {/* We load Mathjax by inserting a script tag into the header. Not the most elegant, but should be fine */}
     <Helmet> 
@@ -70,7 +72,7 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
     <div ref={sidebarRef} className={classes.sidebar} onClick={(e) => e.preventDefault()}/>
 
     {layoutReady && <CKEditor
-      data={data || ""}
+      data={initData}
       onChange={onChange}
       editor={ collaboration ? PostEditorCollaboration : PostEditor }
       onInit={ editor => {
@@ -103,7 +105,7 @@ const CKPostEditor = ({ data, onSave, onChange, documentId, userId, formType, on
         presenceList: {
           container: presenceListRef.current
         },
-        initialData: data
+        initialData: initData
       }}
     />}
   </div>

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -154,12 +154,12 @@ class EditorFormComponent extends Component {
     return getLSHandlers(form && form.getLocalStorageId)
   }
 
-  initializeDraftJS = (draftJS) => {
+  initializeDraftJS = (draftJS, editorType) => {
     const { document, name } = this.props
     let state = {}
 
     // Check whether we have a state from a previous session saved (in localstorage)
-    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix()})
+    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix(editorType)})
     if (savedState) {
       try {
         // eslint-disable-next-line no-console

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -130,9 +130,9 @@ class EditorFormComponent extends Component {
     {
       return {
         draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(value.originalContents.data) : null,
-        markdownValue: editorType === "markdown" ? this.initializeText(value.originalContents.data) : null,
-        htmlValue: editorType === "html" ? this.initializeText(value.originalContents.data) : null,
-        ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(value.originalContents.data) : null
+        markdownValue: editorType === "markdown" ? this.initializeText(value.originalContents.data, editorType) : null,
+        htmlValue: editorType === "html" ? this.initializeText(value.originalContents.data, editorType) : null,
+        ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(value.originalContents.data, editorType) : null
       }
     }
     
@@ -140,9 +140,9 @@ class EditorFormComponent extends Component {
     const { draftJS, html, markdown, ckEditorMarkup } = document[fieldName] || {}
     return {
       draftJSValue: editorType === "draftJS" ? this.initializeDraftJS(draftJS) : null,
-      markdownValue: editorType === "markdown" ? this.initializeText(markdown) : null,
-      htmlValue: editorType === "html" ? this.initializeText(html) : null,
-      ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(ckEditorMarkup) : null
+      markdownValue: editorType === "markdown" ? this.initializeText(markdown, editorType) : null,
+      htmlValue: editorType === "html" ? this.initializeText(html, editorType) : null,
+      ckEditorValue: editorType === "ckEditorMarkup" ? this.initializeText(ckEditorMarkup, editorType) : null
     }
   }
 
@@ -190,9 +190,9 @@ class EditorFormComponent extends Component {
     return EditorState.createEmpty();
   }
 
-  initializeText = (originalContents) => {
+  initializeText = (originalContents, editorType) => {
     const { document, name } = this.props
-    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix()})
+    const savedState = this.getStorageHandlers().get({doc: document, name, prefix:this.getLSKeyPrefix(editorType)})
     if (savedState) {
       return savedState;
     }
@@ -348,8 +348,8 @@ class EditorFormComponent extends Component {
 
   // Get an editor-type-specific prefix to use on localStorage keys, to prevent
   // drafts written with different editors from having conflicting names.
-  getLSKeyPrefix = () => {
-    switch(this.getCurrentEditorType()) {
+  getLSKeyPrefix = (editorType) => {
+    switch(editorType || this.getCurrentEditorType()) {
       case "draftJS":  return "";
       case "markdown": return "md_";
       case "html":     return "html_";
@@ -470,6 +470,9 @@ class EditorFormComponent extends Component {
     const { Loading } = Components
     const CKEditor = this.ckEditor
     const value = ckEditorValue || ckEditorReference?.getData()
+    if (typeof(value) === "string") {
+
+    } 
   
     if (!this.state.ckEditorLoaded || !CKEditor) {
       return <Loading />

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -470,9 +470,6 @@ class EditorFormComponent extends Component {
     const { Loading } = Components
     const CKEditor = this.ckEditor
     const value = ckEditorValue || ckEditorReference?.getData()
-    if (typeof(value) === "string") {
-
-    } 
   
     if (!this.state.ckEditorLoaded || !CKEditor) {
       return <Loading />


### PR DESCRIPTION
This fixes a bug where ckEditor would sometimes offer you the chance to load a saved draft from localstorage, but it'd be a saved draft from another editor-type (generally ckEditor). This was because at the moment you switch editors it's still in the process of switching editors and doesn't have access to the new editor type.

This PR fixes the bug, and adds some defensive programming around it:

1) initializeText now takes an "editorType" parameter that overrides which editor the localstorage should refer to (preventing the bug)

2) ckEditor checks that the data it's been passed is actually a string before using it to initialize, so if in the future it gets passed an object or whatever it won't choke on it.