### PR TITLE
Add InView tracking (Intersection Observer/Scrolling to Elements)

### DIFF
--- a/packages/lesswrong/components/comments/RecentDiscussionThreadsList.jsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThreadsList.jsx
@@ -36,7 +36,7 @@ const RecentDiscussionThreadsList = ({
     },
     ssr: true,
   });
-  
+
   useGlobalKeydown(ev => {
     const F_Key = 70
     if ((event.metaKey || event.ctrlKey) && event.keyCode == F_Key) {
@@ -51,7 +51,7 @@ const RecentDiscussionThreadsList = ({
     [setShowShortformFeed, showShortformFeed]
   );
   
-  const { SingleColumnSection, SectionTitle, SectionButton, ShortformSubmitForm, Loading } = Components
+  const { SingleColumnSection, SectionTitle, SectionButton, ShortformSubmitForm, Loading, AnalyticsInViewTracker } = Components
 
   const { LoadMore } = Components
 
@@ -87,8 +87,10 @@ const RecentDiscussionThreadsList = ({
               updateComment={updateComment}/>
           )}
         </div>}
-        { loadMore && <LoadMore loading={loadingMore || loading} loadMore={loadMore}  /> }
-        { (loading || loadingMore) && <Loading />}
+        <AnalyticsInViewTracker eventProps={{inViewType: "loadMoreButton"}}>
+            { loadMore && <LoadMore loading={loadingMore || loading} loadMore={loadMore}  /> }
+            { (loading || loadingMore) && <Loading />}
+        </AnalyticsInViewTracker>
       </div>
     </SingleColumnSection>
   )

--- a/packages/lesswrong/components/common/AnalyticsInViewTracker.jsx
+++ b/packages/lesswrong/components/common/AnalyticsInViewTracker.jsx
@@ -8,7 +8,7 @@ const AnalyticsInViewTracker = ({eventType, eventProps, observerProps, children,
 
     const { captureEvent } = useTracking()
     useEffect(() => {
-        !!entry && captureEvent(eventType||"inViewEvent", {
+        !skip && !!entry && captureEvent(eventType||"inViewEvent", {
             ...eventProps,
             ...observerProps,
             ...{ time, isIntersecting, intersectionRatio }

--- a/packages/lesswrong/components/common/AnalyticsInViewTracker.jsx
+++ b/packages/lesswrong/components/common/AnalyticsInViewTracker.jsx
@@ -1,0 +1,25 @@
+import { registerComponent } from 'meteor/vulcan:core';
+import React, { useEffect } from 'react';
+import { useIsInView, useTracking } from "../../lib/analyticsEvents";
+
+const AnalyticsInViewTracker = ({eventType, eventProps, observerProps, children, skip}) => {
+    const { ref, entry } = useIsInView(observerProps)
+    const { time, isIntersecting, intersectionRatio } = entry
+
+    const { captureEvent } = useTracking()
+    useEffect(() => {
+        !!entry && captureEvent(eventType||"inViewEvent", {
+            ...eventProps,
+            ...observerProps,
+            ...{ time, isIntersecting, intersectionRatio }
+        })
+    }, [entry])
+
+    return (
+        <span ref={ref}>
+            { children }
+        </span>
+    )
+}
+
+registerComponent('AnalyticsInViewTracker', AnalyticsInViewTracker)

--- a/packages/lesswrong/components/common/Home2.jsx
+++ b/packages/lesswrong/components/common/Home2.jsx
@@ -6,7 +6,7 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const Home2 = () => {
   const currentUser = useCurrentUser();
-  const { RecentDiscussionThreadsList, HomeLatestPosts, RecommendationsAndCurated } = Components
+  const { RecentDiscussionThreadsList, HomeLatestPosts, RecommendationsAndCurated, AnalyticsInViewTracker } = Components
 
   const shouldRenderSidebar = Users.canDo(currentUser, 'posts.moderate.all') ||
       Users.canDo(currentUser, 'alignment.sidebar')
@@ -16,14 +16,21 @@ const Home2 = () => {
         <React.Fragment>
           {shouldRenderSidebar && <Components.SunshineSidebar/>}
           <RecommendationsAndCurated configName="frontpage" />
-          <HomeLatestPosts />
+          <AnalyticsInViewTracker
+              eventProps={{inViewType: "latestPosts"}}
+              observerProps={{threshold:[0, 0.5, 1]}}
+          >
+              <HomeLatestPosts />
+          </AnalyticsInViewTracker>
           <AnalyticsContext pageSectionContext="recentDiscussion">
-              <RecentDiscussionThreadsList
-                terms={{view: 'recentDiscussionThreadsList', limit:20}}
-                commentsLimit={4}
-                maxAgeHours={18}
-                af={false}
-              />
+              <AnalyticsInViewTracker eventProps={{inViewType: "recentDiscussion"}}>
+                  <RecentDiscussionThreadsList
+                    terms={{view: 'recentDiscussionThreadsList', limit:20}}
+                    commentsLimit={4}
+                    maxAgeHours={18}
+                    af={false}
+                  />
+              </AnalyticsInViewTracker>
           </AnalyticsContext>
         </React.Fragment>
       </AnalyticsContext>

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 import Hidden from '@material-ui/core/Hidden';
 import withRecordPostView from '../common/withRecordPostView';
 import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
-import {AnalyticsContext} from "../../lib/analyticsEvents";
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { userHasBoldPostItems } from '../../lib/betas.js';
 
 export const MENU_WIDTH = 18

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -14,6 +14,7 @@ import withRecordPostView from '../../common/withRecordPostView';
 import withNewEvents from '../../../lib/events/withNewEvents.jsx';
 import { userHasPingbacks, userHasTagging } from '../../../lib/betas.js';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
+import { AnalyticsInViewTracker } from '../../common/AnalyticsInViewTracker';
 
 const HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT = 300
 const DEFAULT_TOC_MARGIN = 100
@@ -276,7 +277,7 @@ class PostsPage extends Component {
       LinkPostMessage, PostsCommentsThread, PostsGroupDetails, BottomNavigation,
       PostsTopSequencesNav, PostsPageActions, PostsPageEventData, ContentItemBody, PostsPageQuestionContent,
       TableOfContents, PostsRevisionMessage, AlignmentCrosspostMessage, PostsPageDate, CommentPermalink,
-      PingbacksList, FooterTagList, ReviewPostButton, HoverPreviewLink } = Components
+      PingbacksList, FooterTagList, ReviewPostButton, HoverPreviewLink, AnalyticsInViewTracker } = Components
 
     if (this.shouldHideAsSpam()) {
       throw new Error("Logged-out users can't see unreviewed (possibly spam) posts");
@@ -381,17 +382,18 @@ class PostsPage extends Component {
                 </div>
 
                 {/* Footer */}
-
-                {(wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
+                <AnalyticsInViewTracker eventProps={{inViewType: "lowerVoteButtons"}} >
+                  {(wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
                   <div className={classes.footerSection}>
-                    <div className={classes.voteBottom}>
-                      <PostsVote
-                        collection={Posts}
-                        post={post}
-                        currentUser={currentUser}
-                        />
-                    </div>
+                      <div className={classes.voteBottom}>
+                        <PostsVote
+                          collection={Posts}
+                          post={post}
+                          currentUser={currentUser}
+                          />
+                      </div>
                   </div>}
+                </AnalyticsInViewTracker>
                 {sequenceId && <div className={classes.bottomNavigation}>
                   <AnalyticsContext pageSectionContext="bottomSequenceNavigation">
                     <BottomNavigation post={post}/>
@@ -404,20 +406,22 @@ class PostsPage extends Component {
                   </AnalyticsContext>
                 </div>}
 
-                {/* Answers Section */}
-                {post.question && <div className={classes.post}>
-                  <div id="answers"/>
-                  <AnalyticsContext pageSectionContext="answersSection">
-                    <PostsPageQuestionContent terms={{...commentTerms, postId: post._id}} post={post} refetch={refetch}/>
-                  </AnalyticsContext>
-                </div>}
-                {/* Comments Section */}
-                <div className={classes.commentsSection}>
-                    <AnalyticsContext pageSectionContext="commentsSection">
-                      <PostsCommentsThread terms={{...commentTerms, postId: post._id}} post={post} newForm={!post.question}/>
+                <AnalyticsInViewTracker eventProps={{inViewType: "commentsSection"}} >
+                  {/* Answers Section */}
+                  {post.question && <div className={classes.post}>
+                    <div id="answers"/>
+                    <AnalyticsContext pageSectionContext="answersSection">
+                      <PostsPageQuestionContent terms={{...commentTerms, postId: post._id}} post={post} refetch={refetch}/>
                     </AnalyticsContext>
-                </div>
-              </div>
+                  </div>}
+                  {/* Comments Section */}
+                  <div className={classes.commentsSection}>
+                      <AnalyticsContext pageSectionContext="commentsSection">
+                        <PostsCommentsThread terms={{...commentTerms, postId: post._id}} post={post} newForm={!post.question}/>
+                      </AnalyticsContext>
+                  </div>
+                </AnalyticsInViewTracker>
+            </div>
               <div className={classes.gap2}/>
             </div>
           </AnalyticsContext>
@@ -453,5 +457,5 @@ registerComponent(
   withStyles(styles, { name: "PostsPage" }),
   withRecordPostView,
   withNewEvents,
-  withErrorBoundary,
+  withErrorBoundary
 );

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -382,18 +382,17 @@ class PostsPage extends Component {
                 </div>
 
                 {/* Footer */}
-                <AnalyticsInViewTracker eventProps={{inViewType: "lowerVoteButtons"}} >
-                  {(wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
+
+                {(wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
                   <div className={classes.footerSection}>
-                      <div className={classes.voteBottom}>
-                        <PostsVote
-                          collection={Posts}
-                          post={post}
-                          currentUser={currentUser}
-                          />
-                      </div>
+                    <div className={classes.voteBottom}>
+                      <PostsVote
+                        collection={Posts}
+                        post={post}
+                        currentUser={currentUser}
+                        />
+                    </div>
                   </div>}
-                </AnalyticsInViewTracker>
                 {sequenceId && <div className={classes.bottomNavigation}>
                   <AnalyticsContext pageSectionContext="bottomSequenceNavigation">
                     <BottomNavigation post={post}/>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.jsx
@@ -14,7 +14,6 @@ import withRecordPostView from '../../common/withRecordPostView';
 import withNewEvents from '../../../lib/events/withNewEvents.jsx';
 import { userHasPingbacks, userHasTagging } from '../../../lib/betas.js';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
-import { AnalyticsInViewTracker } from '../../common/AnalyticsInViewTracker';
 
 const HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT = 300
 const DEFAULT_TOC_MARGIN = 100

--- a/packages/lesswrong/lib/analyticsEvents.js
+++ b/packages/lesswrong/lib/analyticsEvents.js
@@ -32,10 +32,7 @@ export const AnalyticsUtil = {
 };
 
 export function captureEvent(eventType, eventProps) {
-  if (eventType==="inViewEvent") {
-    const {time, inViewType, isIntersecting, intersectionRatio} = eventProps
-    console.log({eventType, time, inViewType, isIntersecting, intersectionRatio}) //useful during development
-  }
+  console.log({eventType, eventProps})
   try {
     if (Meteor.isServer) {
       // If run from the server, put this directly into the server's write-to-SQL
@@ -106,7 +103,6 @@ export function useIsInView({rootMargin='0px', threshold=0}={}) {
   const [entry, setEntry] = useState(false)
   const ref = useRef()
   useEffect(() => {
-    console.log({rootMargin, threshold}) // save for debuggin
     const observer = new IntersectionObserver(([ entry ]) => {
       // console.log({"entryWithin": entry}) // save for debuggin
       setEntry(entry)

--- a/packages/lesswrong/lib/analyticsEvents.js
+++ b/packages/lesswrong/lib/analyticsEvents.js
@@ -13,7 +13,7 @@ addGraphQLSchema(`
 `);
 
 // AnalyticsUtil: An object/namespace full of functions which need to bypass
-// the normal import system, because they are client- or server-specific but
+// the normal import, because they are client- or server-specific but
 // are used by code which isn't.
 export const AnalyticsUtil = {
   // clientWriteEvents: Send a graphQL mutation from the client to the server
@@ -32,7 +32,6 @@ export const AnalyticsUtil = {
 };
 
 export function captureEvent(eventType, eventProps) {
-  console.log({eventType, eventProps})
   try {
     if (Meteor.isServer) {
       // If run from the server, put this directly into the server's write-to-SQL

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -443,6 +443,7 @@ importComponent("UserReviews", () => require('../components/review/UserReviews.j
 
 // Analytics Tracking
 importComponent("AnalyticsTracker", () => require('../components/common/AnalyticsTracker.jsx'));
+importComponent("AnalyticsInViewTracker", () => require('../components/common/AnalyticsInViewTracker.jsx'));
 
 // vulcan:ui-bootstrap
 importComponent("FormComponentCheckboxGroup", () => require('../components/vulcan-ui-bootstrap/forms/Checkboxgroup.jsx'));


### PR DESCRIPTION
This PR introduces tracking for intersection events (component is visible in viewport) as part of the analytics infrastructure.

Tracking is added to the homepage and posts page.
Posts page tracking for reaching the comments section.
Home page tracking is of latestPosts section, recentDiscussion, and the load more buttons in each of those.
Also threw in tracking for a few more buttons in this PR, e.g. subscribeButtons.
I've got some concern about the number of events generated and want to think about how to handle that, in particular, the event tracker fires on and off when the page first loads while the post lists aren't yet populated. Probably I can clean that out of the data, but avoiding would also cut down on the number of events.