### PR TITLE
ckEditor blockquotes

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -124,7 +124,6 @@ const createLWTheme = (theme) => {
         paddingLeft: spacingUnit*2,
         borderLeft: `solid 3px ${grey[300]}`,
         margin: 0,
-        ...body1FontSize
       },
       commentBlockquote: {
         fontWeight: 400,
@@ -135,7 +134,6 @@ const createLWTheme = (theme) => {
         borderLeft: `solid 3px ${grey[300]}`,
         margin: 0,
         marginLeft: spacingUnit*1.5,
-        ...body2FontSize
       },
       codeblock: {
         backgroundColor: grey[100],

--- a/packages/lesswrong/themes/stylePiping.js
+++ b/packages/lesswrong/themes/stylePiping.js
@@ -281,10 +281,10 @@ export const postHighlightStyles = theme => {
 export const pBodyStyle = {
   marginTop: "1em",
   marginBottom: "1em",
-  '&:first-of-type': {
+  '&:first-child': {
     marginTop: 0,
   },
-  '&:last-of-type': {
+  '&:last-child': {
     marginBottom: 0,
   }
 }
@@ -299,6 +299,9 @@ export const ckEditorStyles = theme => {
       '& blockquote': {
         fontStyle: "unset",
         ...theme.typography.blockquote,
+        '& p': {
+          ...pBodyStyle,
+        },
         '& .public-DraftStyleDefault-block': {
           marginTop: 0,
           marginBottom: 0,


### PR DESCRIPTION
ckEditor blockquotes were having trouble with looking the correct size, in the editor, because ckEditor had been imposing some of it's own styles.

This was tricky to fix because our custom ckEditor styles could _either_ be layered on top of postStyles, or commentStyles, which manually applied different styles to blockquotes. But... that styling doesn't _appear_ to be necessary?

Not sure about chesterton's blockquote styling.