### PR TITLE
remove blockquotes from singleLineComments

### DIFF
--- a/packages/lesswrong/lib/collections/revisions/resolvers.js
+++ b/packages/lesswrong/lib/collections/revisions/resolvers.js
@@ -108,8 +108,8 @@ addFieldsDict(Revisions, {
       resolver: ({html}) => {
         const mainTextHtml = sanitizeHtml(
           html, { 
-            allowedTags: _.without(sanitizeHtml.defaults.allowedTags, 'blockquote'),
-            nonTextTags: ['blockquote']
+            allowedTags: _.without(Utils.sanitizeAllowedTags, 'blockquote', 'img'),
+            nonTextTags: ['blockquote', 'img']
           }
         )
         const truncatedHtml = truncate(mainTextHtml, PLAINTEXT_HTML_TRUNCATION_LENGTH)

--- a/packages/lesswrong/lib/collections/revisions/resolvers.js
+++ b/packages/lesswrong/lib/collections/revisions/resolvers.js
@@ -59,10 +59,6 @@ export function dataToDraftJS(data, type) {
   }
 }
 
-const nonMainTextTags = [
-  'style', 'script', 'textarea', 'noscript', 'blockquote', 'code', 'img'
-]
-
 addFieldsDict(Revisions, {
   markdown: {
     type: String,
@@ -110,7 +106,12 @@ addFieldsDict(Revisions, {
     resolveAs: {
       type: 'String',
       resolver: ({html}) => {
-        const mainTextHtml = sanitizeHtml(html, { nonTextTags: nonMainTextTags })
+        const mainTextHtml = sanitizeHtml(
+          html, { 
+            allowedTags: _.without(sanitizeHtml.defaults.allowedTags, 'blockquote'),
+            nonTextTags: ['blockquote']
+          }
+        )
         const truncatedHtml = truncate(mainTextHtml, PLAINTEXT_HTML_TRUNCATION_LENGTH)
         return htmlToText
           .fromString(truncatedHtml)

--- a/packages/vulcan-lib/lib/server/utils.js
+++ b/packages/vulcan-lib/lib/server/utils.js
@@ -2,14 +2,16 @@ import sanitizeHtml from 'sanitize-html';
 import { Utils } from '../modules';
 import { throwError } from './errors.js';
 
+Utils.sanitizeAllowedTags = [
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
+  'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
+  'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
+  'tbody', 'tr', 'th', 'td', 'pre', 'img', 'figure', 'figcaption'
+]
+
 Utils.sanitize = function(s) {
   return sanitizeHtml(s, {
-    allowedTags: [
-      'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul',
-      'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike',
-      'code', 'hr', 'br', 'div', 'table', 'thead', 'caption',
-      'tbody', 'tr', 'th', 'td', 'pre', 'img', 'figure', 'figcaption'
-    ],
+    allowedTags: Utils.sanitizeAllowedTags,
     allowedAttributes:  {
       ...sanitizeHtml.defaults.allowedAttributes,
       'figure': ['style']


### PR DESCRIPTION
The previous attempt to remove blockquotes via "sanitize" didn't work because they had to be removed from the allowedTags, as well as added to nonTextTags. 

This new version is a bit simpler – I'm fairly confident it only needs to do remove blockquotes and images. (It turns out images are not included by default in sanitizeHtml, so they were automatically removed when I streamlined the setup here to use sanitizeHtml.defaults.allowedTags)

Codeblocks are fine to include because we just wanted to strip the formatting, which htmlToText already does.