### PR TITLE
Fix bookmarks list sorting

### DIFF
--- a/packages/lesswrong/components/posts/BookmarkButton.jsx
+++ b/packages/lesswrong/components/posts/BookmarkButton.jsx
@@ -47,8 +47,7 @@ const BookmarkButton = ({classes, post, currentUser, menuItem, placement="right"
 
       updateUser({
         selector: {_id: currentUser._id},
-        data: { bookmarkedPostsMetadata: newBookmarks
-      }
+        data: { bookmarkedPostsMetadata: newBookmarks }
       });
     } else {
       setBookmarked(true)

--- a/packages/lesswrong/components/posts/BookmarksList.jsx
+++ b/packages/lesswrong/components/posts/BookmarksList.jsx
@@ -16,7 +16,7 @@ const BookmarksList = ({currentUser, limit=50 }) => {
   });
 
   let bookmarkedPosts = user?.bookmarkedPosts || []
-  bookmarkedPosts = bookmarkedPosts.slice(0, limit)
+  bookmarkedPosts = bookmarkedPosts.reverse().slice(0, limit)
 
   if (loading) return <Loading/>
 

--- a/packages/lesswrong/components/posts/BookmarksPage.jsx
+++ b/packages/lesswrong/components/posts/BookmarksPage.jsx
@@ -5,23 +5,18 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import {useCurrentUser} from "../common/withUser"
 
 const BookmarksPage = () => {
-  const { SingleColumnSection, SectionTitle, BookmarksList} = Components
+  const {SingleColumnSection, SectionTitle, BookmarksList} = Components
 
   const currentUser = useCurrentUser()
 
-  if (currentUser) {
-    return (
-      <SingleColumnSection>
-          <AnalyticsContext listContext={"bookmarksPage"} capturePostItemOnMount>
-              <SectionTitle title="Bookmarks"/>
-              <BookmarksList />
-          </AnalyticsContext>
-      </SingleColumnSection>
-    )}
-   else {
-   return <span>
-     You must sign in to view bookmarked posts.
-   </span>}
+  if (!currentUser) return <span>You must sign in to view bookmarked posts.</span>
+
+  return <SingleColumnSection>
+      <AnalyticsContext listContext={"bookmarksPage"} capturePostItemOnMount>
+        <SectionTitle title="Bookmarks"/>
+        <BookmarksList/>
+      </AnalyticsContext>
+    </SingleColumnSection>
 }
 
 

--- a/packages/lesswrong/components/posts/BookmarksPage.jsx
+++ b/packages/lesswrong/components/posts/BookmarksPage.jsx
@@ -2,18 +2,27 @@ import { registerComponent, Components } from 'meteor/vulcan:core';
 import React from 'react';
 import withErrorBoundary from '../common/withErrorBoundary';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
+import {useCurrentUser} from "../common/withUser"
 
 const BookmarksPage = () => {
   const { SingleColumnSection, SectionTitle, BookmarksList} = Components
 
-  return (
-    <SingleColumnSection>
-        <AnalyticsContext listContext={"bookmarksPage"} capturePostItemOnMount>
-            <SectionTitle title="Bookmarks"/>
-            <BookmarksList />
-        </AnalyticsContext>
-    </SingleColumnSection>
-  )
+  const currentUser = useCurrentUser()
+
+  if (currentUser) {
+    return (
+      <SingleColumnSection>
+          <AnalyticsContext listContext={"bookmarksPage"} capturePostItemOnMount>
+              <SectionTitle title="Bookmarks"/>
+              <BookmarksList />
+          </AnalyticsContext>
+      </SingleColumnSection>
+    )}
+   else {
+   return <span>
+     You must sign in to view bookmarked posts.
+   </span>}
 }
+
 
 registerComponent('BookmarksPage', BookmarksPage, withErrorBoundary);

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -204,10 +204,9 @@ addRoute([
     name: 'bookmarks',
     path: '/bookmarks',
     componentName: 'BookmarksPage',
-    titleComponentName: 'UserPageTitle',
-    subtitleComponentName: 'UserPageTitle',
+    title: 'Bookmarks',
   },
-  
+
   // Tags
   {
     name: 'tags',


### PR DESCRIPTION
This PR does some very minor fixes to bookmarks.

- Changes sorting to be most-recently-added first.
- Displays "must sign in" when on /bookmarks and logged out instead of error. (Styling isn't good, but it's better than an error message.
- Fix up issue of subtitle and tab title being username of random user.