### PR TITLE
improve styling for errors

### DIFF
--- a/packages/lesswrong/styles/_sequences.scss
+++ b/packages/lesswrong/styles/_sequences.scss
@@ -46,6 +46,23 @@
   left:0;
   width:100%;
 
+  .input-title .form-input-errors {
+    background-color:rgba(0,0,0,0.25);;
+    width: 100%;
+    text-align:center;
+    margin:0!important;
+
+    li {
+      position:relative;
+      left:-230px;
+      top:3px;
+      z-index: 3;
+      @include mui-breakpoint-down-sm {
+        left:0;
+      }
+    }
+  }
+
   .editor-form-component {
     max-width: 650px;
     margin: auto;
@@ -148,22 +165,6 @@
   color: white;
   font-variant: small-caps;
   z-index: 2;
-}
-.input-title .form-input-errors {
-    background-color:rgba(0,0,0,0.25);;
-    width: 100%;
-    text-align:center;
-    margin:0!important;
-
-    li {
-      position:relative;
-      left:-230px;
-      top:3px;
-      z-index: 3;
-      @include mui-breakpoint-down-sm {
-        left:0;
-      }
-    }
 }
 
 .sequences-editor-title {

--- a/packages/lesswrong/themes/alignmentForumTheme.js
+++ b/packages/lesswrong/themes/alignmentForumTheme.js
@@ -54,6 +54,10 @@ const theme = createLWTheme({
       fontFamily: sansSerifStack,
       fontVariantNumeric: "lining-nums",
     },
+    errorStyle: {
+      color: palette.error.main,
+      fontFamily: sansSerifStack
+    },
     link: {
       underlinePosition: "72%",
     },

--- a/packages/lesswrong/themes/eaTheme.js
+++ b/packages/lesswrong/themes/eaTheme.js
@@ -86,6 +86,10 @@ const theme = createLWTheme({
     commentStyle: {
       fontFamily: sansSerifStack,
     },
+    errorStyle: {
+      color: palette.error.main,
+      fontFamily: sansSerifStack
+    },
     headline: {
       fontFamily: serifStack,
     },

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -65,6 +65,10 @@ const theme = createLWTheme({
     commentStyle: {
       fontFamily: sansSerifStack
     },
+    errorStyle: {
+      color: palette.error.main,
+      fontFamily: sansSerifStack
+    },
     headline: {
       fontFamily: serifStack,
     },

--- a/packages/vulcan-forms/lib/components/FieldErrors.jsx
+++ b/packages/vulcan-forms/lib/components/FieldErrors.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { registerComponent, Components } from 'meteor/vulcan:core';
+import { withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
 
-const FieldErrors = ({ errors }) => (
-  <ul className="form-input-errors">
+const styles = theme => ({
+  root: {
+    ...theme.typography.errorStyle
+  }
+})
+
+const FieldErrors = ({ classes, errors }) => (
+  <ul className={classNames(classes.root, "form-input-errors")}>
     {errors.map((error, index) => (
       <li key={index}>
         <Components.FormError error={error} errorContext="field" />
@@ -14,4 +22,4 @@ const FieldErrors = ({ errors }) => (
 FieldErrors.propTypes = {
   errors: PropTypes.array.isRequired
 };
-registerComponent('FieldErrors', FieldErrors);
+registerComponent('FieldErrors', FieldErrors, withStyles(styles, {name:"FieldErrors"}));

--- a/packages/vulcan-forms/lib/components/FormErrors.jsx
+++ b/packages/vulcan-forms/lib/components/FormErrors.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { registerComponent, Components } from 'meteor/vulcan:core';
+import { withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
 
-const FormErrors = ({ errors }) => (
-  <div className="form-errors">
+const styles = theme => ({
+  root: {
+    ...theme.typography.errorStyle
+  }
+})
+
+const FormErrors = ({ classes, errors }) => (
+  <div className={classNames(classes.root, "form-errors")}>
     {!!errors.length && (
       <Components.Alert className="flash-message" variant="danger">
         <ul>
@@ -17,7 +24,7 @@ const FormErrors = ({ errors }) => (
     )}
   </div>
 );
-registerComponent('FormErrors', FormErrors);
+registerComponent('FormErrors', FormErrors, withStyles(styles, {name:"FormErrors"}));
 
 // /*
 


### PR DESCRIPTION
Fixed a weird mis-application of the sequence-editor-title style (which was getting applied to post-editor-title field)

Also made all errors red, and started migrating them towards JSS in the process