### PR TITLE
Form Updates

### DIFF
--- a/packages/lesswrong/components/form-components/MuiTextField.jsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.jsx
@@ -12,7 +12,7 @@ const styles = theme => ({
   textField: {
     fontSize: "15px",
     width: 350,
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('sm')]: {
       width: "100%",
     },
   },

--- a/packages/lesswrong/components/form-components/MuiTextField.jsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.jsx
@@ -13,7 +13,7 @@ const styles = theme => ({
     fontSize: "15px",
     width: 350,
     [theme.breakpoints.down('sm')]: {
-      width: "calc(100% - 30px)",
+      width: "calc(100% - 30px)", // leaving 30px so that the "clear" button for select forms has room
     },
   },
   fullWidth: {

--- a/packages/lesswrong/components/form-components/MuiTextField.jsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.jsx
@@ -13,7 +13,7 @@ const styles = theme => ({
     fontSize: "15px",
     width: 350,
     [theme.breakpoints.down('sm')]: {
-      width: "100%",
+      width: "calc(100% - 30px)",
     },
   },
   fullWidth: {

--- a/packages/vulcan-ui-bootstrap/lib/components/forms/FormComponentInner.jsx
+++ b/packages/vulcan-ui-bootstrap/lib/components/forms/FormComponentInner.jsx
@@ -9,7 +9,6 @@ class FormComponentInner extends PureComponent {
     if (['datetime', 'time', 'select', 'radiogroup'].includes(this.props.input)) {
       return (
         <a
-          href="javascript:void(0)"
           className="form-component-clear"
           title={this.context.intl.formatMessage({ id: 'forms.clear_field' })}
           onClick={this.props.clearField}


### PR DESCRIPTION
The form fields were shifting to a "mobile" looking layout much earlier than necessary.

The "clear" button for select forms also needed some extra room, so shrinking the width.

Also removed a "javascript:void(0)" that was causing a harmless but annoying error message