### PR TITLE
Add LWTooltip

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.jsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.jsx
@@ -54,7 +54,7 @@ const HomeLatestPosts = ({ classes }) =>
   }, [updateUser, location, history, currentUser]);
 
   const { query } = location;
-  const { SingleColumnSection, SectionTitle, PostsList2, SectionFooterCheckbox } = Components
+  const { SingleColumnSection, SectionTitle, PostsList2, SectionFooterCheckbox, LWTooltip } = Components
   const currentFilter = query.filter || (currentUser && currentUser.currentFrontpageFilter) || "frontpage";
   const limit = parseInt(query.limit) || 10
 
@@ -104,8 +104,8 @@ const HomeLatestPosts = ({ classes }) =>
 
   return (
     <SingleColumnSection>
-      <SectionTitle title={<Tooltip title={latestTitle} placement="left-start"><span>Latest Posts</span></Tooltip>}>
-        <Tooltip title={personalBlogpostTooltip}>
+      <SectionTitle title={<LWTooltip title={latestTitle} placement="left-start"><span>Latest Posts</span></LWTooltip>}>
+        <LWTooltip title={personalBlogpostTooltip}>
           <div>
             <SectionFooterCheckbox
               onClick={toggleFilter}
@@ -113,7 +113,7 @@ const HomeLatestPosts = ({ classes }) =>
               label={<div className={classes.personalBlogpostsCheckboxLabel}>Include Personal Blogposts</div>}
               />
           </div>
-        </Tooltip>
+        </LWTooltip>
       </SectionTitle>
       <AnalyticsContext listContext={"latestPosts"}>
         <PostsList2 terms={recentPostsTerms}>

--- a/packages/lesswrong/components/common/HomeLatestPosts.jsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.jsx
@@ -85,7 +85,7 @@ const HomeLatestPosts = ({ classes }) =>
     </div>
     <ul>
       <li>Usefulness, novelty and relevance</li>
-      <li>Timeless content (minimize reference to current events</li>
+      <li>Timeless content (minimize reference to current events)</li>
       <li>Explain, rather than persuade</li>
     </ul>
     <div>
@@ -104,7 +104,7 @@ const HomeLatestPosts = ({ classes }) =>
 
   return (
     <SingleColumnSection>
-      <SectionTitle title={<LWTooltip title={latestTitle} placement="left-start"><span>Latest Posts</span></LWTooltip>}>
+      <SectionTitle title={<LWTooltip title={latestTitle} placement="top"><span>Latest Posts</span></LWTooltip>}>
         <LWTooltip title={personalBlogpostTooltip}>
           <div>
             <SectionFooterCheckbox

--- a/packages/lesswrong/components/common/LWTooltip.jsx
+++ b/packages/lesswrong/components/common/LWTooltip.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { registerComponent, Components } from 'meteor/vulcan:core';
 import withHover from './withHover';
+import { withStyles } from '@material-ui/core/styles';
 
-const LWTooltip = ({children, title, placement="bottom-start", hover, anchorEl, stopHover}) => {
+const styles = {
+  root: {
+    display: "inline-block"
+  }
+}
+
+const LWTooltip = ({classes, children, title, placement="bottom-start", hover, anchorEl, stopHover}) => {
   const { LWPopper } = Components
-  return <span>
+  return <span className={classes.root}>
     <LWPopper placement={placement} open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip>
       {title}
     </LWPopper> 
@@ -12,6 +19,6 @@ const LWTooltip = ({children, title, placement="bottom-start", hover, anchorEl, 
   </span>
 }
 
-registerComponent("LWTooltip", LWTooltip, withHover);
+registerComponent("LWTooltip", LWTooltip, withHover, withStyles(styles, {name:"withStyles"}));
 
 

--- a/packages/lesswrong/components/common/LWTooltip.jsx
+++ b/packages/lesswrong/components/common/LWTooltip.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { registerComponent, Components } from 'meteor/vulcan:core';
+import withHover from './withHover';
+
+const LWTooltip = ({children, title, placement="bottom-start", hover, anchorEl, stopHover}) => {
+  const { LWPopper } = Components
+  return <span>
+    <LWPopper placement={placement} open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip>
+      {title}
+    </LWPopper> 
+    {children}
+  </span>
+}
+
+registerComponent("LWTooltip", LWTooltip, withHover);
+
+

--- a/packages/lesswrong/components/common/LWTooltip.jsx
+++ b/packages/lesswrong/components/common/LWTooltip.jsx
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
   root: {
+    // inline-block makes sure that the popper placement works properly (without flickering). "block" would also work, but there may be situations where we want to wrap an object in a tooltip that shouldn't be a block element.
     display: "inline-block"
   }
 }

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -72,6 +72,7 @@ importComponent("ErrorMessage", () => require('../components/common/ErrorMessage
 importComponent("CloudinaryImage", () => require('../components/common/CloudinaryImage.jsx'));
 importComponent("ContentItemBody", () => require('../components/common/ContentItemBody.jsx'));
 importComponent("LWPopper", () => require('../components/common/LWPopper.jsx'));
+importComponent("LWTooltip", () => require('../components/common/LWTooltip.jsx'));
 importComponent("PopperCard", () => require('../components/common/PopperCard.jsx'));
 importComponent("Footer", () => require('../components/common/Footer.jsx'));
 importComponent("LoadMore", () => require('../components/common/LoadMore.jsx'));


### PR DESCRIPTION
Material UI Tooltips have a bug that prevents poppers from closing properly. I've created a LWTooltip which is built on LWPopper, and applied it to a couple existing mui Tooltips.

I created this as part of a more experimental PR, and then decided it was important to get this bit of tech built regardless of whether the experiment panned out so created a separate PR for it.