### PR TITLE
Fix broken draftJS editor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.jsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.jsx
@@ -331,8 +331,9 @@ class EditorFormComponent extends Component {
     const { draftJSValue } = this.state
     const currentContent = draftJSValue.getCurrentContent()
     const newContent = value.getCurrentContent()
+    this.setState({draftJSValue: value})
+    
     if (currentContent !== newContent) {
-      this.setState({draftJSValue: value})
       this.afterChange();
     }
   }


### PR DESCRIPTION
This was broken by commit 34b5958a728a4ff2bce76ee13841a2ae4b6d2bda . The issue is that, unlike `setHtml`, `setMarkdown` and `setCkEditor`, `setDraftJs` is setting a state which contains not just the document being edited, but also some internal details of the editor (including the set of loaded plugins). This refactor added a check for spurious changes, by comparing the editor contents, but draftJS was calling its `onChange` on initialization to add its plugins.