### PR TITLE
Update AllPosts options

### DIFF
--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -71,7 +71,7 @@ class AllPostsPage extends Component {
     const {PostsTimeframeList, PostsList2} = Components
 
     const baseTerms = {
-      karmaThreshold: currentShowLowKarma ? MAX_LOW_KARMA_THRESHOLD : DEFAULT_LOW_KARMA_THRESHOLD,
+      karmaThreshold: query.karmaThreshold || (currentShowLowKarma ? MAX_LOW_KARMA_THRESHOLD : DEFAULT_LOW_KARMA_THRESHOLD),
       filter: currentFilter,
       sortedBy: currentSorting,
       after: query.after,

--- a/packages/lesswrong/components/posts/AllPostsPage.jsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.jsx
@@ -109,6 +109,8 @@ class AllPostsPage extends Component {
         dimWhenLoading={showSettings}
         after={query.after || getAfterDefault({numTimeBlocks, timeBlock, timezone})}
         before={query.before  || getBeforeDefault({timeBlock, timezone})}
+        reverse={query.reverse === "true"}
+        displayShortform={query.includeShortform !== "false"}
       />
     </div>
   }

--- a/packages/lesswrong/components/posts/PostsTimeframeList.jsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeList.jsx
@@ -87,17 +87,18 @@ class PostsTimeframeList extends PureComponent {
   }
 
   render() {
-    const { timezone, classes, postListParameters, displayShortform } = this.props
+    const { timezone, classes, postListParameters, displayShortform, reverse } = this.props
     const { timeframe, after, before, dim } = this.state
     const { PostsTimeBlock } = Components
 
     const timeBlock = timeframeToTimeBlock[timeframe]
     const dates = getDateRange(after, before, timeBlock)
-    
+    const orderedDates = reverse ? dates.reverse() : dates
+
     const renderLoadMoreTimeBlocks = dates.length && dates.length > 1
     return (
       <div className={classNames({[classes.loading]: dim})}>
-        {dates.map((date, index) =>
+        {orderedDates.map((date, index) =>
           <PostsTimeBlock
             key={date.toString()+postListParameters?.limit}
             startDate={moment.tz(date, timezone)}


### PR DESCRIPTION
Adds a few optional parameters to the AllPosts page (which later we can add proper UI for)

– Restores the karmaThreshold parameter on AllPosts (which used to work, and I then I think was accidentally replaced with hardcoded constants)

– adds an optional "reverse" parameter, which reverses the ordering of the timeblocks (used in conjunction with the recently added "after" and "before" parameter, which lets you specify the range of timeblocks to display)

– adds a "includeShortform" option which can be set to false, to hide shortform posts