### PR TITLE
Show read time for posts on mobile

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -116,6 +116,16 @@ const styles = theme => ({
     whiteSpace: "no-wrap",
     fontSize: theme.typography.body2.fontSize,
   },
+  wordCount: {
+    display: 'none',
+    marginLeft: 20,
+    color: theme.palette.grey[600],
+    whiteSpace: "no-wrap",
+    fontSize: theme.typography.body2.fontSize,
+    [theme.breakpoints.down('sm')]: {
+      display: 'inline'
+    }
+  },
   actions: {
     display: 'inline-block',
     marginLeft: 15,
@@ -301,6 +311,9 @@ class PostsPage extends Component {
                       </Tooltip>
                     }
                     {!post.isEvent && <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />}
+                    {!!wordCount && !post.isEvent &&  <Tooltip title={`${wordCount} words`}>
+                        <span className={classes.wordCount}>{parseInt(wordCount/300) || 1 } min read</span>
+                    </Tooltip>}
                     {post.types && post.types.length > 0 && <Components.GroupLinks document={post} />}
                     <a className={classes.commentsLink} href={"#comments"}>{ Posts.getCommentCountStr(post)}</a>
                     <span className={classes.actions}>


### PR DESCRIPTION
Since there is currently no way of accessing read time and word count on mobile, due to that information currently being primarily displayed on hover-over effects, I think we should display that info at the top of the post-item. 

![Screen Shot 2019-10-28 at 8 07 27 PM](https://user-images.githubusercontent.com/9090789/67734576-a5aa1380-f9be-11e9-867f-fc632746db0b.png)
