### PR TITLE
Capture post-view event type

### DIFF
--- a/packages/lesswrong/components/comments/RecentDiscussionThread.jsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.jsx
@@ -105,7 +105,7 @@ const RecentDiscussionThread = ({
       setReadStatus(true);
       setMarkedAsVisitedAt(new Date());
       setExpandAllThreads(true);
-      recordPostView({post, type: "recentDiscussionClick"})
+      recordPostView({post, extraEventProperties: {type: "recentDiscussionClick"}})
     },
     [setReadStatus, setMarkedAsVisitedAt, setExpandAllThreads, recordPostView, post]
   );

--- a/packages/lesswrong/components/comments/RecentDiscussionThread.jsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.jsx
@@ -105,7 +105,7 @@ const RecentDiscussionThread = ({
       setReadStatus(true);
       setMarkedAsVisitedAt(new Date());
       setExpandAllThreads(true);
-      recordPostView({post})
+      recordPostView({post, type: "recentDiscussionClick"})
     },
     [setReadStatus, setMarkedAsVisitedAt, setExpandAllThreads, recordPostView, post]
   );

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -379,7 +379,7 @@ const PostsItem2 = ({
 
   const toggleComments = React.useCallback(
     () => {
-      recordPostView({post})
+      recordPostView({post, extraEventProperties: {type: "toggleComments"}})
       setShowComments(!showComments);
       setReadComments(true);
     },
@@ -387,7 +387,7 @@ const PostsItem2 = ({
   );
 
   const markAsRead = () => {
-    recordPostView({post})
+    recordPostView({post, extraEventProperties: {type: "markAsRead"}})
     setMarkedVisitedAt(new Date()) 
   }
 


### PR DESCRIPTION
This just captures the data on where a post-view event is clicked, just so we can differentiate between the different events in the future.