### PR TITLE
Pingbacks bug

### DIFF
--- a/packages/lesswrong/server/pingbacks.js
+++ b/packages/lesswrong/server/pingbacks.js
@@ -20,24 +20,29 @@ export const htmlToPingbacks = async (html) => {
     // by an absolute link).
     const linkTargetAbsolute = new URLClass(link, 'http://example.com/');
     
-    if (hostIsOnsite(linkTargetAbsolute.host)) {
-      const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
-      const parsedUrl = parseRoute({
-        location: parsePath(onsiteUrl),
-        onError: (pathname) => {
-          // Ignore malformed links
-        }
-      });
-      
-      if (parsedUrl?.currentRoute?.getPingback) {
-        const pingback = await parsedUrl.currentRoute.getPingback(parsedUrl);
-        if (pingback) {
-          if (!(pingback.collectionName in pingbacks))
-            pingbacks[pingback.collectionName] = [];
-          if (!_.find(pingbacks[pingback.collectionName], pingback.documentId))
-            pingbacks[pingback.collectionName].push(pingback.documentId);
+    try {
+      if (hostIsOnsite(linkTargetAbsolute.host)) {
+        const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
+        const parsedUrl = parseRoute({
+          location: parsePath(onsiteUrl),
+          onError: (pathname) => {
+            // Ignore malformed links
+          }
+        });
+        
+        if (parsedUrl?.currentRoute?.getPingback) {
+          const pingback = await parsedUrl.currentRoute.getPingback(parsedUrl);
+          if (pingback) {
+            if (!(pingback.collectionName in pingbacks))
+              pingbacks[pingback.collectionName] = [];
+            if (!_.find(pingbacks[pingback.collectionName], pingback.documentId))
+              pingbacks[pingback.collectionName].push(pingback.documentId);
+          }
         }
       }
+    } catch (err) {
+      console.error(err) // eslint-disable-line
+      console.error(link) // eslint-disable-line
     }
   }
   

--- a/packages/lesswrong/server/pingbacks.js
+++ b/packages/lesswrong/server/pingbacks.js
@@ -29,7 +29,7 @@ export const htmlToPingbacks = async (html) => {
             // Ignore malformed links
           }
         });
-        
+        console.log(a)
         if (parsedUrl?.currentRoute?.getPingback) {
           const pingback = await parsedUrl.currentRoute.getPingback(parsedUrl);
           if (pingback) {
@@ -41,7 +41,7 @@ export const htmlToPingbacks = async (html) => {
         }
       }
     } catch (err) {
-      console.error("failed to create pingback for link: ", link) // eslint-disable-line
+      console.error("failed to create pingback for link:", link) // eslint-disable-line
       console.error(err) // eslint-disable-line
     }
   }  

--- a/packages/lesswrong/server/pingbacks.js
+++ b/packages/lesswrong/server/pingbacks.js
@@ -41,7 +41,7 @@ export const htmlToPingbacks = async (html) => {
         }
       }
     } catch (err) {
-      console.error(link) // eslint-disable-line
+      console.error("failed to create pingback for link: ", link) // eslint-disable-line
       console.error(err) // eslint-disable-line
     }
   }  

--- a/packages/lesswrong/server/pingbacks.js
+++ b/packages/lesswrong/server/pingbacks.js
@@ -20,29 +20,33 @@ export const htmlToPingbacks = async (html) => {
     // by an absolute link).
     const linkTargetAbsolute = new URLClass(link, 'http://example.com/');
     
-    try {
-      if (hostIsOnsite(linkTargetAbsolute.host)) {
-        const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
-        const parsedUrl = parseRoute({
-          location: parsePath(onsiteUrl),
-          onError: (pathname) => {
-            // Ignore malformed links
-          }
-        });
-        
-        if (parsedUrl?.currentRoute?.getPingback) {
-          const pingback = await parsedUrl.currentRoute.getPingback(parsedUrl);
+    if (hostIsOnsite(linkTargetAbsolute.host)) {
+      const onsiteUrl = linkTargetAbsolute.pathname + linkTargetAbsolute.search + linkTargetAbsolute.hash;
+      const parsedUrl = parseRoute({
+        location: parsePath(onsiteUrl),
+        onError: (pathname) => {
+          // Ignore malformed links
+        }
+      });
+      
+      if (parsedUrl?.currentRoute?.getPingback) {
+        const pingback = await parsedUrl.currentRoute.getPingback(parsedUrl);
+        try {
           if (pingback) {
             if (!(pingback.collectionName in pingbacks))
               pingbacks[pingback.collectionName] = [];
             if (!_.find(pingbacks[pingback.collectionName], pingback.documentId))
               pingbacks[pingback.collectionName].push(pingback.documentId);
           }
+        } catch (err) {
+          console.log(link)
+          console.log(pingback)
+          console.log(pingbacks)
+          console.error(err) // eslint-disable-line
+          console.error(link) // eslint-disable-line
+
         }
       }
-    } catch (err) {
-      console.error(err) // eslint-disable-line
-      console.error(link) // eslint-disable-line
     }
   }
   


### PR DESCRIPTION
htmlToPingbacks was accidentally using lodash instead of underscore for a utility function, and throwing an error due to  a mismatch of syntax. This was causing PostSubmit to fail.

The error was only being thrown on the client, and less conveniently formatted than usual. 

This PR replaces the "_.find" with an "array.includes", and also adds a try/catch with error logging so any future errors in htmlPingbacks don't break post submission