### PR TITLE
Navigation drawer can scroll on small/landscape screens

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.jsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.jsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 
 const styles = theme => ({
   paperWithoutToC: {
-    width: 280
+    width: 280,
+    overflowY: "scroll"
   },
   paperWithToC: {
     width: 280,


### PR DESCRIPTION
Fixes a small UI issue on small screens (especially landscape) where the navigation drawer can be taller than the screen without being scrollable.