### PR TITLE
Throttle setCkEditor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -111,6 +111,8 @@ class EditorFormComponent extends Component {
     }
     this.hasUnsavedData = false;
     this.throttledSaveBackup = _.throttle(this.saveBackup, autosaveInterval, {leading:false});
+    this.throttledSetCkEditor = _.throttle(this.setCkEditor, autosaveInterval);
+
   }
 
   async componentDidMount() {
@@ -497,7 +499,7 @@ class EditorFormComponent extends Component {
         documentId: document?._id,
         formType: formType,
         userId: currentUser?._id,
-        onChange: (event, editor) => this.setCkEditor(editor),
+        onChange: (event, editor) => this.throttledSetCkEditor(editor),
         onInit: editor => this.setState({ckEditorReference: editor})
       }
 


### PR DESCRIPTION
CkEditor was behaving sluggishly when the post you're editing got long. I moved the "setCkEditor" function behind a _.throttle