### PR TITLE
fix modal zIndex, refactor sharedOverrides

### DIFF
--- a/packages/lesswrong/components/localGroups/LocalGroupsItem.jsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsItem.jsx
@@ -36,7 +36,6 @@ export const postsItemLikeStyles = theme => ({
     textOverflow: "ellipsis",
     textDecoration: "none",
     whiteSpace: "nowrap",
-    zIndex: "400 !important",
     flexGrow: 1,
     marginRight: theme.spacing.unit * 2,
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/styles/_editor.scss
+++ b/packages/lesswrong/styles/_editor.scss
@@ -217,3 +217,15 @@ figure:after {
     display:none;
   }
 }
+
+
+:root {
+	--ck-sample-base-spacing: 2em;
+	--ck-sample-color-white: #fff;
+	--ck-sample-color-green: #279863;
+	--ck-sample-container-width: 1285px;
+	--ck-sample-sidebar-width: 300px;
+	--ck-sample-editor-min-height: 200px;
+	--ck-z-default: 1301 !important;
+	--ck-z-modal: 1301 !important;
+}

--- a/packages/lesswrong/styles/_editor.scss
+++ b/packages/lesswrong/styles/_editor.scss
@@ -220,12 +220,8 @@ figure:after {
 
 
 :root {
-	--ck-sample-base-spacing: 2em;
-	--ck-sample-color-white: #fff;
-	--ck-sample-color-green: #279863;
-	--ck-sample-container-width: 1285px;
-	--ck-sample-sidebar-width: 300px;
-	--ck-sample-editor-min-height: 200px;
-	--ck-z-default: 1301 !important;
+  // This is the only place I could find that successfully overrode the ckEditor zIndex
+  // necessary to ensure it works on modal dialogs
+  // (also tried adding it to Layout.jsx's JSS, and to the styles file in the ckeditor folder)
 	--ck-z-modal: 1301 !important;
 }

--- a/packages/lesswrong/themes/alignmentForumTheme.js
+++ b/packages/lesswrong/themes/alignmentForumTheme.js
@@ -3,7 +3,6 @@ import deepOrange from '@material-ui/core/colors/deepOrange';
 import indigo from '@material-ui/core/colors/indigo';
 
 import { createMuiTheme } from '@material-ui/core/styles';
-import { sharedOverrides } from './lesswrongTheme';
 
 const defaultTheme = createMuiTheme()
 
@@ -116,8 +115,7 @@ const theme = createLWTheme({
       root: {
         fontWeight: 500,
       }
-    },
-    ...sharedOverrides
+    }
   }
 });
 

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -21,7 +21,6 @@ export const zIndexes = {
   sidebarHoverOver: 2,
   singleLineCommentHover: 3,
   questionPageWhitescreen: 3,
-  muiModal: 3,
   textbox: 4,
   styledMapPopup: 5,
   nextUnread: 999,
@@ -31,6 +30,7 @@ export const zIndexes = {
   tabNavigation: 1101,
   searchResults: 1102,
   header: 1300,
+  ckEditorToolbar: 1301,
   karmaChangeNotifier: 1400,
   notificationsMenu: 1500,
   lwPopper: 10000,
@@ -186,11 +186,6 @@ const createLWTheme = (theme) => {
       strongVoteDelay: 1000,
     },
     overrides: {
-      MuiModal: {
-        root: {
-          zIndex: zIndexes.muiModal
-        }
-      },
       MuiSelect: {
         selectMenu: {
           paddingLeft: spacingUnit

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -10,6 +10,37 @@ const monoStack = [
   'monospace'
 ].join(',')
 
+export const zIndexes = {
+  continueReadingImage: -1,
+  commentsMenu: 1,
+  sequencesPageContent: 1,
+  sequencesImageScrim: 1,
+  postsVote: 1,
+  singleLineCommentMeta: 2,
+  postItemTitle: 2,
+  sidebarHoverOver: 2,
+  singleLineCommentHover: 3,
+  questionPageWhitescreen: 3,
+  muiModal: 3,
+  textbox: 4,
+  styledMapPopup: 5,
+  nextUnread: 999,
+  sunshineSidebar: 1000,
+  postItemMenu: 1001,
+  layout: 1100,
+  tabNavigation: 1101,
+  searchResults: 1102,
+  header: 1300,
+  karmaChangeNotifier: 1400,
+  notificationsMenu: 1500,
+  lwPopper: 10000,
+  lwPopperTooltip: 10001,
+  loginDialog: 10002,
+  searchBar: 100000,
+  // petrovDayButton: 6,
+  // petrovDayLoss: 1000000
+}
+
 const createLWTheme = (theme) => {
   // Defines sensible typography defaults that can be
   // cleanly overriden
@@ -149,36 +180,22 @@ const createLWTheme = (theme) => {
       }
     },
     zIndexes: {
-      continueReadingImage: -1,
-      commentsMenu: 1,
-      sequencesPageContent: 1,
-      sequencesImageScrim: 1,
-      postsVote: 1,
-      singleLineCommentMeta: 2,
-      postItemTitle: 2,
-      sidebarHoverOver: 2,
-      singleLineCommentHover: 3,
-      questionPageWhitescreen: 3,
-      textbox: 4,
-      styledMapPopup: 5,
-      nextUnread: 999,
-      sunshineSidebar: 1000,
-      postItemMenu: 1001,
-      layout: 1100,
-      tabNavigation: 1101,
-      searchResults: 1102,
-      header: 1300,
-      karmaChangeNotifier: 1400,
-      notificationsMenu: 1500,
-      lwPopper: 10000,
-      lwPopperTooltip: 10001,
-      loginDialog: 10002,
-      searchBar: 100000,
-      // petrovDayButton: 6,
-      // petrovDayLoss: 1000000
+      ...zIndexes
     },
     voting: {
       strongVoteDelay: 1000,
+    },
+    overrides: {
+      MuiModal: {
+        root: {
+          zIndex: zIndexes.muiModal
+        }
+      },
+      MuiSelect: {
+        selectMenu: {
+          paddingLeft: spacingUnit
+        }
+      }
     }
   }
 

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -47,14 +47,6 @@ const palette = {
   }
 }
 
-export const sharedOverrides = {
-  MuiSelect: {
-    selectMenu: {
-      paddingLeft: 8
-    }
-  }
-}
-
 const theme = createLWTheme({
   palette: palette,
   typography: {
@@ -135,8 +127,7 @@ const theme = createLWTheme({
         border: `solid 1px rgba(0,0,0,.2)`,
         boxShadow: "0 0 10px rgba(0,0,0,.2)",
       }
-    },
-    ...sharedOverrides
+    }
   }
 });
 


### PR DESCRIPTION
This override's ckEditor's z-index, so that it works properly on MuiModal components. 

During the process of creating this, I originally tried making changes to MuiModal's JSS overrides, which then resulted in a minor refactor of how we handle shared overrides between LW, EA and AF, and removed some (AFAICT?) no longer used JSS. 

I ended up keeping those changes since they seemed net positive.