### PR TITLE
Display names for editors

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -496,12 +496,11 @@ class EditorFormComponent extends Component {
           onChange={(e) => this.handleEditorOverride(e.target.value)}
           disableUnderline
           >
-            {editors.map((editorType, i) => {
-              console.log('etitorType', editorType)
-              return <MenuItem value={editorType} key={i}>
+            {editors.map((editorType, i) =>
+              <MenuItem value={editorType} key={i}>
                 {editorTypeToDisplay[editorType].name} {editorTypeToDisplay[editorType].postfix}
               </MenuItem>
-            })}
+            )}
           </Select>
       </Tooltip>
     )

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { registerComponent, Components } from 'meteor/vulcan:core';
+import { registerComponent, Components, getSetting } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
 import { withStyles } from '@material-ui/core/styles';
 import { editorStyles, postBodyStyles, postHighlightStyles, commentBodyStyles } from '../../themes/stylePiping'
@@ -98,6 +98,15 @@ const styles = theme => ({
 })
 
 const autosaveInterval = 3000; //milliseconds
+const ckEditorName = getSetting('forumType') === 'EAForum' ? 'EA Forum Docs' : 'LessWrong Docs'
+const editorTypeToDisplay = {
+  html: {name: 'HTML', postfix: '[Admin Only]'},
+  ckEditorMarkup: {name: ckEditorName, postfix: '[Beta]'},
+  markdown: {name: 'Markdown'},
+  draftJS: {name: 'Draft-JS'},
+}
+const nonAdminEditors = ['ckEditorMarkup', 'markdown', 'draftJS']
+const adminEditors = ['html', 'ckEditorMarkup', 'markdown', 'draftJS']
 
 class EditorFormComponent extends Component {
   constructor(props) {
@@ -384,9 +393,15 @@ class EditorFormComponent extends Component {
     const defaultType = this.getUserDefaultEditor(currentUser)
     return <div>
         <Typography variant="body2" color="error">
-          This document was last edited in {type} format. Showing {this.getCurrentEditorType()} editor.
-          <a className={classes.errorTextColor} onClick={() => this.handleEditorOverride(defaultType)}> Click here </a>
-          to switch to {defaultType} editor (your default editor).  
+          This document was last edited in {editorTypeToDisplay[type].name} format. Showing the{' '}
+          {editorTypeToDisplay[this.getCurrentEditorType()].name} editor.{' '}
+          <a
+            className={classes.errorTextColor}
+            onClick={() => this.handleEditorOverride(defaultType)}
+          >
+            Click here
+          </a>
+          {' '}to switch to the {editorTypeToDisplay[defaultType].name} editor (your default editor).
         </Typography>
         <br/>
       </div>
@@ -472,18 +487,21 @@ class EditorFormComponent extends Component {
   renderEditorTypeSelect = () => {
     const { currentUser, classes } = this.props
     if (!userHasCkEditor(currentUser) && !currentUser?.isAdmin) return null
+    const editors = currentUser?.isAdmin ? adminEditors : nonAdminEditors
     return (
       <Tooltip title="Warning! Changing format will erase your content" placement="left">
         <Select
-            className={classes.select}
-            value={this.getCurrentEditorType()}
-            onChange={(e) => this.handleEditorOverride(e.target.value)}
-            disableUnderline
-            >
-            {currentUser.isAdmin  && <MenuItem value={'html'}>HTML [Admin Only]</MenuItem>}
-            <MenuItem value={'markdown'}>Markdown</MenuItem>
-            <MenuItem value={'draftJS'}>Draft-JS</MenuItem>
-            <MenuItem value={'ckEditorMarkup'}>LessWrong Docs [Beta]</MenuItem>
+          className={classes.select}
+          value={this.getCurrentEditorType()}
+          onChange={(e) => this.handleEditorOverride(e.target.value)}
+          disableUnderline
+          >
+            {editors.map((editorType, i) => {
+              console.log('etitorType', editorType)
+              return <MenuItem value={editorType} key={i}>
+                {editorTypeToDisplay[editorType].name} {editorTypeToDisplay[editorType].postfix}
+              </MenuItem>
+            })}
           </Select>
       </Tooltip>
     )

--- a/packages/lesswrong/themes/eaTheme.js
+++ b/packages/lesswrong/themes/eaTheme.js
@@ -150,7 +150,7 @@ const theme = createLWTheme({
       main: {
         margin: '30px auto 15px auto',
         '@media (max-width: 959.95px)': {
-          marginTop: 0
+          marginTop: 36,
         }
       }
     },
@@ -255,6 +255,11 @@ const theme = createLWTheme({
     TabNavigationMenuSubItem: {
       root: {
         color: grey[800]
+      }
+    },
+    PostsPageTitle: {
+      root: {
+        lineHeight: 1.25
       }
     },
     PostsTimeBlock: {


### PR DESCRIPTION
If we're branding the editor as LessWrong Docs, don't show ckEditorMarkup to the user. I also use the name EA Forum Docs depending on forumType.