### PR TITLE
Refactor auto-complete form components

### DIFF
--- a/packages/lesswrong/components/form-components/PostsListEditor.jsx
+++ b/packages/lesswrong/components/form-components/PostsListEditor.jsx
@@ -95,7 +95,6 @@ class PostsListEditor extends Component {
       />
       <Components.PostsSearchAutoComplete
         clickAction={this.addPostId}
-        HitComponent={Components.PostsListEditorSearchHit}
       />
     </div>
   }

--- a/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
@@ -5,9 +5,10 @@ import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 const PostsSearchAutoComplete = ({clickAction}) => {
   return <Components.SearchAutoComplete
     indexName={algoliaIndexNames.Posts}
-    clickAction={suggestion => clickAction(suggestion._id)}
+    clickAction={clickAction}
     renderSuggestion={hit => <Components.PostsListEditorSearchHit hit={hit} />}
     placeholder='Search for posts'
+    noSearchPlaceholder='Post ID'
   />
 }
 

--- a/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
@@ -1,52 +1,23 @@
 import React from 'react';
 import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch, Configure } from 'react-instantsearch-dom';
-import { connectAutoComplete } from 'react-instantsearch/connectors';
-import Autosuggest from 'react-autosuggest';
+import { InstantSearch } from 'react-instantsearch-dom';
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
-const PostsSearchAutoComplete = ({clickAction, HitComponent}) => {
+const PostsSearchAutoComplete = ({clickAction}) => {
   const algoliaAppId = getSetting('algolia.appId')
   const algoliaSearchKey = getSetting('algolia.searchKey')
+  
   return <InstantSearch
     indexName={algoliaIndexNames.Posts}
     appId={algoliaAppId}
     apiKey={algoliaSearchKey}
-         >
-    <div className="posts-search-auto-complete">
-      <AutoComplete clickAction={clickAction} />
-      <Configure hitsPerPage={7} />
-    </div>
+  >
+    <Components.SearchAutoComplete
+      clickAction={suggestion => clickAction(suggestion._id)}
+      renderSuggestion={hit => <Components.PostsListEditorSearchHit hit={hit} />}
+      placeholder='Search for posts'
+    />
   </InstantSearch>
 }
-
-
-const AutoComplete = connectAutoComplete(
-  ({ hits, currentRefinement, refine, clickAction}) =>
-  {
-    const onSuggestionSelected = (event, { suggestion }) => {
-      event.preventDefault();
-      event.stopPropagation();
-      clickAction(suggestion._id)
-    }
-    return (
-      <Autosuggest
-        suggestions={hits}
-        onSuggestionSelected={onSuggestionSelected}
-        onSuggestionsFetchRequested={({ value }) => refine(value)}
-        onSuggestionsClearRequested={() => refine('')}
-        getSuggestionValue={hit => hit.title}
-        renderSuggestion={hit =>
-          <Components.PostsListEditorSearchHit hit={hit} />}
-        inputProps={{
-          placeholder: 'Search for posts',
-          value: currentRefinement,
-          onChange: () => {},
-        }}
-        highlightFirstSuggestion
-      />
-    )
-  }
-);
 
 registerComponent("PostsSearchAutoComplete", PostsSearchAutoComplete);

--- a/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/PostsSearchAutoComplete.jsx
@@ -1,23 +1,14 @@
 import React from 'react';
-import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch } from 'react-instantsearch-dom';
+import { registerComponent, Components } from 'meteor/vulcan:core'
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
 const PostsSearchAutoComplete = ({clickAction}) => {
-  const algoliaAppId = getSetting('algolia.appId')
-  const algoliaSearchKey = getSetting('algolia.searchKey')
-  
-  return <InstantSearch
+  return <Components.SearchAutoComplete
     indexName={algoliaIndexNames.Posts}
-    appId={algoliaAppId}
-    apiKey={algoliaSearchKey}
-  >
-    <Components.SearchAutoComplete
-      clickAction={suggestion => clickAction(suggestion._id)}
-      renderSuggestion={hit => <Components.PostsListEditorSearchHit hit={hit} />}
-      placeholder='Search for posts'
-    />
-  </InstantSearch>
+    clickAction={suggestion => clickAction(suggestion._id)}
+    renderSuggestion={hit => <Components.PostsListEditorSearchHit hit={hit} />}
+    placeholder='Search for posts'
+  />
 }
 
 registerComponent("PostsSearchAutoComplete", PostsSearchAutoComplete);

