### PR TITLE
Fix route, title and subtitle handling for sequences posts

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.jsx
+++ b/packages/lesswrong/components/common/HeadTags.jsx
@@ -22,7 +22,7 @@ const HeadTags = (props) => {
     const siteName = getSetting('forumSettings.tabTitle', 'LessWrong 2.0');
     
     const TitleComponent = currentRoute?.titleComponentName ? Components[currentRoute.titleComponentName] : null;
-    const titleString = currentRoute?.title || currentRoute?.subtitle;
+    const titleString = currentRoute?.title || props.title || currentRoute?.subtitle;
     
     return (
       <React.Fragment>

--- a/packages/lesswrong/components/titles/PostsPageTitle.jsx
+++ b/packages/lesswrong/components/titles/PostsPageTitle.jsx
@@ -45,9 +45,9 @@ registerComponent("PostsPageHeaderTitle", PostsPageHeaderTitle,
   withLocation,
   mapProps((props) => {
     const {location} = props;
-    const {params: {_id}} = location;
+    const {params: {_id, postId}} = location;
     return {
-      documentId: _id,
+      documentId: _id || postId,
       ...props
     }
   }),

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -120,6 +120,8 @@ addRoute([
     name: 'sequencesPost',
     path: '/s/:sequenceId/p/:postId',
     componentName: 'SequencesPost',
+    titleComponentName: 'PostsPageHeaderTitle',
+    subtitleComponentName: 'PostsPageHeaderTitle',
     previewComponentName: 'PostLinkPreviewSequencePost',
   },
 


### PR DESCRIPTION
This PR does three things: 

+ Restore a default behavior of the HeadTags component to properly handle a passed `title` property
+ Have the sequence route use the PostsPageHeaderTitle component
+ Modify the PostsPageHeaderTitle component to deal with the parameter names from the sequences route

Together these three changes fix invalid `title` tags that were present on the `s/sequenceId/p/postId` routes and the `rationality/slug`, `hpmor/slug` and `codex/slug` routes. 