### PR TITLE
2018 Review UI updates

### DIFF
--- a/packages/lesswrong/components/Layout.jsx
+++ b/packages/lesswrong/components/Layout.jsx
@@ -40,7 +40,7 @@ const hashCode = function(str) {
 const standaloneNavMenuRouteNames = {
   'LessWrong': [
     'home', 'allPosts', 'questions', 'sequencesHome', 'CommunityHome', 'Shortform', 'Codex',
-    'HPMOR', 'Rationality', 'Sequences', 'collections'
+    'HPMOR', 'Rationality', 'Sequences', 'collections', 'nominations'
   ],
   'AlignmentForum': ['alignment.home', 'sequencesHome', 'allPosts', 'questions', 'Shortform'],
   'EAForum': ['home', 'allPosts', 'questions', 'Community', 'Shortform'],

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -234,7 +234,7 @@ class CommentsItem extends Component {
               <Components.CommentOutdatedWarning comment={comment} post={post} />
             </span>
           </div>
-          {comment.nominatedForReview && <em>{`Nomination for ${comment.nominatedForReview} Review`}</em>}
+          {comment.nominatedForReview && <Link to={"/nominations"}><em>{`Nomination for ${comment.nominatedForReview} Review`}</em></Link>}
           {this.renderBodyOrEditor()}
           {!comment.deleted && !collapsed && this.renderCommentBottom()}
         </div>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -7,6 +7,7 @@ import { shallowEqual, shallowEqualExcept } from '../../../lib/modules/utils/com
 import { withStyles } from '@material-ui/core/styles';
 import withErrorBoundary from '../../common/withErrorBoundary';
 import withUser from '../../common/withUser';
+import { Link } from '../../../lib/reactRouterWrapper.js';
 
 // Shared with ParentCommentItem
 export const styles = theme => ({

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.jsx
@@ -98,6 +98,11 @@ export const styles = theme => ({
   username: {
     marginRight: 10,
   },
+  nomination: {
+    color: theme.palette.lwTertiary.main,
+    fontStyle: "italic",
+    marginBottom: theme.spacing.unit
+  }
 })
 
 class CommentsItem extends Component {
@@ -235,7 +240,9 @@ class CommentsItem extends Component {
               <Components.CommentOutdatedWarning comment={comment} post={post} />
             </span>
           </div>
-          {comment.nominatedForReview && <Link to={"/nominations"}><em>{`Nomination for ${comment.nominatedForReview} Review`}</em></Link>}
+          {comment.nominatedForReview && <Link to={"/nominations"} className={classes.nomination}>
+            {`Nomination for ${comment.nominatedForReview} Review`}
+          </Link>}
           {this.renderBodyOrEditor()}
           {!comment.deleted && !collapsed && this.renderCommentBottom()}
         </div>

--- a/packages/lesswrong/components/comments/RecentDiscussionThreadsList.jsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThreadsList.jsx
@@ -26,7 +26,7 @@ class RecentDiscussionThreadsList extends PureComponent {
   }
 
   render () {
-    const { results, loading, loadMore, networkStatus, updateComment, currentUser, data: { refetch } } = this.props
+    const { results, loading, loadMore, networkStatus, updateComment, currentUser, data: { refetch }, title="Recent Discussion", shortformButton=true } = this.props
     const { showShortformFeed, expandAllThreads } = this.state
     const { SingleColumnSection, SectionTitle, SectionButton, ShortformSubmitForm, Loading } = Components
     
@@ -40,10 +40,11 @@ class RecentDiscussionThreadsList extends PureComponent {
 
     const expandAll = currentUser?.noCollapseCommentsFrontpage || expandAllThreads
 
+    // TODO: Probably factor out "RecentDiscussionThreadsList" vs "RecentDiscussionSection", rather than making RecentDiscussionThreadsList cover both and be weirdly customizable
     return (
       <SingleColumnSection>
-        <SectionTitle title="Recent Discussion">
-          {currentUser && currentUser.isReviewed && <div onClick={this.toggleShortformFeed}>
+        <SectionTitle title={title}>
+          { currentUser?.isReviewed && shortformButton && <div onClick={this.toggleShortformFeed}>
             <SectionButton>
               <AddBoxIcon />
               New Shortform Post

--- a/packages/lesswrong/components/comments/SingleLineComment.jsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.jsx
@@ -133,7 +133,7 @@ const SingleLineComment = ({comment, classes, nestingLevel, hover, parentComment
           <Components.FormatDate date={comment.postedAt} tooltip={false}/>
         </span>
         {(comment.baseScore > -5) && <span className={classes.truncatedHighlight}> 
-          { comment.nominatedForReview && <span>[Nomination]</span>}
+      { comment.nominatedForReview && <span>[Nomination]{" "}</span>}
           {plaintextMainText} 
         </span>}      
       </div>

--- a/packages/lesswrong/components/comments/SingleLineComment.jsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.jsx
@@ -132,7 +132,10 @@ const SingleLineComment = ({comment, classes, nestingLevel, hover, parentComment
         <span className={classes.date}>
           <Components.FormatDate date={comment.postedAt} tooltip={false}/>
         </span>
-        {(comment.baseScore > -5) && <span className={classes.truncatedHighlight}> {plaintextMainText} </span>}      
+        {(comment.baseScore > -5) && <span className={classes.truncatedHighlight}> 
+          { comment.nominatedForReview && <span>[Nomination]</span>}
+          {plaintextMainText} 
+        </span>}      
       </div>
       {displayHoverOver && <span className={classNames(classes.highlight)}>
         <CommentBody truncated comment={comment}/>

--- a/packages/lesswrong/components/common/SectionFooter.jsx
+++ b/packages/lesswrong/components/common/SectionFooter.jsx
@@ -13,7 +13,9 @@ const styles = (theme) => ({
     marginRight: theme.spacing.unit*1.5,
     marginLeft: theme.spacing.unit,
     color: theme.palette.lwTertiary.main,
+    flexWrap: "wrap",
     '& > *': {
+      marginBottom: theme.spacing.unit,
       '&:after': {
         content: '"•"',
         marginLeft: theme.spacing.unit*2,

--- a/packages/lesswrong/components/common/SectionFooter.jsx
+++ b/packages/lesswrong/components/common/SectionFooter.jsx
@@ -13,30 +13,19 @@ const styles = (theme) => ({
     marginRight: theme.spacing.unit*1.5,
     marginLeft: theme.spacing.unit,
     color: theme.palette.lwTertiary.main,
-    [theme.breakpoints.down('xs')]: {
-      flexWrap: "wrap"
-    },
     '& > *': {
-      [theme.breakpoints.down('xs')]: {
-        width: "100%",
-        textAlign: "right",
-        paddingTop: theme.spacing.unit,
-        paddingBottom: theme.spacing.unit
+      '&:after': {
+        content: '"•"',
+        marginLeft: theme.spacing.unit*2,
+        marginRight: theme.spacing.unit*2,
       },
-      [theme.breakpoints.up('sm')]: {
+      // Each child of the sectionFooter has a bullet divider, except for the last one.
+      '&:last-child': {
         '&:after': {
-          content: '"•"',
-          marginLeft: theme.spacing.unit*2,
-          marginRight: theme.spacing.unit*2,
-        },
-        // Each child of the sectionFooter has a bullet divider, except for the last one.
-        '&:last-child': {
-          '&:after': {
-            content: '""',
-            margin:0,
-          }
-        },
-      }
+          content: '""',
+          margin:0,
+        }
+      },
     }
   }
 })

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.jsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.jsx
@@ -145,8 +145,14 @@ export default {
       divider: true,
       showOnCompressed: true,
     }, {
+      id: 'nominations',
+      title: '2018 Review',
+      link: '/nominations',
+      subItem: true,
+    },
+    {
       id: 'shortform',
-      title: 'Shortform [Beta]',
+      title: 'Shortform',
       link: '/shortform',
       subItem: true,
     }, {

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.jsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.jsx
@@ -97,12 +97,12 @@ const LocalGroupPage = ({ classes, documentId: groupId, currentUser }) => {
                 <React.Fragment>
                   <SectionButton>
                     <Link to={{pathname:"/newPost", search: `?${qs.stringify({eventForm: true, groupId})}`}} className={classes.leftAction}>
-                      Create new event
+                      New event
                     </Link>
                   </SectionButton>
                   <SectionButton>
                     <Link to={{pathname:"/newPost", search: `?${qs.stringify({groupId})}`}} className={classes.leftAction}>
-                      Create new group post
+                      New group post
                     </Link>
                   </SectionButton>
                 </React.Fragment>}

--- a/packages/lesswrong/components/posts/Nominations2018.jsx
+++ b/packages/lesswrong/components/posts/Nominations2018.jsx
@@ -19,10 +19,15 @@ const Nominations2018 = ({classes}) => {
       <SingleColumnSection>
         <SectionTitle title="Nominated Posts for the 2018 Review">
           <a className={classes.setting} onClick={() => setSortBy(!sortByMost)}>
-            Sort by: {sortByMost ? "most" : "fewest"} Nominations
+            Sort by: {sortByMost ? "most" : "fewest"} nominations
           </a>
         </SectionTitle>
-        <PostsList2 terms={{view:"nominations2018", sortByMost: sortByMost}} showNominationCount/>
+        <PostsList2 
+          terms={{view:"nominations2018", sortByMost: sortByMost, limit: 13}} 
+          showNominationCount
+          enableTotal
+          dense
+        />
       </SingleColumnSection>
       <SingleColumnSection>
         <RecentDiscussionThreadsList

--- a/packages/lesswrong/components/posts/Nominations2018.jsx
+++ b/packages/lesswrong/components/posts/Nominations2018.jsx
@@ -3,13 +3,25 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 
 const Nominations2018 = () => {
 
-  const { SingleColumnSection, SectionTitle,  PostsList2 } = Components
+  const { SingleColumnSection, SectionTitle, PostsList2, RecentDiscussionThreadsList } = Components
 
   return (
+    <div>
       <SingleColumnSection>
         <SectionTitle title="Nominated Posts for the 2018 Review"/>
         <PostsList2 terms={{view:"nominations2018"}}/>
       </SingleColumnSection>
+      <SingleColumnSection>
+        <RecentDiscussionThreadsList
+          title="2018 Review Discussion"
+          shortformButton={false}
+          terms={{view: '2018reviewRecentDiscussionThreadsList', limit:20}}
+          commentsLimit={4}
+          maxAgeHours={18}
+          af={false}
+        />
+      </SingleColumnSection>
+    </div>
   )
 }
 

--- a/packages/lesswrong/components/posts/Nominations2018.jsx
+++ b/packages/lesswrong/components/posts/Nominations2018.jsx
@@ -23,7 +23,7 @@ const Nominations2018 = ({classes}) => {
           </a>
         </SectionTitle>
         <PostsList2 
-          terms={{view:"nominations2018", sortByMost: sortByMost, limit: 13}} 
+          terms={{view:"nominations2018", sortByMost: sortByMost, limit: 50}} 
           showNominationCount
           enableTotal
           dense

--- a/packages/lesswrong/components/posts/Nominations2018.jsx
+++ b/packages/lesswrong/components/posts/Nominations2018.jsx
@@ -1,15 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent } from 'meteor/vulcan:core';
+import { withStyles } from '@material-ui/core/styles';
 
-const Nominations2018 = () => {
+const styles = theme => ({
+  setting: {
+    ...theme.typography.body2,
+    color: theme.palette.grey[600]
+  }
+})
+
+const Nominations2018 = ({classes}) => {
+  const [sortByMost, setSortBy] = useState(false);
 
   const { SingleColumnSection, SectionTitle, PostsList2, RecentDiscussionThreadsList } = Components
 
   return (
     <div>
       <SingleColumnSection>
-        <SectionTitle title="Nominated Posts for the 2018 Review"/>
-        <PostsList2 terms={{view:"nominations2018"}}/>
+        <SectionTitle title="Nominated Posts for the 2018 Review">
+          <a className={classes.setting} onClick={() => setSortBy(!sortByMost)}>
+            Sort by: {sortByMost ? "most" : "fewest"} Nominations
+          </a>
+        </SectionTitle>
+        <PostsList2 terms={{view:"nominations2018", sortByMost: sortByMost}} showNominationCount/>
       </SingleColumnSection>
       <SingleColumnSection>
         <RecentDiscussionThreadsList
@@ -25,4 +38,4 @@ const Nominations2018 = () => {
   )
 }
 
-registerComponent('Nominations2018', Nominations2018);
+registerComponent('Nominations2018', Nominations2018, withStyles(styles, {name:"Nominations2018"}));

--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -12,7 +12,6 @@ import { useCurrentUser } from "../common/withUser";
 import classNames from 'classnames';
 import Hidden from '@material-ui/core/Hidden';
 import withRecordPostView from '../common/withRecordPostView';
-import StarOutlinedIcon from '@material-ui/icons/StarOutlined';
 
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
@@ -211,10 +210,7 @@ export const styles = (theme) => ({
     ...theme.typography.body2,
     color: theme.palette.grey[600],
     width: 30,
-    textAlign: "center"
-  },
-  nominationCountIcon: {
-    opacity: .5
+    textAlign: "center",
   },
   sequenceImage: {
     position: "relative",
@@ -455,7 +451,6 @@ const PostsItem2 = ({
               <Tooltip placement="right" title={`This post has ${post.nominationCount2018} nomination${post.nominationCount2018 > 1 ? 's' : ''} for the 2018 review`}>
                 <span>
                   { post.nominationCount2018}
-                  <StarOutlinedIcon className={classes.nominationCountIcon}/>
                 </span>
               </Tooltip>
             </div>}

--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -12,6 +12,7 @@ import { useCurrentUser } from "../common/withUser";
 import classNames from 'classnames';
 import Hidden from '@material-ui/core/Hidden';
 import withRecordPostView from '../common/withRecordPostView';
+import StarOutlinedIcon from '@material-ui/icons/StarOutlined';
 
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
@@ -211,6 +212,9 @@ export const styles = (theme) => ({
     color: theme.palette.grey[600],
     width: 30,
     textAlign: "center"
+  },
+  nominationCountIcon: {
+    opacity: .5
   },
   sequenceImage: {
     position: "relative",
@@ -449,7 +453,10 @@ const PostsItem2 = ({
 
             {showNominationCount && <div className={classes.nominationCount}>
               <Tooltip placement="right" title={`This post has ${post.nominationCount2018} nomination${post.nominationCount2018 > 1 ? 's' : ''} for the 2018 review`}>
-                <span>{ post.nominationCount2018}</span>
+                <span>
+                  { post.nominationCount2018}
+                  <StarOutlinedIcon className={classes.nominationCountIcon}/>
+                </span>
               </Tooltip>
             </div>}
 

--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -206,6 +206,12 @@ export const styles = (theme) => ({
       color: theme.palette.primary.main,
     },
   },
+  nominationCount: {
+    ...theme.typography.body2,
+    color: theme.palette.grey[600],
+    width: 30,
+    textAlign: "center"
+  },
   sequenceImage: {
     position: "relative",
     marginLeft: -60,
@@ -326,6 +332,8 @@ const PostsItem2 = ({
   // icon.
   bookmark,
   // recordPostView, isRead: From the withRecordPostView HoC.
+  // showNominationCount: (bool) whether this should display it's number of Review nominations
+  showNominationCount,
   recordPostView, isRead,
   classes,
 }) => {
@@ -437,6 +445,12 @@ const PostsItem2 = ({
 
             {bookmark && <div className={classes.bookmark}>
               <BookmarkButton post={post}/>
+            </div>}
+
+            {showNominationCount && <div className={classes.nominationCount}>
+              <Tooltip placement="right" title={`This post has ${post.nominationCount2018} nomination${post.nominationCount2018 > 1 && 's'} for the 2018 review`}>
+                <span>{ post.nominationCount2018}</span>
+              </Tooltip>
             </div>}
 
             <div className={classes.mobileDismissButton}>

--- a/packages/lesswrong/components/posts/PostsItem2.jsx
+++ b/packages/lesswrong/components/posts/PostsItem2.jsx
@@ -448,7 +448,7 @@ const PostsItem2 = ({
             </div>}
 
             {showNominationCount && <div className={classes.nominationCount}>
-              <Tooltip placement="right" title={`This post has ${post.nominationCount2018} nomination${post.nominationCount2018 > 1 && 's'} for the 2018 review`}>
+              <Tooltip placement="right" title={`This post has ${post.nominationCount2018} nomination${post.nominationCount2018 > 1 ? 's' : ''} for the 2018 review`}>
                 <span>{ post.nominationCount2018}</span>
               </Tooltip>
             </div>}

--- a/packages/lesswrong/components/posts/PostsList2.jsx
+++ b/packages/lesswrong/components/posts/PostsList2.jsx
@@ -53,7 +53,9 @@ const PostsList2 = ({
   showLoading = true, showLoadMore = true, showNoResults = true,
   hideLastUnread = false,
   enableTotal=false,
+  showNominationCount,
   classes,
+  dense,
 }) => {
   const [haveLoadedMore, setHaveLoadedMore] = useState(false);
   const { results, loading, error, count, totalCount, loadMore, limit } = useMulti({
@@ -114,15 +116,15 @@ const PostsList2 = ({
           ? <PostsItem2 key={post._id}
              post={post} terms={terms} index={i}
              showQuestionTag={terms.filter!=="questions"}
-             showNominationCount
-             dense
+             showNominationCount={showNominationCount}
+             dense={dense}
              hideOnSmallScreens
             />
           : <PostsItem2 key={post._id}
               post={post} terms={terms} index={i}
               showQuestionTag={terms.filter!=="questions"}
-              showNominationCount
-              dense
+              showNominationCount={showNominationCount}
+              dense={dense}
             />
       )}
       {(showLoadMore || children?.length>0) && <SectionFooter>

--- a/packages/lesswrong/components/posts/PostsList2.jsx
+++ b/packages/lesswrong/components/posts/PostsList2.jsx
@@ -113,11 +113,13 @@ const PostsList2 = ({
           ? <PostsItem2 key={post._id}
              post={post} terms={terms} index={i}
              showQuestionTag={terms.filter!=="questions"}
+             showNominationCount
              hideOnSmallScreens
             />
           : <PostsItem2 key={post._id}
               post={post} terms={terms} index={i}
               showQuestionTag={terms.filter!=="questions"}
+              showNominationCount
             />
       )}
       {(showLoadMore || children?.length>0) && <SectionFooter>

--- a/packages/lesswrong/components/posts/PostsList2.jsx
+++ b/packages/lesswrong/components/posts/PostsList2.jsx
@@ -52,6 +52,7 @@ const PostsList2 = ({
   dimWhenLoading = false,
   showLoading = true, showLoadMore = true, showNoResults = true,
   hideLastUnread = false,
+  enableTotal=false,
   classes,
 }) => {
   const [haveLoadedMore, setHaveLoadedMore] = useState(false);
@@ -61,7 +62,7 @@ const PostsList2 = ({
     collection: Posts,
     queryName: 'postsListQuery',
     fragmentName: 'PostsList',
-    enableTotal: false,
+    enableTotal: enableTotal,
     fetchPolicy: 'cache-and-network',
     ssr: true
   });
@@ -114,12 +115,14 @@ const PostsList2 = ({
              post={post} terms={terms} index={i}
              showQuestionTag={terms.filter!=="questions"}
              showNominationCount
+             dense
              hideOnSmallScreens
             />
           : <PostsItem2 key={post._id}
               post={post} terms={terms} index={i}
               showQuestionTag={terms.filter!=="questions"}
               showNominationCount
+              dense
             />
       )}
       {(showLoadMore || children?.length>0) && <SectionFooter>

--- a/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
+++ b/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
@@ -1,17 +1,10 @@
 import React from 'react';
 import { Components, registerComponent } from 'meteor/vulcan:core';
-import Typography from '@material-ui/core/Typography';
 import { Link } from '../../lib/reactRouterWrapper.js';
 import Tooltip from '@material-ui/core/Tooltip';
-import Hidden from '@material-ui/core/Hidden';
-import { withStyles } from '@material-ui/core/styles';
-
-const styles = theme => ({
-
-})
 
 const Recommendations2018Review = ({settings}) => {
-  const { SubSection, SectionSubtitle, RecommendationsList, SeparatorBullet, SectionFooter } = Components
+  const { SubSection, SectionSubtitle, RecommendationsList, SectionFooter } = Components
 
   const reviewTooltip = <div>
     <div>This month, the LessWrong community is reflecting on posts from 2018</div>

--- a/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
+++ b/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Components, registerComponent } from 'meteor/vulcan:core';
+import Typography from '@material-ui/core/Typography';
+import { Link } from '../../lib/reactRouterWrapper.js';
+import Tooltip from '@material-ui/core/Tooltip';
+import Hidden from '@material-ui/core/Hidden';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+
+})
+
+const Recommendations2018Review = ({settings}) => {
+  const { SubSection, SectionSubtitle, RecommendationsList, SeparatorBullet, SectionFooter } = Components
+
+  const reviewTooltip = <div>
+    <div>This month, the LessWrong community is reflecting on posts from 2018</div>
+    <ul>
+      <li>Users with 1000+ karma can nominate posts until</li>
+    </ul>
+  </div>
+
+  const review2018TopUrl = ""
+  const review2018MonthlyUrl = ""
+
+  return (
+    <div>
+      <Tooltip placement="top-start" title={reviewTooltip}>
+        <Link to={"/nominations"}>
+          <SectionSubtitle >
+            The LessWrong 2018 Review
+          </SectionSubtitle>
+        </Link>
+      </Tooltip>
+      <SubSection>
+        <RecommendationsList algorithm={{...settings, review2018: true}} showLoginPrompt={false} />
+      </SubSection>
+      <SectionFooter>
+        <Link to={review2018TopUrl}>
+          Top 2018 Posts
+        </Link>
+        <Link to={review2018MonthlyUrl}>
+          2018 Posts by Month
+        </Link>
+      </SectionFooter>
+    </div>
+  )
+}
+
+registerComponent('Recommendations2018Review', Recommendations2018Review);

--- a/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
+++ b/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
@@ -29,14 +29,14 @@ const Recommendations2018Review = ({settings}) => {
         <RecommendationsList algorithm={{...settings, review2018: true, excludeDefaultRecommendations: true}} showLoginPrompt={false} />
       </SubSection>
       <SectionFooter>
+        <Link to={"/nominations"}>
+          View All Nominations
+        </Link>
         <Link to={review2018TopUrl}>
           Top 2018 Posts
         </Link>
         <Link to={review2018MonthlyUrl}>
-          2018 Posts by Month
-        </Link>
-        <Link to={"/nominations"}>
-          All Nominations
+          2018 Posts Monthly
         </Link>
       </SectionFooter>
     </div>

--- a/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
+++ b/packages/lesswrong/components/recommendations/Recommendations2018Review.jsx
@@ -13,8 +13,8 @@ const Recommendations2018Review = ({settings}) => {
     </ul>
   </div>
 
-  const review2018TopUrl = ""
-  const review2018MonthlyUrl = ""
+  const review2018TopUrl = "/allPosts?after=2018-01-01&before=2019-01-01&limit=100&timeframe=allTime"
+  const review2018MonthlyUrl = "/allPosts?after=2018-01-01&before=2019-01-01&limit=14&timeframe=monthly&includeShortform=false&reverse=true"
 
   return (
     <div>
@@ -26,7 +26,7 @@ const Recommendations2018Review = ({settings}) => {
         </Link>
       </Tooltip>
       <SubSection>
-        <RecommendationsList algorithm={{...settings, review2018: true}} showLoginPrompt={false} />
+        <RecommendationsList algorithm={{...settings, review2018: true, excludeDefaultRecommendations: true}} showLoginPrompt={false} />
       </SubSection>
       <SectionFooter>
         <Link to={review2018TopUrl}>
@@ -34,6 +34,9 @@ const Recommendations2018Review = ({settings}) => {
         </Link>
         <Link to={review2018MonthlyUrl}>
           2018 Posts by Month
+        </Link>
+        <Link to={"/nominations"}>
+          All Nominations
         </Link>
       </SectionFooter>
     </div>

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.jsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.jsx
@@ -16,7 +16,7 @@ const recommendationAlgorithms = [
   {
     name: "sample",
     description: "Weighted sample"
-  },
+  }
 ];
 
 function getDefaultSettings(configName) {

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.jsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.jsx
@@ -19,6 +19,7 @@ const styles = theme => ({
     marginBottom: theme.spacing.unit*2,
   },
   curated: {
+    marginTop: theme.spacing.unit,
     display: "block"
   },
   subtitle: {

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.jsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.jsx
@@ -19,14 +19,12 @@ const styles = theme => ({
     marginBottom: theme.spacing.unit*2,
   },
   curated: {
-    display: "block",
-    marginTop: theme.spacing.unit*2,
+    display: "block"
   },
   subtitle: {
     [theme.breakpoints.down('sm')]:{
       marginBottom: 0,
-    },
-    marginBottom: theme.spacing.unit,
+    }
   },
   footerWrapper: {
     display: "flex",
@@ -70,7 +68,7 @@ class RecommendationsAndCurated extends PureComponent {
   render() {
     const { continueReading, classes, currentUser } = this.props;
     const { showSettings } = this.state
-    const { BetaTag, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, RecommendationsList, PostsList2, SubscribeWidget, SectionTitle, SectionSubtitle, SubSection, SeparatorBullet, BookmarksList } = Components;
+    const { BetaTag, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, SubscribeWidget, SectionTitle, SectionSubtitle, SubSection, SeparatorBullet, BookmarksList, Recommendations2018Review } = Components;
 
     const configName = "frontpage"
     const settings = getRecommendationSettings({settings: this.state.settings, currentUser, configName})
@@ -93,13 +91,14 @@ class RecommendationsAndCurated extends PureComponent {
       <div><em>(Click to see all)</em></div>
     </div>
 
-    const allTimeTooltip = <div>
-      <div>
-        A weighted, randomized sample of the highest karma posts
-        {settings.onlyUnread && " that you haven't read yet"}.
-      </div>
-      <div><em>(Click to see more recommendations)</em></div>
-    </div>
+    // Disabled during 2018 Review
+    // const allTimeTooltip = <div>
+    //   <div>
+    //     A weighted, randomized sample of the highest karma posts
+    //     {settings.onlyUnread && " that you haven't read yet"}.
+    //   </div>
+    //   <div><em>(Click to see more recommendations)</em></div>
+    // </div>
 
     // defaultFrontpageSettings does not contain anything that overrides a user
     // editable setting, so the reverse ordering here is fine
@@ -157,7 +156,10 @@ class RecommendationsAndCurated extends PureComponent {
           </SubSection>
       </React.Fragment>}
 
-      {!settings.hideFrontpage && <div>
+      <Recommendations2018Review settings={frontpageRecommendationSettings} />
+
+      {/* Disabled during 2018 Review */}
+      {/* {!settings.hideFrontpage && <div>
         <div>
           <Tooltip placement="top-start" title={allTimeTooltip}>
             <Link to={"/recommendations"}>
@@ -171,7 +173,7 @@ class RecommendationsAndCurated extends PureComponent {
         <SubSection>
           <RecommendationsList algorithm={frontpageRecommendationSettings} />
         </SubSection>
-      </div>}
+      </div>} */}
 
       <Tooltip placement="top-start" title={curatedTooltip}>
         <Link to={curatedUrl}>

--- a/packages/lesswrong/components/recommendations/RecommendationsList.jsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.jsx
@@ -5,7 +5,7 @@ import { withRecommendations } from './withRecommendations';
 
 class RecommendationsList extends Component {
   render() {
-    const { recommendations, recommendationsLoading, currentUser } = this.props;
+    const { recommendations, recommendationsLoading, currentUser, showLoginPrompt=true } = this.props;
     const { PostsItem2, PostsLoading, SectionFooter, LoginPopupButton } = Components;
     
     const nameWithArticle = getSetting('siteNameWithArticle')
@@ -23,7 +23,7 @@ class RecommendationsList extends Component {
         <PostsItem2 post={post} key={post._id}/>)}
       {recommendations.length===0 &&
         <span>There are no more recommendations left.</span>}
-      {!currentUser && <SectionFooter>
+      {!currentUser && showLoginPrompt && <SectionFooter>
         <LoginPopupButton title={improvedRecommendationsTooltip}>
           Log in for improved recommendations
         </LoginPopupButton>

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -247,12 +247,12 @@ class UsersProfile extends Component {
               Manage Subscriptions
             </Link>}
             { currentUser && currentUser._id != user._id && <NewConversationButton user={user}>
-              <a>Send Message</a>
+              <a>Message</a>
             </NewConversationButton>}
             { currentUser && currentUser._id !== user._id && <SubscribeTo
               document={user}
-              subscribeMessage="Subscribe to this user's posts"
-              unsubscribeMessage="Unsubscribe from this user's posts"
+              subscribeMessage="Subscribe to posts"
+              unsubscribeMessage="Unsubscribe from posts"
             /> }
             {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
               <FormattedMessage id="users.edit_account"/>

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -226,7 +226,11 @@ class UsersProfile extends Component {
       <div className={classNames("page", "users-profile", classes.profilePage)}>
         {/* Bio Section */}
         <SingleColumnSection>
-          <SectionTitle title={Users.getDisplayName(user)}/>
+          <SectionTitle title={Users.getDisplayName(user)}>
+            {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
+              <FormattedMessage id="users.edit_account"/>
+            </Link>}
+          </SectionTitle>
 
           <SectionFooter>
             { this.renderMeta() }
@@ -254,9 +258,6 @@ class UsersProfile extends Component {
               subscribeMessage="Subscribe to posts"
               unsubscribeMessage="Unsubscribe from posts"
             /> }
-            {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
-              <FormattedMessage id="users.edit_account"/>
-            </Link>}
           </SectionFooter>
 
           { user.bio && <ContentItemBody className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} description={`user ${user._id} bio`} /> }

--- a/packages/lesswrong/components/users/UsersProfile.jsx
+++ b/packages/lesswrong/components/users/UsersProfile.jsx
@@ -17,7 +17,7 @@ import { postBodyStyles } from '../../themes/stylePiping'
 export const sectionFooterLeftStyles = {
   flexGrow: 1,
   display: "flex",
-  '&:after': {
+  '&&:after': {
     content: '""'
   }
 }
@@ -29,7 +29,13 @@ const styles = theme => ({
       margin: 0,
     }
   },
-  meta: sectionFooterLeftStyles,
+  meta: {
+    ...sectionFooterLeftStyles,
+    [theme.breakpoints.down('sm')]: {
+      width: "100%",
+      marginBottom: theme.spacing.unit,
+    }
+  },
   icon: {
     '&$specificalz': {
       fontSize: 18,
@@ -226,22 +232,18 @@ class UsersProfile extends Component {
       <div className={classNames("page", "users-profile", classes.profilePage)}>
         {/* Bio Section */}
         <SingleColumnSection>
-          <SectionTitle title={Users.getDisplayName(user)}>
-            {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
-              <FormattedMessage id="users.edit_account"/>
-            </Link>}
-          </SectionTitle>
+          <SectionTitle title={Users.getDisplayName(user)}/>
 
           <SectionFooter>
             { this.renderMeta() }
             { user.twitterUsername &&  <a href={"https://twitter.com/" + user.twitterUsername}>
               @{user.twitterUsername}
             </a>}
-            { currentUser && currentUser.isAdmin &&
+            { currentUser?.isAdmin &&
               <div>
                 <DialogGroup
                   actions={[]}
-                  trigger={<span>Register RSS Feed</span>}
+                  trigger={<span>Register RSS</span>}
                 >
                   <div><Components.newFeedButton user={user} /></div>
                 </DialogGroup>
@@ -258,6 +260,9 @@ class UsersProfile extends Component {
               subscribeMessage="Subscribe to posts"
               unsubscribeMessage="Unsubscribe from posts"
             /> }
+            {Users.canEdit(currentUser, user) && <Link to={Users.getEditUrl(user)}>
+              <FormattedMessage id="users.edit_account"/>
+            </Link>}
           </SectionFooter>
 
           { user.bio && <ContentItemBody className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} description={`user ${user._id} bio`} /> }

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -831,8 +831,7 @@ Posts.addView("nominations2018", terms => {
     options: {
       sort: {
         nominationCount2018: terms.sortByMost ? -1 : 1
-      },
-      limit: 100
+      }
     }
   }
 })

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -553,6 +553,23 @@ ensureIndex(Posts,
   { name: "posts.afRecentDiscussionThreadsList", }
 );
 
+Posts.addView("2018reviewRecentDiscussionThreadsList", terms => {
+  return {
+    selector: {
+      ...recentDiscussionFilter,
+      nominationCount2018: { $gt: 0 }
+    },
+    options: {
+      sort: {lastCommentedAt:-1},
+      limit: terms.limit || 12,
+    }
+  }
+})
+ensureIndex(Posts,
+  augmentForDefaultView({ nominationCount2018: 1, lastCommentedAt:-1, baseScore:1, hideFrontpageComments:1 }),
+  { name: "posts.2018reviewRecentDiscussionThreadsList", }
+);
+
 Posts.addView("shortformDiscussionThreadsList", terms => {
   return {
     selector: {

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -830,7 +830,7 @@ Posts.addView("nominations2018", terms => {
     },
     options: {
       sort: {
-        nominationCount2018: -1
+        nominationCount2018: 1
       },
       limit: 100
     }

--- a/packages/lesswrong/lib/collections/posts/views.js
+++ b/packages/lesswrong/lib/collections/posts/views.js
@@ -830,7 +830,7 @@ Posts.addView("nominations2018", terms => {
     },
     options: {
       sort: {
-        nominationCount2018: 1
+        nominationCount2018: terms.sortByMost ? -1 : 1
       },
       limit: 100
     }

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -425,4 +425,5 @@ importComponent("RecommendationsAlgorithmPicker", () => require('../components/r
 importComponent("RecommendationsList", () => require('../components/recommendations/RecommendationsList.jsx'));
 importComponent("RecommendationsPage", () => require('../components/recommendations/RecommendationsPage.jsx'));
 importComponent("RecommendationsAndCurated", () => require('../components/recommendations/RecommendationsAndCurated.jsx'));
+importComponent("Recommendations2018Review", () => require('../components/recommendations/Recommendations2018Review.jsx'));
 

--- a/packages/lesswrong/server/recommendations.js
+++ b/packages/lesswrong/server/recommendations.js
@@ -58,6 +58,9 @@ const pipelineFilterUnread = ({currentUser}) => {
 // deterministically combine them without writing out each individual case
 // combinatorially. . ... Yeah .... Sometimes life is hard.
 const getInclusionSelector = algorithm => {
+  if (algorithm.review2018) {
+    return { postedAt: {$gt: new Date("2018-01-01"), $lt: new Date("2019-09-01")}}
+  }
   if (algorithm.includePersonal) {
     if (algorithm.includeMeta) {
       return {}

--- a/packages/lesswrong/server/recommendations.js
+++ b/packages/lesswrong/server/recommendations.js
@@ -158,7 +158,7 @@ const samplePosts = async ({count, currentUser, algorithm, sampleWeightFn}) => {
 
   const numPostsToReturn = Math.max(0, Math.min(recommendablePostsMetadata.length, count))
 
-  const defaultRecommendations = recommendablePostsMetadata.filter(p=> !!p.defaultRecommendation).map(p=>p._id)
+  const defaultRecommendations = algorithm.excludeDefaultRecommendations ? [] : recommendablePostsMetadata.filter(p=> !!p.defaultRecommendation).map(p=>p._id)
 
   const sampledPosts = new WeightedList(
     _.map(recommendablePostsMetadata, post => [post._id, sampleWeightFn(post)])

--- a/packages/lesswrong/server/recommendations.js
+++ b/packages/lesswrong/server/recommendations.js
@@ -59,7 +59,7 @@ const pipelineFilterUnread = ({currentUser}) => {
 // combinatorially. . ... Yeah .... Sometimes life is hard.
 const getInclusionSelector = algorithm => {
   if (algorithm.review2018) {
-    return { postedAt: {$gt: new Date("2018-01-01"), $lt: new Date("2019-09-01")}}
+    return { postedAt: {$gt: new Date("2018-01-01"), $lt: new Date("2019-01-01")}}
   }
   if (algorithm.includePersonal) {
     if (algorithm.includeMeta) {


### PR DESCRIPTION
– CommentsItem-Nomination UI now links to the /nominations page
– /nominations page now has a RecentDiscussion section
– /nominations page now displays nomination counts, default sorted by "fewest"
– Frontpage replaces "From the Archives" with "The LessWrong 2018 Review" section