### PR TITLE
Remove pr questions in TODOs

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -42,8 +42,6 @@ const standaloneNavMenuRouteNames = {
     'home', 'allPosts', 'questions', 'sequencesHome', 'CommunityHome', 'Shortform', 'Codex',
     'HPMOR', 'Rationality', 'Sequences', 'collections'
   ],
-  // TODO-PR-Q: I left this mimicking current behavior, it's possible you'd
-  // rather just have an empty list
   'AlignmentForum': ['alignment.home', 'sequencesHome', 'allPosts', 'questions', 'Shortform'],
   'EAForum': ['home', 'allPosts', 'questions', 'Community', 'Shortform'],
 }

--- a/packages/lesswrong/components/notifications/NotificationEmailPreviewPage.jsx
+++ b/packages/lesswrong/components/notifications/NotificationEmailPreviewPage.jsx
@@ -11,10 +11,6 @@ const parseIds = (urlStr) => {
   return urlStr.split(",");
 }
 
-// TODO-PR-Q: This currently is named NotificationEmailPreviewPage and is
-// available under a similar URL. I can change it to reflect it's generalized
-// usage, but it would probably be a minor bother for anyone used to using it.
-// LMK what you want me to do.
 const NotificationEmailPreviewPage = () => {
   const currentUser = useCurrentUser();
   const { query } = useLocation();


### PR DESCRIPTION
I realized right after merge that the previous PR still had a question for the reviewer in the comments. And apparently there was another one in there too.