### PR TITLE
version incrementer uses editedAt

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.js
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.js
@@ -202,7 +202,7 @@ function getInitialVersion(document) {
 }
 
 async function getNextVersion(documentId, updateType = 'minor', fieldName, isDraft) {
-  const lastRevision = await Revisions.findOne({documentId: documentId, fieldName}, {sort: {version: -1}}) || {}
+  const lastRevision = await Revisions.findOne({documentId: documentId, fieldName}, {sort: {editedAt: -1}}) || {}
   const { major, minor, patch } = extractVersionsFromSemver(lastRevision.version)
   switch (updateType) {
     case "patch":


### PR DESCRIPTION
Previously, the post-version-incrementor was sorting the existing revisions by version