### PR TITLE
Add bson-ext, a native-code library for faster mongodb protocol serialize/deserialize

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bcrypt": "^3.0.6",
     "body-parser": "^1.18.3",
     "bowser": "^1.9.4",
+    "bson-ext": "^2.0.3",
     "chalk": "^2.4.1",
     "cheerio": "^0.22",
     "classnames": "^2.2.6",


### PR DESCRIPTION
When the webserver talks to mongodb, it uses a protocol called BSON (Binary jSON). By default, it parses and serializes this protocol using Javascript, which involves lots and lots of slow memory allocations. But there's a native-code library for doing that, which is significantly faster. Depending on `bson-ext` is sufficient without any code changes; the mongodb driver detects that it is available and uses it.