### PR TITLE
Fix crash on login

### DIFF
--- a/packages/lesswrong/lib/fragments.ts
+++ b/packages/lesswrong/lib/fragments.ts
@@ -88,7 +88,6 @@ registerFragment(`
     groups
     services
     pageUrl
-    locale
     voteBanned
     banned
     isReviewed

--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -173,7 +173,7 @@ class App extends PureComponent {
   initLocale = () => {
     let userLocale = '';
     let localeMethod = '';
-    const { currentUser, cookies, locale } = this.props;
+    const { cookies, locale } = this.props;
     const availableLocales = Object.keys(Strings);
     const detectedLocale = detectLocale();
 

--- a/packages/vulcan-core/lib/modules/components/App.jsx
+++ b/packages/vulcan-core/lib/modules/components/App.jsx
@@ -186,12 +186,8 @@ class App extends PureComponent {
       // 2. look for a cookie
       userLocale = cookies.get('locale');
       localeMethod = 'cookie';
-    } else if (currentUser && currentUser.locale) {
-      // 3. if user is logged in, check for their preferred locale
-      userLocale = currentUser.locale;
-      localeMethod = 'user';
     } else if (detectedLocale) {
-      // 4. else, check for browser settings
+      // 3. else, check for browser settings
       userLocale = detectedLocale;
       localeMethod = 'browser';
     }


### PR DESCRIPTION
In a refactoring PR, I removed the "locale" field from user objects, which we inherited from Vulcan and which would let users set their language (except that we had disabled it). However, I missed a fragment reference to that field, which apparently broke quite a bit more than you'd expect.

(Interestingly, some prototype typescript-for-fragments code I was working on today caught the fragment-field-with-no-backing-collection-field issue here, though I didn't realize it was serious.)