### PR TITLE
[WIP] add tracking of ExternalLinkClicks + Hover Preview Tracking

### DIFF
--- a/packages/lesswrong/components/common/withHover.jsx
+++ b/packages/lesswrong/components/common/withHover.jsx
@@ -7,46 +7,33 @@ export const withHover = (WrappedComponent) => {
         const [anchorEl, setAnchorEl] = useState(null)
         const delayTimer = useRef(null)
         const mouseOverStart = useRef()
-        const mouseOverEnd = useRef()
 
 
         const { captureEvent } = useTracking({eventType:"hoverEventTriggered"})
 
-        const captureHoverEvent = useCallback(() => {
-            captureEvent("hoverEventTriggered",
-                {hover,
-                    timerId: delayTimer.current,
-                    // mouseOverStart: mouseOverStart.current,
-                    // mouseOverEnd: mouseOverEnd.current,
-                    hoverDuration: mouseOverEnd.current - mouseOverStart.current,
-                timeToCapture: new Date() - mouseOverStart.current})
+        const captureHoverEvent = () => {
+            captureEvent("hoverEventTriggered", {timeToCapture: new Date() - mouseOverStart.current})
             clearTimeout(delayTimer.current)
-        },[hover, delayTimer, mouseOverStart, mouseOverEnd])
+        }
 
-        const handleMouseOver = useCallback((event) => {
+        const handleMouseOver = (event) => {
             setHover(true)
             setAnchorEl(event.currentTarget)
-            mouseOverEnd.current = undefined
             mouseOverStart.current = new Date()
             clearTimeout(delayTimer.current)
-            delayTimer.current = setTimeout(captureHoverEvent,500)
-            console.log({event: "mouseEnterTriggered", timerId: delayTimer.current})
-        }, [delayTimer, captureHoverEvent])
+            delayTimer.current = setTimeout(captureHoverEvent,1000)
+            // console.log({event: "mouseEnterTriggered", timerId: delayTimer.current})
+        }
 
-        const handleMouseLeave = useCallback(() => {
+        const handleMouseLeave = () => {
             setHover(false)
             setAnchorEl(null)
             clearTimeout(delayTimer.current)
-            mouseOverEnd.current = new Date()
-            const hoverDuration = mouseOverEnd.current - mouseOverStart.current
-            console.log({event: "mouseLeaveTriggered", timerId: delayTimer.current,
-                // mouseOverStart: mouseOverStart.current,
-                // mouseOverEnd: mouseOverEnd.current,
-                hoverDuration})
-            delayTimer.current = null
-            if ( hoverDuration > 1000 ) captureEvent("longHoverEventComplete", {hoverDuration})
+            const hoverDuration = new Date() - mouseOverStart.current
+            // console.log({event: "mouseLeaveTriggered", timerId: delayTimer.current, hoverDuration})
+            if ( hoverDuration > 2500 ) captureEvent("longHoverEventTriggered", {type: "longHoverEvent", hoverDuration})
             mouseOverStart.current = undefined
-        }, [delayTimer, mouseOverStart])
+        }
 
 
         const allProps = { hover, anchorEl, stopHover: handleMouseLeave, ...props }

--- a/packages/lesswrong/components/common/withHover.jsx
+++ b/packages/lesswrong/components/common/withHover.jsx
@@ -1,46 +1,35 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTracking } from "../../lib/analyticsEvents";
-import {hookToHoc} from "../../lib/hocUtils";
 
