### PR TITLE
Add analytics tracking to Review Voting page

### DIFF
--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -334,20 +334,16 @@ const ReviewVotingPage = ({classes}) => {
                 />
               </div>
               <div className={classes.comments}>
-                <AnalyticsContext pageSectionContext="Nominations">
-                  <PostReviewsAndNominations
-                    title="Nominations"
-                    terms={{view:"nominations2018", postId: expandedPost._id}}
-                    post={expandedPost}
-                  />
-                </AnalyticsContext>
-                <AnalyticsContext pageSectionContext="Reviews">
-                  <PostReviewsAndNominations
-                    title="Reviews"
-                    terms={{view:"reviews2018", postId: expandedPost._id}}
-                    post={expandedPost}
-                  />
-                </AnalyticsContext>
+                <PostReviewsAndNominations
+                  title="Nominations"
+                  terms={{view:"nominations2018", postId: expandedPost._id}}
+                  post={expandedPost}
+                />
+                <PostReviewsAndNominations
+                  title="Reviews"
+                  terms={{view:"reviews2018", postId: expandedPost._id}}
+                  post={expandedPost}
+                />
               </div>
             </div>
           </div>}

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -498,24 +498,24 @@ const VoteTableRow = withStyles(voteRowStyles, {name: "VoteTableRow"})((
   const currentUser = useCurrentUser()
 
   return <AnalyticsContext pageElementContext="voteTableRow">
-  <div className={classNames(classes.root, {[classes.expanded]: expandedPostId === post._id})}>
-    <div>
-      <div className={classes.postVote} >
-        <div className={classes.post}>
-          <LWTooltip title={<PostsPreviewTooltip showAllInfo post={post}/>} tooltip={false} flip={false}>
-            <PostsTitle post={post} showIcons={false} showLinkTag={false} wrap />
-          </LWTooltip>
+    <div className={classNames(classes.root, {[classes.expanded]: expandedPostId === post._id})}>
+      <div>
+        <div className={classes.postVote} >
+          <div className={classes.post}>
+            <LWTooltip title={<PostsPreviewTooltip showAllInfo post={post}/>} tooltip={false} flip={false}>
+              <PostsTitle post={post} showIcons={false} showLinkTag={false} wrap />
+            </LWTooltip>
+          </div>
+          {post.userId !== currentUser._id && <div>
+              {useQuadratic ?
+                <QuadraticVotingButtons postId={post._id} votes={quadraticVotes} vote={dispatchQuadraticVote} /> :
+                <VotingButtons postId={post._id} dispatch={dispatch} votes={votes} />
+              }
+          </div>}
+          {post.userId === currentUser._id && <MetaInfo>You cannot vote on your own posts</MetaInfo>}
         </div>
-        {post.userId !== currentUser._id && <div>
-            {useQuadratic ?
-              <QuadraticVotingButtons postId={post._id} votes={quadraticVotes} vote={dispatchQuadraticVote} /> :
-              <VotingButtons postId={post._id} dispatch={dispatch} votes={votes} />
-            }
-        </div>}
-        {post.userId === currentUser._id && <MetaInfo>You cannot vote on your own posts</MetaInfo>}
       </div>
     </div>
-  </div>
   </AnalyticsContext>
 })
 


### PR DESCRIPTION
This PR add analytics tracking for pretty much all actions on the votesReview page except for vote button presses which are already logged in Mongo DB. Tracking includes:
- show instructions click
- vote resort click
- clicking on vote table row
- clicking on review and nomination singleLines
- hovering on items (but not voteTableRows -> that has an error when trying to capture)