### PR TITLE
Tagging tweaks

### DIFF
--- a/packages/lesswrong/components/tagging/AddTag.jsx
+++ b/packages/lesswrong/components/tagging/AddTag.jsx
@@ -27,25 +27,30 @@ const styles = theme => ({
 
 const AddTag = ({post, onTagSelected, classes}) => {
   const currentUser = useCurrentUser();
+  const [searchOpen, setSearchOpen] = React.useState(false);
   const algoliaAppId = getSetting('algolia.appId')
   const algoliaSearchKey = getSetting('algolia.searchKey')
+  const searchStateChanged = React.useCallback((searchState) => {
+    setSearchOpen(searchState.query?.length > 0);
+  }, []);
   
   return <div className={classes.root}>
     <InstantSearch
       indexName={algoliaIndexNames.Tags}
       appId={algoliaAppId}
       apiKey={algoliaSearchKey}
+      onSearchStateChange={searchStateChanged}
     >
       <SearchBox reset={null} focusShortcuts={[]} autoFocus={false}/>
       
-      <Hits hitComponent={({hit}) =>
+      {searchOpen && <Hits hitComponent={({hit}) =>
         <Components.TagSearchHit hit={hit}
           onClick={ev => {
             onTagSelected(hit);
             ev.stopPropagation();
           }}
         />
-      }/>
+      }/>}
     </InstantSearch>
     {currentUser?.isAdmin &&
       <Link to="/tag/create" className={classes.newTag}>

--- a/packages/lesswrong/lib/collections/tagRels/views.js
+++ b/packages/lesswrong/lib/collections/tagRels/views.js
@@ -7,6 +7,7 @@ TagRels.addView('postsWithTag', terms => {
       tagId: terms.tagId,
       baseScore: {$gt: 0},
     },
+    sort: {baseScore: -1},
   }
 });
 
@@ -16,6 +17,7 @@ TagRels.addView('tagsOnPost', terms => {
       postId: terms.postId,
       baseScore: {$gt: 0},
     },
+    sort: {baseScore: -1},
   }
 });
 


### PR DESCRIPTION
Sort tags by descending relevance on post pages and in post footers. In the add-tag search popup, hide the search results until you start typing a query. Autofocus the search box when you click Add Tag (this one turns out to be surprisingly complicated).