-export function useHover() {
-    const [hover, setHover] = useState(true)
-    const [anchorEl, setAnchorEl] = useState(null)
+export const withHover = (WrappedComponent) => {
+    return (props) => {
+        const [hover, setHover] = useState(true)
+        const [anchorEl, setAnchorEl] = useState(null)
 
-    const ref = useRef()
+        const {captureEvent} = useTracking()
 
-    const { captureEvent } = useTracking()
+        const handleMouseOver = useCallback((event) => {
+            setHover(true)
+            setAnchorEl(event.currentTarget)
+            console.log("mouseover triggered")
+            captureEvent("hoverEventTriggered")
+        }, [])
 
-    const handleMouseOver = useCallback((event) => {
-        setHover(true)
-        setAnchorEl(event.currentTarget)
-        console.log("mouseover triggered")
-        captureEvent("hoverEventTriggered")
-    },[] )
+        const handleMouseLeave = useCallback(() => {
+            setHover(false)
+            setAnchorEl(null)
+            console.log("mouseleaver triggered")
+        }, [])
 
-    const handleMouseLeave = useCallback(() => {
-        setHover(false)
-        setAnchorEl(null)
-        console.log("mouseleaver triggered")
-    },[])
 
-    useEffect(() => {
-            const node = ref?.current?.props.ref;
-            console.log(node)
-            console.log({node: ref.current})
-            if (node) {
-                console.log("node branch executed")
-                console.log(node)
-                node.addEventListener('mouseover', handleMouseOver)
-                node.addEventListener('mouseleave', handleMouseLeave)
-                return () => {
-                    node.addEventListener('mouseover', handleMouseOver)
-                    node.addEventListener('mouseleave', handleMouseLeave)
-                }
-            }
-        },[ref])
+        const allProps = {hover, anchorEl, stopHover: handleMouseLeave, ...props}
 
-      return { ref, hover, anchorEl, stopHover: handleMouseLeave }
+        return (
+            <span onMouseOver={handleMouseOver} onMouseLeave={handleMouseLeave}>
+                <WrappedComponent { ...allProps }/>
+            </span>
+        )
+    }
 }
 
-export const withHover = hookToHoc(useHover)
 export default withHover

--- a/packages/lesswrong/components/common/withHover.jsx
+++ b/packages/lesswrong/components/common/withHover.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useCallback} from 'react';
+import React, {useState, useRef } from 'react';
 import { useTracking } from "../../lib/analyticsEvents";
 
 export const withHover = (WrappedComponent) => {
@@ -31,7 +31,8 @@ export const withHover = (WrappedComponent) => {
             clearTimeout(delayTimer.current)
             const hoverDuration = new Date() - mouseOverStart.current
             // console.log({event: "mouseLeaveTriggered", timerId: delayTimer.current, hoverDuration})
-            if ( hoverDuration > 2500 ) captureEvent("longHoverEventTriggered", {type: "longHoverEvent", hoverDuration})
+            //TODO: rename "longHoverEventTriggered -> hoverEventTriggered
+            if ( hoverDuration > 2500 ) captureEvent("longHoverEventTriggered", {hoverEventType: "longHoverEvent", hoverDuration})
             mouseOverStart.current = undefined
         }
 

--- a/packages/lesswrong/components/common/withHover.jsx
+++ b/packages/lesswrong/components/common/withHover.jsx
@@ -3,7 +3,7 @@ import { useTracking } from "../../lib/analyticsEvents";
 
 export const withHover = (WrappedComponent) => {
     return (props) => {
-        const [hover, setHover] = useState(true)
+        const [hover, setHover] = useState(false)
         const [anchorEl, setAnchorEl] = useState(null)
         const delayTimer = useRef(null)
         const mouseOverStart = useRef()

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.jsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Components, registerComponent, parseRoute, parsePath, Utils } from 'meteor/vulcan:core';
 import { hostIsOnsite, useLocation, getUrlClass } from '../../lib/routeUtil';
 import Sentry from '@sentry/node';
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 export const parseRouteWithErrors = (onsiteUrl, contentSourceDescription) => {
   return parseRoute({
@@ -63,9 +64,12 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }) => 
         const PreviewComponent = parsedUrl.currentRoute.previewComponentName ? Components[parsedUrl.currentRoute.previewComponentName] : null;
         
         if (PreviewComponent) {
-          return <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id}/>
+          return <AnalyticsContext pageElementContext="linkPreview" href={destinationUrl} type={parsedUrl.currentRoute.previewComponentName} id={parsedUrl?.params?._id}>
+                    <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id}/>
+                 </AnalyticsContext>
         } else {
           return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} onSite/>
+
         }
       }
     } else {

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.jsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.jsx
@@ -64,7 +64,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }) => 
         const PreviewComponent = parsedUrl.currentRoute.previewComponentName ? Components[parsedUrl.currentRoute.previewComponentName] : null;
         
         if (PreviewComponent) {
-          return <AnalyticsContext pageElementContext="linkPreview" href={destinationUrl} type={parsedUrl.currentRoute.previewComponentName} id={parsedUrl?.params?._id}>
+          return <AnalyticsContext pageElementContext="linkPreview" href={destinationUrl} hoverPreviewType={parsedUrl.currentRoute.previewComponentName} id={parsedUrl?.params?._id}>
                     <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id}/>
                  </AnalyticsContext>
         } else {

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -226,9 +226,11 @@ const DefaultPreview = ({classes, href, innerHTML, anchorEl, hover, onsite=false
       </LWPopper>
 
       {onsite ?
-        <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} /> 
-        :
-        <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />}
+          <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+          :
+          <Components.AnalyticsTracker eventType="link" eventProps={{to: href, externalLink: true}}>
+            <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+          </Components.AnalyticsTracker>}
     </span>
   );
 }

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -217,7 +217,7 @@ const defaultPreviewStyles = theme => ({
 const DefaultPreview = ({classes, href, innerHTML, anchorEl, hover, onsite=false, id}) => {
   const { LWPopper } = Components
   return (
-      <AnalyticsContext pageElementContext="linkPreview" type="DefaultPreview" href={href} onsite={onsite} id={id}>
+      <AnalyticsContext pageElementContext="linkPreview" hoverPreviewType="DefaultPreview" href={href} onsite={onsite} id={id}>
         <span>
           <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
             <Card>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.jsx
@@ -9,6 +9,7 @@ import withHover from '../common/withHover';
 import Card from '@material-ui/core/Card';
 import { withStyles } from '@material-ui/core/styles';
 import { looksLikeDbIdString } from '../../lib/routeUtil.js';
+import {AnalyticsContext} from "../../lib/analyticsEvents";
 
 const PostLinkPreview = ({href, targetLocation, innerHTML, id}) => {
   const postID = targetLocation.params._id;
@@ -216,22 +217,24 @@ const defaultPreviewStyles = theme => ({
 const DefaultPreview = ({classes, href, innerHTML, anchorEl, hover, onsite=false, id}) => {
   const { LWPopper } = Components
   return (
-    <span>
-      <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
-        <Card>
-          <div className={classes.hovercard}>
-            {href}
-          </div>
-        </Card>
-      </LWPopper>
+      <AnalyticsContext pageElementContext="linkPreview" type="DefaultPreview" href={href} onsite={onsite} id={id}>
+        <span>
+          <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
+            <Card>
+              <div className={classes.hovercard}>
+                {href}
+              </div>
+            </Card>
+          </LWPopper>
 
-      {onsite ?
-          <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
-          :
-          <Components.AnalyticsTracker eventType="link" eventProps={{to: href, externalLink: true}}>
-            <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
-          </Components.AnalyticsTracker>}
-    </span>
+          {onsite ?
+              <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+              :
+              <Components.AnalyticsTracker eventType="link" eventProps={{to: href, externalLink: true}}>
+                <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+              </Components.AnalyticsTracker>}
+        </span>
+      </AnalyticsContext>
   );
 }
 registerComponent('DefaultPreview', DefaultPreview, withHover, withStyles(defaultPreviewStyles, {name:"DefaultPreview"}));

--- a/packages/lesswrong/components/users/UsersNameDisplay.jsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.jsx
@@ -10,6 +10,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { BookIcon } from '../icons/bookIcon'
 import withHover from '../common/withHover'
 import classNames from 'classnames';
+import {AnalyticsContext} from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   userName: {
@@ -63,14 +64,16 @@ const UsersNameDisplay = ({user, classes, nofollow=false, simple=false, hover, a
     return <span className={classes.userName}>{Users.getDisplayName(user)}</span>
   }
 
-  return <Link to={Users.getProfileUrl(user)} className={classes.userName}
-      {...(nofollow ? {rel:"nofollow"} : {})}
-    >
-      <LWPopper className={classes.tooltip} placement="top" open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip>
-        {tooltip}
-      </LWPopper>
-      {Users.getDisplayName(user)}
-    </Link>
+  return <AnalyticsContext pageElementContext="UserNameDisplay" userId={user._id}>
+      <Link to={Users.getProfileUrl(user)} className={classes.userName}
+        {...(nofollow ? {rel:"nofollow"} : {})}
+      >
+        <LWPopper className={classes.tooltip} placement="top" open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip>
+          {tooltip}
+        </LWPopper>
+        {Users.getDisplayName(user)}
+      </Link>
+  </AnalyticsContext>
 }
 
 UsersNameDisplay.propTypes = {

--- a/packages/lesswrong/lib/analyticsEvents.js
+++ b/packages/lesswrong/lib/analyticsEvents.js
@@ -32,7 +32,7 @@ export const AnalyticsUtil = {
 };
 
 export function captureEvent(eventType, eventProps) {
-  // console.log({eventType, eventProps}) //useful during development
+  console.log({eventType, eventProps}) //useful during development
   try {
     if (Meteor.isServer) {
       // If run from the server, put this directly into the server's write-to-SQL


### PR DESCRIPTION
This PR introduces two changes:
- Clicking on external links (offsite) registers an OnClick events. These links (like all <a> tags) are already extracted for hoverPreviews and so it was easy to wrap them in an AnalyticsTracker component.
- Registering a tracking event for when people view LinkHoverPreviews. This was much, much tricker.
-- decided to put the core tracking in withHover which seemed general and low-level. Rewrote withHover to be functional internally so I could invoke useTracking. Couldn't just rewrite withHover as Hook + hookToHOC due to issues with refs/adding the eventHandlers. It worked to have with withHover be functional but still return a wrapped component (that has handlers/ref).
-- Due the the extreme number of times withHover gets triggered, implemented a timer to only send withHover tracking events if the hoverPreview is displayed for some mininum time. There was much trickiness to getting that working. 
-- the withHover tracking can fire twice per hover: once as soon as minimum hover time is passed, and again upon mouseLeave if an even longer threshold was triggered.

Some issues remain:
- a hoverEvent event gets registered when clicking on links even when not actually hovering on them.
- the withHover tracking doesn't include AnalyticsContext data that's added beneath the withHover wrapped component even though the context is getting updated. I've tried lots of things to no avail.
-- I'm wondering if the issue is that the captureTrackingEvent callback gets defined at the time withHover is rendered (and that's when useContext) is called, and it's not refreshed later after more context is added. Tried for many hours, but nothing I did fixed this.
- I've occasionally seen this error about too many setStates within callback, reaching MaxDepth or something. Haven't tracked that down yet.

- I'm generally unsure whether making withHover a bunch more complicated will affect performance.