--- a/packages/lesswrong/components/search/SearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.jsx
@@ -1,38 +1,47 @@
 import React from 'react';
-import { registerComponent, Components } from 'meteor/vulcan:core'
-import { Configure } from 'react-instantsearch-dom';
+import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
+import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
 
 const SearchAutoComplete = connectAutoComplete(
-  ({ hits, currentRefinement, refine, clickAction, placeholder, renderSuggestion, hitsPerPage=7 }) =>
+  ({ hits, currentRefinement, refine, clickAction, placeholder, renderSuggestion, hitsPerPage=7, indexName }) =>
   {
+    const algoliaAppId = getSetting('algolia.appId')
+    const algoliaSearchKey = getSetting('algolia.searchKey')
+    
     const onSuggestionSelected = (event, { suggestion }) => {
       event.preventDefault();
       event.stopPropagation();
       clickAction(suggestion._id)
     }
-    return <div className="posts-search-auto-complete">
-      <Autosuggest
-        suggestions={hits}
-        onSuggestionSelected={(event, {suggestion}) => {
-          event.preventDefault();
-          event.stopPropagation();
-          onSuggestionSelected(suggestion);
-        }}
-        onSuggestionsFetchRequested={({ value }) => refine(value)}
-        onSuggestionsClearRequested={() => refine('')}
-        getSuggestionValue={hit => hit.title}
-        renderSuggestion={renderSuggestion}
-        inputProps={{
-          placeholder: placeholder,
-          value: currentRefinement,
-          onChange: () => {},
-        }}
-        highlightFirstSuggestion
-      />
-      <Configure hitsPerPage={hitsPerPage} />
-    </div>;
+    return <InstantSearch
+      indexName={indexName}
+      appId={algoliaAppId}
+      apiKey={algoliaSearchKey}
+    >
+      <div className="posts-search-auto-complete">
+        <Autosuggest
+          suggestions={hits}
+          onSuggestionSelected={(event, {suggestion}) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onSuggestionSelected(suggestion);
+          }}
+          onSuggestionsFetchRequested={({ value }) => refine(value)}
+          onSuggestionsClearRequested={() => refine('')}
+          getSuggestionValue={hit => hit.title}
+          renderSuggestion={renderSuggestion}
+          inputProps={{
+            placeholder: placeholder,
+            value: currentRefinement,
+            onChange: () => {},
+          }}
+          highlightFirstSuggestion
+        />
+        <Configure hitsPerPage={hitsPerPage} />
+      </div>
+    </InstantSearch>
   }
 );
 

--- a/packages/lesswrong/components/search/SearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { registerComponent, Components } from 'meteor/vulcan:core'
+import { Configure } from 'react-instantsearch-dom';
+import { connectAutoComplete } from 'react-instantsearch/connectors';
+import Autosuggest from 'react-autosuggest';
+
+const SearchAutoComplete = connectAutoComplete(
+  ({ hits, currentRefinement, refine, clickAction, placeholder, renderSuggestion, hitsPerPage=7 }) =>
+  {
+    const onSuggestionSelected = (event, { suggestion }) => {
+      event.preventDefault();
+      event.stopPropagation();
+      clickAction(suggestion._id)
+    }
+    return <div className="posts-search-auto-complete">
+      <Autosuggest
+        suggestions={hits}
+        onSuggestionSelected={(event, {suggestion}) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onSuggestionSelected(suggestion);
+        }}
+        onSuggestionsFetchRequested={({ value }) => refine(value)}
+        onSuggestionsClearRequested={() => refine('')}
+        getSuggestionValue={hit => hit.title}
+        renderSuggestion={renderSuggestion}
+        inputProps={{
+          placeholder: placeholder,
+          value: currentRefinement,
+          onChange: () => {},
+        }}
+        highlightFirstSuggestion
+      />
+      <Configure hitsPerPage={hitsPerPage} />
+    </div>;
+  }
+);
+
+registerComponent("SearchAutoComplete", SearchAutoComplete);

