### PR TITLE
[WIP] New layout for pingbacks and tags

### DIFF
--- a/packages/lesswrong/components/posts/PingbacksList.jsx
+++ b/packages/lesswrong/components/posts/PingbacksList.jsx
@@ -15,7 +15,7 @@ const styles = theme => ({
 });
 
 const PingbacksList = ({classes, postId}) => {
-  const { results, loading } = useMulti({
+  const { results, loading, loadMoreProps } = useMulti({
     terms: {
       view: "pingbackPosts",
       postId: postId,
@@ -29,31 +29,28 @@ const PingbacksList = ({classes, postId}) => {
   });
   const currentUser = useCurrentUser();
 
-  const { SectionSubtitle, Pingback, Loading } = Components
+  const { SectionSubtitle, Pingback, Loading, LoadMore } = Components
 
   if (loading)
     return <Loading/>
+  if (!results || !results.length)
+    return null;
   
-  if (results) {
-    if (results.length > 0) {
-      return <div className={classes.root}>
-        <SectionSubtitle>
-          <Tooltip title="Posts that linked to this post" placement="right">
-            <span>Pingbacks</span>
-          </Tooltip>
-        </SectionSubtitle>
-        <div className={classes.list}>
-          {results.map((post, i) => 
-            <div key={post._id} >
-              <Pingback post={post} currentUser={currentUser}/>
-            </div>
-          )}
+  return <div className={classes.root}>
+    <SectionSubtitle>
+      <Tooltip title="Posts that linked to this post" placement="right">
+        <span>Pingbacks</span>
+      </Tooltip>
+    </SectionSubtitle>
+    <div className={classes.list}>
+      {results.map((post, i) =>
+        <div key={post._id} >
+          <Pingback post={post} currentUser={currentUser}/>
         </div>
-      </div>
-    }
-  }
-  
-  return null;
+      )}
+      <LoadMore {...loadMoreProps}/>
+    </div>
+  </div>
 }
 
 registerComponent("PingbacksList", PingbacksList, withStyles(styles, {name: "PingbacksList"}));

--- a/packages/lesswrong/components/posts/PingbacksList.jsx
+++ b/packages/lesswrong/components/posts/PingbacksList.jsx
@@ -29,7 +29,7 @@ const PingbacksList = ({classes, postId}) => {
   });
   const currentUser = useCurrentUser();
 
-  const { SectionSubtitle, Pingback, Loading, LoadMore } = Components
+  const { Pingback, Loading, LoadMore } = Components
 
   if (loading)
     return <Loading/>
@@ -37,11 +37,6 @@ const PingbacksList = ({classes, postId}) => {
     return null;
   
   return <div className={classes.root}>
-    <SectionSubtitle>
-      <Tooltip title="Posts that linked to this post" placement="right">
-        <span>Pingbacks</span>
-      </Tooltip>
-    </SectionSubtitle>
     <div className={classes.list}>
       {results.map((post, i) =>
         <div key={post._id} >

--- a/packages/lesswrong/components/posts/PostsPage/PostFooter.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostFooter.jsx
@@ -3,11 +3,14 @@ import { registerComponent, Components } from 'meteor/vulcan:core';
 import { userHasPingbacks, userHasTagging } from '../../../lib/betas.js';
 import { useCurrentUser } from '../../common/withUser';
 import { withStyles } from '@material-ui/core/styles';
+import { legacyBreakpoints } from '../../../lib/modules/utils/theme';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const MAX_COLUMN_WIDTH = 720
 
 const styles = theme => ({
   root: {
+    position: "relative",
     maxWidth: 650 + (theme.spacing.unit*4),
     marginLeft: 'auto',
     marginRight: 'auto'
@@ -20,6 +23,44 @@ const styles = theme => ({
       maxWidth: MAX_COLUMN_WIDTH
     }
   },
+  
+  twoColumn: {
+    position: "relative",
+  },
+  leftColumn: {
+    width: 300,
+    display: "inline-block",
+  },
+  divider: {
+    position: "absolute",
+    marginLeft: "auto",
+    marginRight: "auto",
+    width: "0px",
+    borderLeftStyle: "solid",
+    borderLeftWidth: "1px",
+    color: "rgba(0,0,0,0.3)",
+    left: 0,
+    right: 0,
+    top: 10,
+    bottom: 35,
+
+    [legacyBreakpoints.maxSmall]: {
+      display: "none"
+    }
+  },
+  rightColumn: {
+    float: "right",
+    width: 300,
+    display: "inline-block",
+  },
+  listHeader: {
+    fontSize: "1.2rem",
+    marginBottom: ".5em",
+    fontWeight: 600,
+  },
+  clear: {
+    clear: "both"
+  },
 });
 
 const PostFooter = ({post, sequenceId, classes}) => {
@@ -31,11 +72,31 @@ const PostFooter = ({post, sequenceId, classes}) => {
       <BottomNavigation post={post}/>
     </div>}
     
-    {userHasPingbacks(currentUser) &&
-      <PingbacksList postId={post._id}/>}
-    
-    {userHasTagging(currentUser) &&
-      <FooterTagList post={post}/>}
+    <div className={classes.twoColumn}>
+      {userHasPingbacks(currentUser) &&
+        <div className={classes.leftColumn}>
+          <div className={classes.listHeader}>
+            <Tooltip title="Posts that linked to this post" placement="right">
+              <span>Pingbacks:</span>
+            </Tooltip>
+          </div>
+          <PingbacksList postId={post._id}/>
+        </div>}
+      
+      <div className={classes.divider}/>
+      
+      {userHasTagging(currentUser) &&
+        <div className={classes.rightColumn}>
+          <div className={classes.listHeader}>
+            <Tooltip title="Tags that are relevant to this post" placement="right">
+              <span>Tags:</span>
+            </Tooltip>
+          </div>
+          <FooterTagList post={post}/>
+        </div>}
+      
+      <div className={classes.clear}></div>
+    </div>
   </div>
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostFooter.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostFooter.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { registerComponent, Components } from 'meteor/vulcan:core';
+import { userHasPingbacks, userHasTagging } from '../../../lib/betas.js';
+import { useCurrentUser } from '../../common/withUser';
+import { withStyles } from '@material-ui/core/styles';
+
+const MAX_COLUMN_WIDTH = 720
+
+const styles = theme => ({
+  root: {
+    maxWidth: 650 + (theme.spacing.unit*4),
+    marginLeft: 'auto',
+    marginRight: 'auto'
+  },
+  bottomNavigation: {
+    width: 640,
+    margin: 'auto',
+    [theme.breakpoints.down('sm')]: {
+      width:'100%',
+      maxWidth: MAX_COLUMN_WIDTH
+    }
+  },
+});
+
+const PostFooter = ({post, sequenceId, classes}) => {
+  const { BottomNavigation, PingbacksList, FooterTagList } = Components;
+  const currentUser = useCurrentUser();
+  
+  return <div className={classes.root}>
+    {sequenceId && <div className={classes.bottomNavigation}>
+      <BottomNavigation post={post}/>
+    </div>}
+    
+    {userHasPingbacks(currentUser) &&
+      <PingbacksList postId={post._id}/>}
+    
+    {userHasTagging(currentUser) &&
+      <FooterTagList post={post}/>}
+  </div>
+}
+
+registerComponent("PostFooter", PostFooter,
+  withStyles(styles, {name: "PostFooter"}));
+

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -12,7 +12,6 @@ import classNames from 'classnames';
 import { extractVersionsFromSemver } from '../../../lib/editor/utils'
 import withRecordPostView from '../../common/withRecordPostView';
 import withNewEvents from '../../../lib/events/withNewEvents.jsx';
-import { userHasPingbacks, userHasTagging } from '../../../lib/betas.js';
 
 const HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT = 300
 const DEFAULT_TOC_MARGIN = 100
@@ -153,14 +152,6 @@ const styles = theme => ({
   draft: {
     color: theme.palette.secondary.light
   },
-  bottomNavigation: {
-    width: 640,
-    margin: 'auto',
-    [theme.breakpoints.down('sm')]: {
-      width:'100%',
-      maxWidth: MAX_COLUMN_WIDTH
-    }
-  },
   authors: {
     display: 'inline-block',
     marginRight: SECONDARY_SPACING
@@ -263,10 +254,10 @@ class PostsPage extends Component {
   render() {
     const { post, refetch, currentUser, classes, location: { query, params } } = this.props
     const { PostsPageTitle, PostsAuthors, HeadTags, PostsVote, ContentType,
-      LinkPostMessage, PostsCommentsThread, PostsGroupDetails, BottomNavigation,
+      LinkPostMessage, PostsCommentsThread, PostsGroupDetails,
       PostsTopSequencesNav, PostsPageActions, PostsPageEventData, ContentItemBody, PostsPageQuestionContent,
       TableOfContents, PostsRevisionMessage, AlignmentCrosspostMessage, PostsPageDate, CommentPermalink,
-      PingbacksList, FooterTagList, ReviewPostButton } = Components
+      PostFooter, ReviewPostButton } = Components
 
     if (this.shouldHideAsSpam()) {
       throw new Error("Logged-out users can't see unreviewed (possibly spam) posts");
@@ -353,7 +344,6 @@ class PostsPage extends Component {
                   {query.revision && <PostsRevisionMessage post={post} />}
                   { html && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`}/> }
                 </div>
-                {userHasTagging(currentUser) && <FooterTagList post={post}/>}
               </div>
             </div>
 
@@ -369,13 +359,8 @@ class PostsPage extends Component {
                     />
                 </div>
               </div>}
-            {sequenceId && <div className={classes.bottomNavigation}>
-              <BottomNavigation post={post}/>
-            </div>}
             
-            {userHasPingbacks(currentUser) && <div className={classes.post}>
-              <PingbacksList postId={post._id}/>
-            </div>}
+            <PostFooter post={post} sequenceId={sequenceId} />
 
             {/* Answers Section */}
             {post.question && <div className={classes.post}>

--- a/packages/lesswrong/components/posts/PostsPage/index.js
+++ b/packages/lesswrong/components/posts/PostsPage/index.js
@@ -13,3 +13,4 @@ importComponent("ContentType", () => require('./ContentType.jsx'));
 importComponent("PostsRevisionSelector", () => require('./PostsRevisionSelector.jsx'));
 importComponent("PostsRevisionsList", () => require('./PostsRevisionsList.jsx'));
 importComponent("PostsRevisionMessage", () => require('./PostsRevisionMessage.jsx'));
+importComponent("PostFooter", () => require('./PostFooter.jsx'));


### PR DESCRIPTION
The premise: For desktop, a two-column layout for pingbacks and tags, parallel to the columns used for the previous/next post links. Trying out a few variants. Might make the right column look more like the pingbacks on the left, but maybe not because currently it has some color which is nice.

![Screen Shot 2019-12-02 at 17 47 46](https://user-images.githubusercontent.com/101191/70024869-30e36f80-1550-11ea-8a09-fdcf2fa6984a.png)
