### PR TITLE
Defensive editor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -128,6 +128,7 @@ class EditorFormComponent extends Component {
   }
 
   getEditorStatesFromType = (editorType, contents) => {
+    // TODO; this should check the contents for being null
     const { document, fieldName, value } = this.props
     const { editorOverride } = this.state || {} // Provide default value, since we can call this before state is initialized
 
@@ -135,8 +136,7 @@ class EditorFormComponent extends Component {
     const newValue = contents || value
 
     // Initialize the editor to whatever the canonicalContent is
-    if (newValue && newValue.originalContents && newValue.originalContents.data
-        && !editorOverride
+    if (newValue?.originalContents?.data && !editorOverride
         && editorType === newValue.originalContents.type)
     {
       return {

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -128,9 +128,12 @@ class EditorFormComponent extends Component {
   }
 
   getEditorStatesFromType = (editorType, contents) => {
-    // TODO; this should check the contents for being null
     const { document, fieldName, value } = this.props
     const { editorOverride } = this.state || {} // Provide default value, since we can call this before state is initialized
+
+    if (!editorType) {
+      throw new Error('getEditorStateFromType must be supplied an editorType')
+    }
 
     // if contents are manually specified, use those:
     const newValue = contents || value
@@ -446,7 +449,10 @@ class EditorFormComponent extends Component {
 
   handleUpdateVersion = async (document) => {
     if (!document) return
-    const editorType = document.contents?.originalContents?.type
+    if (!document.contents?.originalContents) {
+      throw new Error('handleUpdateVersion called with missing document originalContents')
+    }
+    const editorType = document.contents.originalContents.type
     this.setState({
       ...this.getEditorStatesFromType(editorType, document.contents)
     })

--- a/packages/lesswrong/lib/collections/revisions/collection.js
+++ b/packages/lesswrong/lib/collections/revisions/collection.js
@@ -18,6 +18,9 @@ addUniversalFields({collection: Revisions})
 // we will hide those revisions unless they are marked as post-1.0.0 releases. This is not ideal, but
 // seems acceptable
 Revisions.checkAccess = function (user, revision) {
+  if (!revision) {
+    throw new Error('Cannot check access on a missing revision')
+  }
   if ((user && user._id) === revision.userId) return true
   const { major } = extractVersionsFromSemver(revision.version)
   return major > 0

--- a/packages/lesswrong/lib/editor/make_editable.js
+++ b/packages/lesswrong/lib/editor/make_editable.js
@@ -92,7 +92,6 @@ export const makeEditable = ({collection, options = {}}) => {
             const { checkAccess } = Revisions
             if (version) {
               const revision = await Revisions.findOne({documentId: doc._id, version, fieldName: field})
-              // TODO; can we get a test
               if (!revision || !checkAccess(currentUser, revision)) {
                 throw new Error(
                   `No revision found for documentId: ${doc._id}, version: ${version}. ` +

--- a/packages/lesswrong/lib/editor/make_editable.js
+++ b/packages/lesswrong/lib/editor/make_editable.js
@@ -92,7 +92,14 @@ export const makeEditable = ({collection, options = {}}) => {
             const { checkAccess } = Revisions
             if (version) {
               const revision = await Revisions.findOne({documentId: doc._id, version, fieldName: field})
-              return checkAccess(currentUser, revision) ? revision : null
+              // TODO; can we get a test
+              if (!revision || !checkAccess(currentUser, revision)) {
+                throw new Error(
+                  `No revision found for documentId: ${doc_id}, version: ${version}. ` +
+                  'It either doesn\'t exist or you don\'t have access'
+                )
+              }
+              return revision
             }
             return {
               editedAt: (doc[field] && doc[field].editedAt) || new Date(),

--- a/packages/lesswrong/lib/editor/make_editable.js
+++ b/packages/lesswrong/lib/editor/make_editable.js
@@ -95,7 +95,7 @@ export const makeEditable = ({collection, options = {}}) => {
               // TODO; can we get a test
               if (!revision || !checkAccess(currentUser, revision)) {
                 throw new Error(
-                  `No revision found for documentId: ${doc_id}, version: ${version}. ` +
+                  `No revision found for documentId: ${doc._id}, version: ${version}. ` +
                   'It either doesn\'t exist or you don\'t have access'
                 )
               }

--- a/packages/vulcan-core/lib/modules/containers/withSingle.js
+++ b/packages/vulcan-core/lib/modules/containers/withSingle.js
@@ -87,7 +87,7 @@ export function useSingle({ collectionName,
   fragmentName, 
   extraVariables, 
   fetchPolicy, 
-  propertyName, 
+  propertyName, // TODO; intentionally unused? (prolly not worth the todo)
   extraQueries, 
   documentId, 
   extraVariablesValues

--- a/packages/vulcan-core/lib/modules/containers/withSingle.js
+++ b/packages/vulcan-core/lib/modules/containers/withSingle.js
@@ -87,7 +87,7 @@ export function useSingle({ collectionName,
   fragmentName, 
   extraVariables, 
   fetchPolicy, 
-  propertyName, // TODO; intentionally unused? (prolly not worth the todo)
+  propertyName, // TODO: Intentionally unused?
   extraQueries, 
   documentId, 
   extraVariablesValues


### PR DESCRIPTION
Adds several sections of defensive null checking.

More controversially, adds an error if you specifically request a version of a post you don't have access to. I'm not sure where @raemon and I wound up on this, but I think I had addressed his concerns.

The general case against: In general, when you request a document which a) you have access to and b) you don't have access to a field of, you get only the information you have access to. In the case where you do have access to the post but not the revision, therefore, you should get the post info, but not the contents of the version that you don't have access to.

Rebuttal in favor: Requesting a docId and a version is only done to specifically get the contents of that version. In that frame, it's more like the entire document is the thing you don't have access to. This also localizes the error close to the cause.

Specific objection from @Raemon: If you request all versions of a document (which will happen in the future) and a resolver throws an error, this probably leads to you getting *no* results, even for ones that you do have access to.

Rebuttal in favor: The code that requests all versions should either: a) get a list of versions it does have access to and request those. Specifically it should not be able to even find out the version number of a version it doesn't have access to. Or b) bypass the specific-version resolver in favor an approach that returns a list of revisions, silently excluding the ones for which the user does not have access.