### PR TITLE
fix truncation

### DIFF
--- a/packages/lesswrong/lib/editor/ellipsize.jsx
+++ b/packages/lesswrong/lib/editor/ellipsize.jsx
@@ -96,14 +96,18 @@ export const commentExcerptFromHTML = (comment, currentUser, postPage) => {
 
   const truncationCharCount = getTruncationCharCount(comment, currentUser, postPage)
 
-  return truncatise(htmlRemovedStyles, {
-    // We want the amount comments get truncated to to be less than the threshold at which they are truncated, so that users don't have the experience of expanding a comment only to see a couple more words (which just feels silly).
-
-    // This varies by the size of the comment or truncation amount, and reducing it by 1/4th seems about right.
-    TruncateLength: Math.floor(truncationCharCount - (truncationCharCount/4)),
-    TruncateBy: "characters",
-    Suffix: `... <span class="read-more"><a class="read-more-default">(Read more)</a><a class="read-more-tooltip">(Click to expand thread. ⌘/CTRL+F to Expand All)</a><span class="read-more-f-tooltip">Cmd/Ctrl F to expand all comments on this post</span></span>${styles}`,
-  });
+  if (htmlRemovedStyles.length > truncationCharCount) {
+    return truncatise(htmlRemovedStyles, {
+      // We want the amount comments get truncated to to be less than the threshold at which they are truncated, so that users don't have the experience of expanding a comment only to see a couple more words (which just feels silly).
+  
+      // This varies by the size of the comment or truncation amount, and reducing it by 1/4th seems about right.
+      TruncateLength: Math.floor(truncationCharCount - (truncationCharCount/4)),
+      TruncateBy: "characters",
+      Suffix: `... <span class="read-more"><a class="read-more-default">(Read more)</a><a class="read-more-tooltip">(Click to expand thread. ⌘/CTRL+F to Expand All)</a><span class="read-more-f-tooltip">Cmd/Ctrl F to expand all comments on this post</span></span>${styles}`,
+    });
+  } else {
+    return htmlRemovedStyles
+  }
 };
 
 export const excerptFromMarkdown = (body, mdi) => {


### PR DESCRIPTION
At some point during a truncation-refactor, it lost the ability to check if the truncated comment was actually long enough to warrant truncation. This adds a check for that back in.