--- a/packages/lesswrong/components/search/SearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.jsx
@@ -4,45 +4,42 @@ import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
 
-const SearchAutoComplete = connectAutoComplete(
-  ({ hits, currentRefinement, refine, clickAction, placeholder, renderSuggestion, hitsPerPage=7, indexName }) =>
-  {
-    const algoliaAppId = getSetting('algolia.appId')
-    const algoliaSearchKey = getSetting('algolia.searchKey')
-    
-    const onSuggestionSelected = (event, { suggestion }) => {
-      event.preventDefault();
-      event.stopPropagation();
-      clickAction(suggestion._id)
-    }
-    return <InstantSearch
-      indexName={indexName}
-      appId={algoliaAppId}
-      apiKey={algoliaSearchKey}
-    >
-      <div className="posts-search-auto-complete">
-        <Autosuggest
-          suggestions={hits}
-          onSuggestionSelected={(event, {suggestion}) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onSuggestionSelected(suggestion);
-          }}
-          onSuggestionsFetchRequested={({ value }) => refine(value)}
-          onSuggestionsClearRequested={() => refine('')}
-          getSuggestionValue={hit => hit.title}
-          renderSuggestion={renderSuggestion}
-          inputProps={{
-            placeholder: placeholder,
-            value: currentRefinement,
-            onChange: () => {},
-          }}
-          highlightFirstSuggestion
-        />
-        <Configure hitsPerPage={hitsPerPage} />
-      </div>
-    </InstantSearch>
+const SearchAutoComplete = ({ hits, currentRefinement, refine, clickAction, placeholder, renderSuggestion, hitsPerPage=7, indexName }) => {
+  const algoliaAppId = getSetting('algolia.appId')
+  const algoliaSearchKey = getSetting('algolia.searchKey')
+  
+  const onSuggestionSelected = (event, { suggestion }) => {
+    event.preventDefault();
+    event.stopPropagation();
+    clickAction(suggestion._id)
   }
-);
+  return <InstantSearch
+    indexName={indexName}
+    appId={algoliaAppId}
+    apiKey={algoliaSearchKey}
+  >
+    <div className="posts-search-auto-complete">
+      <Autosuggest
+        suggestions={hits}
+        onSuggestionSelected={(event, {suggestion}) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onSuggestionSelected(suggestion);
+        }}
+        onSuggestionsFetchRequested={({ value }) => refine(value)}
+        onSuggestionsClearRequested={() => refine('')}
+        getSuggestionValue={hit => hit.title}
+        renderSuggestion={renderSuggestion}
+        inputProps={{
+          placeholder: placeholder,
+          value: currentRefinement,
+          onChange: () => {},
+        }}
+        highlightFirstSuggestion
+      />
+      <Configure hitsPerPage={hitsPerPage} />
+    </div>
+  </InstantSearch>
+}
 
-registerComponent("SearchAutoComplete", SearchAutoComplete);
+registerComponent("SearchAutoComplete", SearchAutoComplete, connectAutoComplete);

--- a/packages/lesswrong/components/search/SearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.jsx
@@ -3,8 +3,24 @@ import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
 import { InstantSearch, Configure } from 'react-instantsearch-dom';
 import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
+import { withStyles } from '@material-ui/core/styles';
 
