### PR TITLE
Implement localStorage for ckEditor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -304,9 +304,17 @@ class EditorFormComponent extends Component {
 
   setMarkdown = (e) => {
     const newContent = e.target.value
-    const changed = (this.state.htmlValue !== newContent);
+    const changed = (this.state.markdownValue !== newContent);
     this.setState({markdownValue: newContent})
 
+    if (changed)
+      this.afterChange();
+  }
+
+  setCkEditor = (editor) => {
+    const newContent = editor.getData()
+    const changed = (this.state.ckEditorValue !== newContent);
+    this.setState({ckEditorValue: newContent})
     if (changed)
       this.afterChange();
   }
@@ -489,7 +497,7 @@ class EditorFormComponent extends Component {
         documentId: document?._id,
         formType: formType,
         userId: currentUser?._id,
-        onChange: (event, editor) => this.setState({ckEditorValue: editor.getData()}),
+        onChange: (event, editor) => this.setCkEditor(editor),
         onInit: editor => this.setState({ckEditorReference: editor})
       }
 


### PR DESCRIPTION
Pretty self explanatory. This adds localStorage to ckEditor. 

In practice, this means that localStorage works normally for *non*-collaborative ckEditor. For collaborative ckEditor, it'll get overridden by the latest cloud version of the document. But, if you want to replace whatevers-on-the-cloud with whatevers-in-localStorage, you can un-share the document and it'll revert to a non-cloud version.

Also fixes what I assume would have been a (rare) bug where the markdown localstorage was comparing itself to the html localstorage. (I think in practice the "oldVersion == newVersion?" check always returns true because it's only triggered on an "onChange", and the contents are basically never identical. But seemed worth fixing while I was at it)