### PR TITLE
sort drafts by modifiedAt

### DIFF
--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -9,12 +9,6 @@ import { makeEditableOptions, makeEditableOptionsModeration } from './custom_fie
 import { PostRelations } from '../postRelations/index';
 const MINIMUM_APPROVAL_KARMA = 5
 
-function PostsEditSetModifiedAt (data) {
-  data.modifiedAt = new Date()
-  return data;
-}
-addCallback("post.update.before", PostsEditSetModifiedAt);
-
 function PostsEditRunPostUndraftedSyncCallbacks (data, { oldDocument: post }) {
   if (data.draft === false && post.draft) {
     data = runCallbacks("post.undraft.before", data, post);

--- a/packages/lesswrong/lib/collections/posts/callbacks.js
+++ b/packages/lesswrong/lib/collections/posts/callbacks.js
@@ -9,6 +9,12 @@ import { makeEditableOptions, makeEditableOptionsModeration } from './custom_fie
 import { PostRelations } from '../postRelations/index';
 const MINIMUM_APPROVAL_KARMA = 5
 
+function PostsEditSetModifiedAt (data) {
+  data.modifiedAt = new Date()
+  return data;
+}
+addCallback("post.update.before", PostsEditSetModifiedAt);
+
 function PostsEditRunPostUndraftedSyncCallbacks (data, { oldDocument: post }) {
   if (data.draft === false && post.draft) {
     data = runCallbacks("post.undraft.before", data, post);

--- a/packages/lesswrong/lib/collections/posts/fragments.js
+++ b/packages/lesswrong/lib/collections/posts/fragments.js
@@ -11,6 +11,7 @@ registerFragment(`
     slug
     postedAt
     createdAt
+    modifiedAt
     sticky
     metaSticky
     status

--- a/packages/lesswrong/lib/collections/posts/schema.js
+++ b/packages/lesswrong/lib/collections/posts/schema.js
@@ -57,6 +57,13 @@ const schema = {
       }
     }
   },
+  // Timestamp of last post modification
+  modifiedAt: {
+    type: Date,
+    optional: true,
+    viewableBy: ['guests'],
+    onInsert: () => new Date(),
+  },
   // URL
   url: {
     type: String,

--- a/packages/lesswrong/lib/collections/posts/schema.js
+++ b/packages/lesswrong/lib/collections/posts/schema.js
@@ -61,7 +61,6 @@ const schema = {
     type: Date,
     optional: true,
     viewableBy: ['guests'],
-    onInsert: () => new Date(),
     ...denormalizedField({
       getValue: () => {
         return new Date()

--- a/packages/lesswrong/lib/collections/posts/schema.js
+++ b/packages/lesswrong/lib/collections/posts/schema.js
@@ -1,10 +1,9 @@
 import Users from 'meteor/vulcan:users';
 import { Utils, getCollection } from 'meteor/vulcan:core';
 import moment from 'moment';
-import { foreignKeyField, resolverOnlyField } from '../../modules/utils/schemaUtils'
+import { foreignKeyField, resolverOnlyField, denormalizedField } from '../../modules/utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 import { PostRelations } from "../postRelations/collection.js"
-
 
 const formGroups = {
   // TODO - Figure out why properly moving this from custom_fields to schema was producing weird errors and then fix it
@@ -63,6 +62,11 @@ const schema = {
     optional: true,
     viewableBy: ['guests'],
     onInsert: () => new Date(),
+    ...denormalizedField({
+      getValue: () => {
+        return new Date()
+      }
+    }),
   },
   // URL
   url: {

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -433,11 +433,11 @@ Posts.addView("drafts", terms => {
     }
 }});
 ensureIndex(Posts,
-  augmentForDefaultView({ userId: 1, hideAuthor: 1, deletedDraft: 1, createdAt: -1 }),
+  augmentForDefaultView({ userId: 1, hideAuthor: 1, deletedDraft: 1, modifiedAt: -1 }),
   { name: "posts.userId_createdAt" }
 );
 ensureIndex(Posts,
-  augmentForDefaultView({ shareWithUsers: 1, deletedDraft: 1, createdAt: -1 }),
+  augmentForDefaultView({ shareWithUsers: 1, deletedDraft: 1, modifiedAt: -1 }),
   { name: "posts.userId_shareWithUsers" }
 );
 

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -429,7 +429,7 @@ Posts.addView("drafts", terms => {
       hiddenRelatedQuestion: viewFieldAllowAny,
     },
     options: {
-      sort: {createdAt: -1}
+      sort: {modifiedAt: -1}
     }
 }});
 ensureIndex(Posts,

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -429,15 +429,15 @@ Posts.addView("drafts", terms => {
       hiddenRelatedQuestion: viewFieldAllowAny,
     },
     options: {
-      sort: {modifiedAt: -1}
+      sort: {modifiedAt: -1, createdAt: -1}
     }
 }});
 ensureIndex(Posts,
-  augmentForDefaultView({ userId: 1, hideAuthor: 1, deletedDraft: 1, modifiedAt: -1 }),
+  augmentForDefaultView({ userId: 1, hideAuthor: 1, deletedDraft: 1, modifiedAt: -1, createdAt: -1 }),
   { name: "posts.userId_createdAt" }
 );
 ensureIndex(Posts,
-  augmentForDefaultView({ shareWithUsers: 1, deletedDraft: 1, modifiedAt: -1 }),
+  augmentForDefaultView({ shareWithUsers: 1, deletedDraft: 1, modifiedAt: -1, createdAt: -1 }),
   { name: "posts.userId_shareWithUsers" }
 );
 

--- a/packages/lesswrong/server/migrations/2019-11-04-postsModifiedAtField.js
+++ b/packages/lesswrong/server/migrations/2019-11-04-postsModifiedAtField.js
@@ -1,0 +1,10 @@
+import { registerMigration } from './migrationUtils';
+import { recomputeDenormalizedValues } from '../scripts/recomputeDenormalized';
+
+registerMigration({
+  name: "postsModifiedAtField",
+  idempotent: true,
+  action: async () => {
+    await recomputeDenormalizedValues({collectionName: "Posts", fieldName: "modifiedAt"});
+  }
+});


### PR DESCRIPTION
It was getting annoying to find drafts I had recently worked on but created awhile ago, so I added a "modifiedAt" field to posts and now sort drafts by it.