-const SearchAutoComplete = ({ clickAction, placeholder, renderSuggestion, hitsPerPage=7, indexName }) => {
+const styles = theme => ({
+  autoComplete: {
+    "& li": {
+      listStyle: "none",
+    },
+    "& .react-autosuggest__suggestion--highlighted": {
+        backgroundColor: "rgba(0,0,0,0.05)",
+    },
+    "& ul": {
+      marginLeft: 0,
+      paddingLeft: 0,
+    },
+  }
+});
+
+const SearchAutoComplete = ({ clickAction, placeholder, renderSuggestion, hitsPerPage=7, indexName, classes }) => {
   const algoliaAppId = getSetting('algolia.appId')
   const algoliaSearchKey = getSetting('algolia.searchKey')
   
@@ -31,7 +47,7 @@ const SearchAutoComplete = ({ clickAction, placeholder, renderSuggestion, hitsPe
     appId={algoliaAppId}
     apiKey={algoliaSearchKey}
   >
-    <div className="posts-search-auto-complete">
+    <div className={classes.autoComplete}>
       <AutocompleteTextbox onSuggestionSelected={onSuggestionSelected} placeholder={placeholder} renderSuggestion={renderSuggestion} />
       <Configure hitsPerPage={hitsPerPage} />
     </div>
@@ -64,4 +80,5 @@ const AutocompleteTextbox = connectAutoComplete(
   }
 );
 
-registerComponent("SearchAutoComplete", SearchAutoComplete);
+registerComponent("SearchAutoComplete", SearchAutoComplete,
+  withStyles(styles, {name: "SearchAutoComplete"}));

--- a/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
@@ -1,23 +1,15 @@
 import React from 'react';
-import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch } from 'react-instantsearch-dom';
+import { registerComponent, Components } from 'meteor/vulcan:core'
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
 const SequencesSearchAutoComplete = ({clickAction}) => {
-  const algoliaAppId = getSetting('algolia.appId')
-  const algoliaSearchKey = getSetting('algolia.searchKey')
-  return <InstantSearch
+  return <Components.SearchAutoComplete
     indexName={algoliaIndexNames.Sequences}
-    appId={algoliaAppId}
-    apiKey={algoliaSearchKey}
-  >
-    <Components.SearchAutoComplete
-      clickAction={clickAction}
-      renderSuggestion={hit => <Components.SequencesSearchHit hit={hit} clickAction={clickAction} />}
-      placeholder='Search for sequences'
-      hitsPerPage={3}
-    />
-  </InstantSearch>
+    clickAction={clickAction}
+    renderSuggestion={hit => <Components.SequencesSearchHit hit={hit} clickAction={clickAction} />}
+    placeholder='Search for sequences'
+    hitsPerPage={3}
+  />
 }
 
 registerComponent("SequencesSearchAutoComplete", SequencesSearchAutoComplete);

--- a/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch, Configure } from 'react-instantsearch-dom';
-import { connectAutoComplete } from 'react-instantsearch/connectors';
-import Autosuggest from 'react-autosuggest';
+import { InstantSearch } from 'react-instantsearch-dom';
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
 const SequencesSearchAutoComplete = ({clickAction}) => {
@@ -12,31 +10,14 @@ const SequencesSearchAutoComplete = ({clickAction}) => {
     indexName={algoliaIndexNames.Sequences}
     appId={algoliaAppId}
     apiKey={algoliaSearchKey}
-         >
-    <div className="posts-search-auto-complete">
-      <AutoComplete clickAction={clickAction}/>
-      <Configure hitsPerPage={3} />
-    </div>
+  >
+    <Components.SearchAutoComplete
+      clickAction={clickAction}
+      renderSuggestion={hit => <Components.SequencesSearchHit hit={hit} clickAction={clickAction} />}
+      placeholder='Search for sequences'
+      hitsPerPage={3}
+    />
   </InstantSearch>
 }
-
-
-const AutoComplete = connectAutoComplete(
-  ({ hits, currentRefinement, refine, clickAction }) =>
-    <Autosuggest
-      suggestions={hits}
-      onSuggestionsFetchRequested={({ value }) => refine(value)}
-      onSuggestionsClearRequested={() => refine('')}
-      getSuggestionValue={hit => hit.title}
-      renderSuggestion={hit =>
-        <Components.SequencesSearchHit hit={hit} clickAction={clickAction} />}
-      inputProps={{
-        placeholder: 'Search for sequences',
-        value: currentRefinement,
-        onChange: () => {},
-      }}
-      highlightFirstSuggestion
-    />
-);
 
 registerComponent("SequencesSearchAutoComplete", SequencesSearchAutoComplete);

--- a/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/SequencesSearchAutoComplete.jsx
@@ -9,6 +9,7 @@ const SequencesSearchAutoComplete = ({clickAction}) => {
     renderSuggestion={hit => <Components.SequencesSearchHit hit={hit} clickAction={clickAction} />}
     placeholder='Search for sequences'
     hitsPerPage={3}
+    noSearchPlaceholder='Sequence ID'
   />
 }
 

--- a/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
@@ -5,9 +5,10 @@ import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 const UsersSearchAutoComplete = ({clickAction, label}) => {
   return <Components.SearchAutoComplete
     indexName={algoliaIndexNames.Users}
-    clickAction={suggestion => clickAction(suggestion.objectID)}
+    clickAction={clickAction}
     renderSuggestion={hit => <Components.UsersAutoCompleteHit document={hit} />}
     placeholder={label || "Search for Users"}
+    noSearchPlaceholder='User ID'
   />
 }
 

--- a/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
@@ -1,27 +1,14 @@
 import React from 'react';
-import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch } from 'react-instantsearch-dom';
+import { registerComponent, Components } from 'meteor/vulcan:core'
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
 const UsersSearchAutoComplete = ({clickAction, label}) => {
-  const algoliaAppId = getSetting('algolia.appId')
-  const algoliaSearchKey = getSetting('algolia.searchKey')
-
-  if(!algoliaAppId) {
-    return <div>User search is disabled (Algolia App ID not configured on server)</div>
-  }
-
-  return <InstantSearch
+  return <Components.SearchAutoComplete
     indexName={algoliaIndexNames.Users}
-    appId={algoliaAppId}
-    apiKey={algoliaSearchKey}
-  >
-    <Components.SearchAutoComplete
-      clickAction={suggestion => clickAction(suggestion.objectID)}
-      renderSuggestion={hit => <Components.UsersAutoCompleteHit document={hit} />}
-      placeholder={label || "Search for Users"}
-    />
-  </InstantSearch>
+    clickAction={suggestion => clickAction(suggestion.objectID)}
+    renderSuggestion={hit => <Components.UsersAutoCompleteHit document={hit} />}
+    placeholder={label || "Search for Users"}
+  />
 }
 
 registerComponent("UsersSearchAutoComplete", UsersSearchAutoComplete);

--- a/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
+++ b/packages/lesswrong/components/search/UsersSearchAutoComplete.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { registerComponent, Components, getSetting } from 'meteor/vulcan:core'
-import { InstantSearch, Configure } from 'react-instantsearch-dom';
-import { connectAutoComplete } from 'react-instantsearch/connectors';
-import Autosuggest from 'react-autosuggest';
+import { InstantSearch } from 'react-instantsearch-dom';
 import { algoliaIndexNames } from '../../lib/algoliaIndexNames.js';
 
 const UsersSearchAutoComplete = ({clickAction, label}) => {
@@ -18,41 +16,12 @@ const UsersSearchAutoComplete = ({clickAction, label}) => {
     appId={algoliaAppId}
     apiKey={algoliaSearchKey}
   >
-    <div>
-      <AutoComplete clickAction={clickAction} label={label}/>
-      <Configure hitsPerPage={7} />
-    </div>
+    <Components.SearchAutoComplete
+      clickAction={suggestion => clickAction(suggestion.objectID)}
+      renderSuggestion={hit => <Components.UsersAutoCompleteHit document={hit} />}
+      placeholder={label || "Search for Users"}
+    />
   </InstantSearch>
 }
-
-const AutoComplete = connectAutoComplete(
-  ({ hits, currentRefinement, refine, clickAction, label }) =>
-  {
-    const onSuggestionSelected = (event, { suggestion }) => {
-      event.preventDefault();
-      event.stopPropagation();
-      clickAction(suggestion.objectID)
-    }
-    return <span>
-      <Autosuggest
-        suggestions={hits}
-        onSuggestionsFetchRequested={({ value }) => refine(value)}
-        onSuggestionsClearRequested={() => refine('')}
-        getSuggestionValue={hit => hit.title}
-        onSuggestionSelected={onSuggestionSelected}
-        renderInputComponent={hit => <Components.UsersSearchInput inputProps={hit}/>}
-        renderSuggestion={hit =>
-          <Components.UsersAutoCompleteHit document={hit} />}
-        inputProps={{
-          placeholder: label || "Search for Users",
-          value: currentRefinement,
-          onChange: () => {},
-        }}
-        highlightFirstSuggestion
-      />
-    </span>
-  }
-
-);
 
 registerComponent("UsersSearchAutoComplete", UsersSearchAutoComplete);

--- a/packages/lesswrong/components/tagging/AddTag.jsx
+++ b/packages/lesswrong/components/tagging/AddTag.jsx
@@ -59,6 +59,18 @@ const AddTag = ({post, onTagSelected, classes}) => {
     }
   }, []);
   
