### PR TITLE
Fix event-notification emails

### DIFF
--- a/packages/lesswrong/lib/notificationTypes.jsx
+++ b/packages/lesswrong/lib/notificationTypes.jsx
@@ -86,7 +86,7 @@ export const PostApprovedNotification = registerNotificationType({
 
 export const NewEventNotification = registerNotificationType({
   name: "newEvent",
-  userSettingField: null, //TODO
+  userSettingField: "notificationPostsInGroups",
   getMessage({documentType, documentId}) {
     let document = getDocument(documentType, documentId);
     let group = {}


### PR DESCRIPTION
The bug here was that the `newEvent` notification type wasn't attached to its config setting, so notifications of that type always used the global default setting, which is onsite-only.