### PR TITLE
Fix AnswersList

### DIFF
--- a/packages/lesswrong/components/questions/AnswersList.jsx
+++ b/packages/lesswrong/components/questions/AnswersList.jsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, useList } from 'meteor/vulcan:core';
+import { Components, registerComponent, useMulti } from 'meteor/vulcan:core';
 import React from 'react';
 import { Comments } from '../../lib/collections/comments';
 import { withStyles } from '@material-ui/core/styles'
@@ -29,7 +29,7 @@ const styles = theme => ({
 })
 
 const AnswersList = ({terms, post, classes}) => {
-  const { results } = useList({
+  const { results } = useMulti({
     terms,
     collection: Comments,
     queryName: 'AnswersListQuery',


### PR DESCRIPTION
Broken by me during hookification, as I used `useList` which doesn't exist instead of `useMulti` and eslint can't catch broken cross-package imports. Oops.