+  if (!algoliaAppId || !algoliaSearchKey) {
+    return <div className={classes.root} ref={containerRef}>
+      <input placeholder="Tag ID" type="text" onKeyPress={ev => {
+        if (ev.charCode===13) {
+          const id = ev.target.value;
+          onTagSelected(id);
+          ev.preventDefault();
+        }
+      }}/>
+    </div>
+  }
+  
   return <div className={classes.root} ref={containerRef}>
     <InstantSearch
       indexName={algoliaIndexNames.Tags}
@@ -71,7 +83,7 @@ const AddTag = ({post, onTagSelected, classes}) => {
       {searchOpen && <Hits hitComponent={({hit}) =>
         <Components.TagSearchHit hit={hit}
           onClick={ev => {
-            onTagSelected(hit);
+            onTagSelected(hit._id);
             ev.stopPropagation();
           }}
         />

--- a/packages/lesswrong/components/tagging/FooterTagList.jsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.jsx
@@ -84,12 +84,12 @@ const FooterTagList = ({post, classes}) => {
           <Paper>
             <Components.AddTag
               post={post}
-              onTagSelected={tag => {
+              onTagSelected={tagId => {
                 setAnchorEl(null);
                 setIsOpen(false);
                 mutate({
                   variables: {
-                    tagId: tag._id,
+                    tagId: tagId,
                     postId: post._id,
                   },
                 });

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -280,6 +280,7 @@ importComponent("ShowParentComment", () => require('../components/comments/ShowP
 
 importComponent("PostsListEditorSearchHit", () => require('../components/search/PostsListEditorSearchHit.jsx'));
 importComponent("PostsSearchHit", () => require('../components/search/PostsSearchHit.jsx'));
+importComponent("SearchAutoComplete", () => require('../components/search/SearchAutoComplete.jsx'));
 importComponent("PostsSearchAutoComplete", () => require('../components/search/PostsSearchAutoComplete.jsx'));
 importComponent("CommentsSearchHit", () => require('../components/search/CommentsSearchHit.jsx'));
 importComponent("UsersSearchHit", () => require('../components/search/UsersSearchHit.jsx'));

--- a/packages/lesswrong/styles/_posts.scss
+++ b/packages/lesswrong/styles/_posts.scss
@@ -49,19 +49,6 @@
   margin-bottom: $vmargin * 2;
 }
 
-.posts-search-auto-complete {
-  li {
-    list-style: none;
-  }
-  .react-autosuggest__suggestion--highlighted {
-      background-color: rgba(0,0,0,0.05);
-  }
-  ul {
-    margin-left: 0px;
-    padding-left: 0px;
-  }
-}
-
 svg.drag-handle {
     pointer-events: none;
     position: absolute;


### PR DESCRIPTION
In order to test an alternative post-footer layout with pingbacks and prev/next sequence navigation, I wanted to create a sequence on my local dev instance. But putting posts into a sequence uses `PostsSearchAutoComplete` which doesn't work without Algolia, which I didn't have on that particular local test server. This issue has bothered me enough times in enough contexts that I decided to fix it.

There are three autocomplete-using components that were copy-paste-modified from each other, `{Posts,Sequences,Users}SearchAutoComplete`, and a similar but not copy-pasted `AddTag`. I refactored the three components to share code, via a new component `SearchAutoComplete`. For all four components I added a simple fallback where, if you don't have Algolia enabled, it provides a janky text box into which you can type an ID.