### PR TITLE
Fix navigation-event sending

### DIFF
--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -228,7 +228,7 @@ class App extends PureComponent {
     // Reuse the container objects for location and navigation context, so that
     // they will be reference-stable and won't trigger spurious rerenders.
     if (!this.locationContext) {
-      this.locationContext = location;
+      this.locationContext = {...location};
     } else {
       Object.assign(this.locationContext, location);
     }
@@ -244,7 +244,7 @@ class App extends PureComponent {
     // subscribeLocationContext changes (by shallow comparison) whenever the
     // URL changes.
     if (!this.subscribeLocationContext || this.subscribeLocationContext.pathname != location.pathname) {
-      this.subscribeLocationContext = location;
+      this.subscribeLocationContext = {...location};
     } else {
       Object.assign(this.subscribeLocationContext, location);
     }


### PR DESCRIPTION
Fix sending of navigation events. What was happening here was, `subscribeLocationContext` didn't actually have the reference-stability properties it was supposed to, because it was using the same incrementally-updated object as `locationContext`, and `locationContext`'s update would happen first.