### PR TITLE
Visual fixes to EditTitle

### DIFF
--- a/packages/lesswrong/components/editor/EditTitle.jsx
+++ b/packages/lesswrong/components/editor/EditTitle.jsx
@@ -16,15 +16,17 @@ const styles = theme => ({
     borderBottom: "solid 1px rgba(0,0,0,.2)",
     '&:focused': {
       borderBottom: "solid 1px rgba(0,0,0,.2)"
-    }
+    },
+    "& textarea": {
+      overflowY: "hidden",
+    },
   },
   question: {
     fontSize: theme.typography.display1.fontSize,
-    height: 65,
+    minHeight: 65,
     paddingTop: theme.spacing.unit*1.5,
     lineHeight: '1.2em',
-    borderBottom: "none"
-  }
+  },
 })
 
 class EditTitle extends Component {
@@ -47,6 +49,7 @@ class EditTitle extends Component {
         })
       }}
       multiline
+      disableUnderline={true}
     />
   }
 }

--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -18,6 +18,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { userHasCkEditor } from '../../lib/betas.js';
 
 const postEditorHeight = 250;
+const questionEditorHeight = 150;
 const commentEditorHeight = 100;
 const postEditorHeightRows = 15;
 const commentEditorHeightRows = 5;
@@ -72,6 +73,12 @@ const styles = theme => ({
     minHeight: commentEditorHeight,
     '& .ck.ck-content': {
       minHeight: commentEditorHeight,
+    }
+  },
+  questionEditorHeight: {
+    minHeight: questionEditorHeight,
+    '& .ck.ck-content': {
+      minHeight: questionEditorHeight,
     }
   },
   errorTextColor: {
@@ -617,8 +624,10 @@ class EditorFormComponent extends Component {
 
   getHeightClass = () => {
     const { document, classes, form: { commentStyles } } = this.props
-    if (commentStyles || document.question) {
+    if (commentStyles) {
       return classes.commentEditorHeight
+    } else if (document.question) {
+      return classes.questionEditorHeight;
     } else {
       return classes.postEditorHeight
     }


### PR DESCRIPTION
Fix some visual/layout problems with forms, particularly the `EditTitle` component.
 * Replaced double-bottom-border in `EditTitle` with single-bottom-border, to match post pages
 * Got rid of spurious vertical scroll arrows
 * Changed vertical sizing of the ask-a-question dialog to prevent overlap

Before:

![QuestionDialogBefore](https://user-images.githubusercontent.com/101191/69512130-b4211780-0ef7-11ea-94a9-affd4e4846aa.png)

After:

![QuestionDialogAfter](https://user-images.githubusercontent.com/101191/69512133-b6837180-0ef7-11ea-9d8e-3ecdca374277.png)
