### PR TITLE
rearrange mobile secondary postPage info

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -19,6 +19,7 @@ const DEFAULT_TOC_MARGIN = 100
 const MAX_TOC_WIDTH = 270
 const MIN_TOC_WIDTH = 200
 const MAX_COLUMN_WIDTH = 720
+const SECONDARY_SPACING = 20
 
 const styles = theme => ({
   root: {
@@ -112,24 +113,24 @@ const styles = theme => ({
     fontSize: '1.4rem',
   },
   commentsLink: {
-    marginLeft: 20,
+    marginRight: SECONDARY_SPACING,
     color: theme.palette.grey[600],
     whiteSpace: "no-wrap",
+    display: "inline-block",
     fontSize: theme.typography.body2.fontSize,
   },
   wordCount: {
     display: 'none',
-    marginLeft: 20,
+    marginRight: SECONDARY_SPACING,
     color: theme.palette.grey[600],
     whiteSpace: "no-wrap",
     fontSize: theme.typography.body2.fontSize,
     [theme.breakpoints.down('sm')]: {
-      display: 'inline'
+      display: 'inline-block'
     }
   },
   actions: {
     display: 'inline-block',
-    marginLeft: 15,
     cursor: "pointer",
     color: theme.palette.grey[600],
   },
@@ -160,8 +161,9 @@ const styles = theme => ({
       maxWidth: MAX_COLUMN_WIDTH
     }
   },
-  inline: {
-    display: 'inline-block'
+  authors: {
+    display: 'inline-block',
+    marginRight: SECONDARY_SPACING
   },
   unreviewed: {
     fontStyle: "italic",
@@ -175,12 +177,16 @@ const styles = theme => ({
   },
   feedName: {
     fontSize: theme.typography.body2.fontSize,
-    marginLeft: 20,
+    marginRight: SECONDARY_SPACING,
     display: 'inline-block',
     color: theme.palette.grey[600],
     [theme.breakpoints.down('sm')]: {
       display: "none"
     }
+  },
+  date: {
+    marginRight: SECONDARY_SPACING,
+    display: 'inline-block',
   },
   commentsSection: {
     minHeight: 'calc(70vh - 100px)',
@@ -201,7 +207,7 @@ const styles = theme => ({
     color: theme.palette.grey[600]
   },
   postType: {
-    marginLeft: 20
+    marginRight: SECONDARY_SPACING
   }
 })
 
@@ -298,7 +304,7 @@ class PostsPage extends Component {
                 <div className={classes.headerLeft}>
                   <PostsPageTitle post={post} />
                   <div className={classes.secondaryInfo}>
-                    <span className={classes.inline}>
+                    <span className={classes.authors}>
                       <PostsAuthors post={post}/>
                     </span>
                     <span className={classes.postType}>
@@ -311,10 +317,12 @@ class PostsPage extends Component {
                         </a>
                       </Tooltip>
                     }
-                    {!post.isEvent && <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />}
                     {!!wordCount && !post.isEvent &&  <Tooltip title={`${wordCount} words`}>
                         <span className={classes.wordCount}>{parseInt(wordCount/300) || 1 } min read</span>
                     </Tooltip>}
+                    {!post.isEvent && <span className={classes.date}>
+                      <PostsPageDate post={post} hasMajorRevision={hasMajorRevision} />
+                    </span>}
                     {post.types && post.types.length > 0 && <Components.GroupLinks document={post} />}
                     <a className={classes.commentsLink} href={"#comments"}>{ Posts.getCommentCountStr(post)}</a>
                     <span className={classes.actions}>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageDate.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageDate.jsx
@@ -3,26 +3,18 @@ import { registerComponent, Components } from 'meteor/vulcan:core';
 import { withStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import { ExpandedDate } from '../../common/FormatDate.jsx';
-import classNames from 'classnames';
 
 const styles = theme => ({
   date: {
-    marginLeft: 20,
-    display: 'inline-block',
     color: theme.palette.grey[600],
+    whiteSpace: "no-wrap",
     fontSize: theme.typography.body2.fontSize,
   },
   mobileDate: {
     [theme.breakpoints.up('md')]: {
       display:"none"
     }
-  },
-  desktopDate: {
-    whiteSpace: "no-wrap",
-    [theme.breakpoints.down('sm')]: {
-      display:"none"
-    }
-  },
+  }
 });
 
 const PostsPageDate = ({ post, hasMajorRevision, classes }) => {
@@ -38,27 +30,17 @@ const PostsPageDate = ({ post, hasMajorRevision, classes }) => {
 
   if (hasMajorRevision) {
     return (
-      <span>
-        <span className={classNames(classes.date, classes.mobileDate)}>
-          <PostsRevisionSelector post={post}/>
-        </span>
-        <span className={classNames(classes.date, classes.desktopDate)}>
-          <PostsRevisionSelector format="Do MMM YYYY" post={post}/>
-        </span>
+      <span className={classes.date}>
+        <PostsRevisionSelector format="Do MMM YYYY" post={post}/>
       </span>
     )
   }
   
   return (<React.Fragment>
     <Tooltip title={tooltip} placement="bottom">
-      <span>
-        <span className={classNames(classes.date, classes.mobileDate)}>
-          <FormatDate date={post.postedAt} tooltip={false} />
-        </span>
-        <span className={classNames(classes.date, classes.desktopDate)}>
+        <span className={classes.date}>
           <FormatDate date={post.postedAt} format="Do MMM YYYY" tooltip={false} />
         </span>
-      </span>
     </Tooltip>
   </React.Fragment>);
 }


### PR DESCRIPTION
The comment-count info on mobile post pages were being split over multiple lines, which was hard to read and click. I made all the secondary-info into inline-blocks so that "no wrap" worked properly, and then rearranged them slightly:

![image](https://user-images.githubusercontent.com/3246710/69545405-9e870e80-0f46-11ea-9a80-8e83256d5e9c.png)
