### PR TITLE
[Hotfix] Revert recent email theme changes

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { emailBodyStyles } from '../../themes/stylePiping'
 
 const styles = theme => ({
-  root: emailBodyStyles(theme)
+  // root: emailBodyStyles(theme)
 })
 
 // Wrapper for top-level formatting of emails, eg controling width and

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, getSetting } from 'meteor/vulcan:core';
 import { Utils } from 'meteor/vulcan:lib';
 import { withStyles } from '@material-ui/core/styles';
-import { emailBodyStyles } from '../../themes/stylePiping'
+// import { emailBodyStyles } from '../../themes/stylePiping'
 
 const styles = theme => ({
   // root: emailBodyStyles(theme)

--- a/packages/lesswrong/server/emails/renderEmail.js
+++ b/packages/lesswrong/server/emails/renderEmail.js
@@ -28,7 +28,6 @@ export const emailDoctype = '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transi
 // specific dysfunctional email clients (like the ".ExternalClass" and
 // ".yshortcuts" entries.)
 const emailGlobalCss = `
-  html {font-size: 13px;}
   .ReadMsgBody { width: 100%; background-color: #ebebeb;}
   .ExternalClass {width: 100%; background-color: #ebebeb;}
   .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height:100%;}
@@ -57,6 +56,9 @@ const emailGlobalCss = `
   }
   
   /* Global styles that apply eg inside of posts */
+  a {
+    color: #5f9b65
+  }
   blockquote {
     border-left: solid 3px #e0e0e0;
     padding: .75em 2em;


### PR DESCRIPTION
Email fontsize was still too large after first attempt at a fix, and possibly other problems existed as well. Revert while we figure out the long term solution.