### PR TITLE
Add option to make loadMore work with query parameters

### DIFF
--- a/packages/lesswrong/components/comments/RecentComments.jsx
+++ b/packages/lesswrong/components/comments/RecentComments.jsx
@@ -1,14 +1,22 @@
 import React from 'react';
-import { Components, registerComponent, withList, withEdit } from 'meteor/vulcan:core';
+import { Components, registerComponent, useMulti, withEdit } from 'meteor/vulcan:core';
 import { Comments } from '../../lib/collections/comments';
 import withUser from '../common/withUser';
 
-const RecentComments = ({results, currentUser, loading, loadMore, networkStatus, updateComment}) => {
-  const loadingMore = networkStatus === 2;
-  if (!loading && results && !results.length) {
+const RecentComments = ({currentUser, updateComment, terms}) => {
+  const { loadingInitial, loadMoreProps, results } = useMulti({
+    terms,
+    collection: Comments,
+    queryName: 'selectCommentsListQuery',
+    fragmentName: 'SelectCommentsList',
+    enableTotal: false,
+    pollInterval: 0,
+    queryLimitName: "recentCommentsLimit"
+  });
+  if (!loadingInitial && results && !results.length) {
     return (<div>No comments found</div>)
   }
-  if (loading || !results) {
+  if (loadingInitial || !results) {
     return <Components.Loading />
   }
   
@@ -25,19 +33,12 @@ const RecentComments = ({results, currentUser, loading, loadMore, networkStatus,
           />
         </div>
       )}
-      {loadMore && <Components.LoadMore loading={loadingMore || loading} loadMore={loadMore}  />}
+      <Components.LoadMore {...loadMoreProps} />
     </div>
   )
 }
 
 registerComponent('RecentComments', RecentComments,
-  [withList, {
-    collection: Comments,
-    queryName: 'selectCommentsListQuery',
-    fragmentName: 'SelectCommentsList',
-    enableTotal: false,
-    pollInterval: 0,
-  }],
   [withEdit, {
     collection: Comments,
     fragmentName: 'SelectCommentsList',

--- a/packages/vulcan-core/lib/modules/containers/withMulti.js
+++ b/packages/vulcan-core/lib/modules/containers/withMulti.js
@@ -34,7 +34,7 @@ Terms object can have the following properties:
 
 */
 
-import { useState } from 'react';
+import { useState, useContext } from 'react';
 import { graphql, useQuery } from 'react-apollo';
 import gql from 'graphql-tag';
 import {
@@ -46,6 +46,8 @@ import {
 } from 'meteor/vulcan:lib';
 import compose from 'recompose/compose';
 import withState from 'recompose/withState';
+import qs from 'qs';
+import { LocationContext, NavigationContext } from '../components/App'
 
 function getGraphQLQueryFromOptions({
   collectionName, collection, fragmentName, fragment, extraQueries, extraVariables,
@@ -201,7 +203,6 @@ export default function withMulti({
 export function useMulti({
   terms,
   extraVariablesValues,
-  
   pollInterval = getSetting('pollInterval', 0), //LESSWRONG: Polling defaults disabled
   enableTotal = false, //LESSWRONG: enableTotal defaults false
   enableCache = false,
@@ -214,8 +215,14 @@ export function useMulti({
   limit:initialLimit = 10, // Only used as a fallback if terms.limit is not specified
   itemsPerPage = 10,
   skip = false,
+  queryLimitName,
 }) {
-  const [ limit, setLimit ] = useState((terms && terms.limit) || initialLimit);
+  // Since we don't have access to useLocation and useNavigation we have to manually reference context here
+  const { query: locationQuery, location } = useContext(LocationContext);
+  const { history } = useContext(NavigationContext)
+
+  const defaultLimit = ((locationQuery && parseInt(locationQuery[queryLimitName])) || (terms && terms.limit) || initialLimit)
+  const [ limit, setLimit ] = useState(defaultLimit);
   const [ hasRequestedMore, setHasRequestedMore ] = useState(false);
   
   ({ collectionName, collection } = extractCollectionInfo({ collectionName, collection }));
@@ -254,6 +261,10 @@ export function useMulti({
   const loadMore = () => {
     setHasRequestedMore(true);
     setLimit(limit+itemsPerPage);
+    if (queryLimitName) {
+      const newQuery = {...locationQuery, [queryLimitName]: limit+itemsPerPage}
+      history.push({...location, search: `?${qs.stringify(newQuery)}`})
+    }
   };
   
   // A bundle of props that you can pass to Components.LoadMore, to make


### PR DESCRIPTION
For certain lists, it's pretty important that when you click on a link, and then press back, you can scroll back to the place in the list that you previously were located at. This was previously prevented by us resetting the limits on various lists when the component unmounts, but this PR adds an option to instead save that state in a URL parameter, allowing that state to be preserved between navigations. 