### PR TITLE
ckEditor fix weird inner-scrolling bug

### DIFF
--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -238,7 +238,11 @@ export const ckEditorStyles = theme => {
         '--ck-focus-outer-shadow': "none",
         '--ck-inner-shadow': "none",
         '& p': {
-          ...pBodyStyle
+          marginTop: "1em",
+          marginBottom: "1em",
+          '&:first-of-type': {
+            marginTop: 0,
+          }
         },
         '.ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected, .ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected': {
           outline: "none"


### PR DESCRIPTION
Previously, ckEditor used pBody style, which removes botto-margins from the last p-block in a list. For some reason this resulted in ckEditor having a weird "inner scrollbar", presumably because ckEditor's height was set expecting a slight bottom margin on the final element.
