### PR TITLE
Fix subscription migration

### DIFF
--- a/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.js
+++ b/packages/lesswrong/server/migrations/2019-05-01-migrateSubscriptions.js
@@ -80,7 +80,7 @@ registerMigration({
               newSubscriptions.push({
                 userId: user._id,
                 state: "subscribed",
-                documentId: userSubscribedTo._id,
+                documentId: userSubscribedTo.itemId,
                 collectionName: "Users",
                 type: "newPosts",
               });


### PR DESCRIPTION
This migration caused LW to have to recover from backups. The EA Forum would like to run this migration without using backups. @jimrandomh you were close, instead of `documentId`, it was `itemId`.