### PR TITLE
Sunshine cleanup

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestCommentsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestCommentsList.jsx
@@ -20,7 +20,7 @@ class AFSuggestCommentsList extends Component {
       return (
         <div>
           <Components.SunshineListTitle>
-            <Components.OmegaIcon className={classes.icon}/> Suggested Comments
+            <div><Components.OmegaIcon className={classes.icon}/> Suggested Comments</div>
           </Components.SunshineListTitle>
           {this.props.results.map(comment =>
             <div key={comment._id} >

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsList.jsx
@@ -20,7 +20,7 @@ class AFSuggestPostsList extends Component {
       return (
         <div>
           <Components.SunshineListTitle>
-            <Components.OmegaIcon className={classes.icon}/> Suggested Posts
+            <div><Components.OmegaIcon className={classes.icon}/> Suggested Posts</div>
           </Components.SunshineListTitle>
           {this.props.results.map(post =>
             <div key={post._id} >

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersList.jsx
@@ -20,7 +20,7 @@ class AFSuggestUsersList extends Component {
       return (
         <div>
           <C.SunshineListTitle>
-            <C.OmegaIcon className={classes.icon}/> Suggested Users
+            <div><C.OmegaIcon className={classes.icon}/> Suggested Users</div>
           </C.SunshineListTitle>
           {this.props.results.map(user =>
             <div key={user._id} >

--- a/packages/lesswrong/components/sunshineDashboard/LastCuratedDate.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/LastCuratedDate.jsx
@@ -9,7 +9,11 @@ class LastCuratedDate extends Component {
     const { MetaInfo, FormatDate } = Components
     const curatedDate = results && results.length && results[0].curatedDate
     if (curatedDate) {
-      return <div><MetaInfo>Last Curation: <FormatDate date={results[0].curatedDate}/></MetaInfo></div>
+      return <div>
+        <MetaInfo>
+          <FormatDate date={results[0].curatedDate}/>
+        </MetaInfo>
+      </div>
     } else {
       return null
     }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.jsx
@@ -8,11 +8,14 @@ import PropTypes from 'prop-types';
 
 class SunshineCuratedSuggestionsList extends Component {
   render () {
-    const { results, classes } = this.props
+    const { results, loading } = this.props
+
+    if (loading) return <Components.Loading/>
+
     const { SunshineListTitle, SunshineCuratedSuggestionsItem, LastCuratedDate } = Components
     if (results && results.length) {
       return (
-        <div className={classes.root}>
+        <div>
           <SunshineListTitle>
             Suggestions for Curated
             <LastCuratedDate terms={{view:'curated', limit:1}}/>
@@ -31,8 +34,7 @@ class SunshineCuratedSuggestionsList extends Component {
 }
 
 SunshineCuratedSuggestionsList.propTypes = {
-  results: PropTypes.array,
-  classes: PropTypes.object.isRequired
+  results: PropTypes.array
 };
 
 const withListOptions = {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.jsx
@@ -2,18 +2,8 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 import { withMulti } from '../../lib/crud/withMulti';
 import React, { Component } from 'react';
 import { Posts } from '../../lib/collections/posts';
-import { withStyles } from '@material-ui/core/styles';
 import withUser from '../common/withUser';
 import PropTypes from 'prop-types';
-
-const styles = theme => ({
-  root: {
-    opacity:.2,
-    '&:hover': {
-      opacity: 1,
-    }
-  }
-})
 
 
 class SunshineCuratedSuggestionsList extends Component {
@@ -55,6 +45,5 @@ registerComponent(
   'SunshineCuratedSuggestionsList',
   SunshineCuratedSuggestionsList,
   [withMulti, withListOptions],
-  withUser,
-  withStyles(styles, {name: "SunshineCuratedSuggestionsList"})
+  withUser
 );

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
@@ -9,6 +9,9 @@ const styles = theme => ({
     borderTop: "solid 1px rgba(0,0,0,.2)",
     padding: theme.spacing.unit*1.5,
     fontWeight: 600,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center"
   }
 })
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
@@ -10,7 +10,7 @@ const styles = theme => ({
     padding: theme.spacing.unit*1.5,
     fontWeight: 600,
     display: "flex",
-    justifyContent: "flex-start",
+    justifyContent: "space-between",
     alignItems: "center"
   }
 })

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.jsx
@@ -10,7 +10,7 @@ const styles = theme => ({
     padding: theme.spacing.unit*1.5,
     fontWeight: 600,
     display: "flex",
-    justifyContent: "space-between",
+    justifyContent: "flex-start",
     alignItems: "center"
   }
 })

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.jsx
@@ -13,7 +13,8 @@ class SunshineNewUsersList extends Component {
       return (
         <div>
           <SunshineListTitle>
-            New Users <SunshineListCount count={totalCount}/>
+            <span>New Users</span>
+            <SunshineListCount count={totalCount}/>
           </SunshineListTitle>
           {this.props.results.map(user =>
             <div key={user._id} >

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -44,7 +44,7 @@ const SunshineSidebar = ({currentUser, classes}) => {
   const [showSidebar, setShowSidebar] = useState(false)
   const [showUnderbelly, setShowUnderbelly] = useState(false)
 
-  const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList, SunshineListTitle } = Components
+  const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList } = Components
 
   return (
     <div className={classNames(classes.root, {[classes.showSidebar]:showSidebar})}>
@@ -52,6 +52,13 @@ const SunshineSidebar = ({currentUser, classes}) => {
         <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
         <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}}/>
         <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
+        
+        {/* alignmentForumAdmins see AF content above the fold */}
+        { currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
+          <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
+          <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
+          <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
+        </div>}
       </div>}
 
       { showSidebar ? <div className={classes.toggle} onClick={() => setShowSidebar(false)}>
@@ -67,7 +74,9 @@ const SunshineSidebar = ({currentUser, classes}) => {
       { showSidebar && <div>
         {!!currentUser.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
         <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}}/>
-        { currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
+        
+        {/* regular admins (but not sunshines) see AF content below the fold */}
+        { Users.isAdmin(currentUser) && <div>
           <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
           <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
           <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
@@ -75,21 +84,17 @@ const SunshineSidebar = ({currentUser, classes}) => {
       </div>}
 
       { showSidebar && <div>
-        { showUnderbelly ? <div onClick={() => setShowUnderbelly(false)}>
-          <SunshineListTitle>
-            Hide the Underbelly
-            <KeyboardArrowDownIcon/>
-          </SunshineListTitle>
+        { showUnderbelly ? <div className={classes.toggle} onClick={() => setShowUnderbelly(false)}>
+          Hide the Underbelly
+          <KeyboardArrowDownIcon/>
         </div>
         :
-        <div onClick={() => setShowUnderbelly(true)}>
-          <SunshineListTitle>
-            Show the Underbelly
-            <KeyboardArrowRightIcon/>
-          </SunshineListTitle>
+        <div className={classes.toggle} onClick={() => setShowUnderbelly(true)}>
+          Show the Underbelly
+          <KeyboardArrowRightIcon/>
         </div>}
         { showUnderbelly && <div>
-          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true, includeBioOnlyUsers: true}} allowContentPreview={false}/>
+          <SunshineNewUsersList terms={{view:"allUsers", limit: 30}} allowContentPreview={false}/>
         </div>}
       </div>}
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -1,10 +1,10 @@
 import { Components, registerComponent } from 'meteor/vulcan:core';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Users from 'meteor/vulcan:users';
 import withUser from '../common/withUser';
 import PropTypes from 'prop-types';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
-import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import classNames from 'classnames';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { withStyles } from '@material-ui/core/styles';
@@ -26,78 +26,75 @@ const styles = theme => ({
     background: "white",
   },
   toggle: {
-    position:"absolute",
+    position: "relative",
     zIndex: theme.zIndexes.sunshineSidebar,
-    float: "right",
-    right: 0,
-    margin: 12,
+    display: "flex",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    padding: 8,
+    width: "100%",
+    fontSize: "1rem",
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[400],
     cursor: "pointer",
-    color: theme.palette.grey[400]
   }
 })
 
-class SunshineSidebar extends Component {
-  state = { showSidebar: true, showUnderbelly: false }
+const SunshineSidebar = ({currentUser, classes}) => {
+  const [showSidebar, setShowSidebar] = useState(false)
+  const [showUnderbelly, setShowUnderbelly] = useState(false)
 
-  toggleSidebar = () => {
-    this.setState({showSidebar: !this.state.showSidebar})
-  }
+  const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList, SunshineListTitle } = Components
 
-  toggleUnderbelly = () => {
-    // The stuff that was probably spam and hidden away from us so we wouldn't have to look at it, but sometimes turns out to be important
-    this.setState({showUnderbelly: !this.state.showUnderbelly})
-  }
+  return (
+    <div className={classNames(classes.root, {[classes.showSidebar]:showSidebar})}>
+      {Users.canDo(currentUser, 'posts.moderate.all') && <div>
+        <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
+        <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}}/>
+        <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
+      </div>}
 
-  render () {
-    const { currentUser, classes } = this.props
-    const { showSidebar, showUnderbelly } = this.state
-    const { SunshineNewUsersList, SunshineNewCommentsList, SunshineNewPostsList, SunshineReportedContentList, SunshineCuratedSuggestionsList, AFSuggestUsersList, AFSuggestPostsList, AFSuggestCommentsList, SunshineListTitle } = Components
-
-    return (
-      <div className={classNames(classes.root, {[classes.showSidebar]:showSidebar})}>
-        { showSidebar ? <KeyboardArrowDownIcon
-          className={classes.toggle}
-          onClick={this.toggleSidebar}/>
-          :
-          <KeyboardArrowLeftIcon
-            className={classes.toggle}
-            onClick={this.toggleSidebar}
-          />}
-        { showSidebar && <div>
-            {Users.canDo(currentUser, 'posts.moderate.all') && <div>
-            <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
-            <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}}/>
-            <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
-            {!!currentUser.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
-            <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}}/>
-          </div>}        
-          { currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
-            <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
-            <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
-            <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
-          </div>}
+      { showSidebar ? <div className={classes.toggle} onClick={() => setShowSidebar(false)}>
+        Hide Full Sidebar
+          <KeyboardArrowDownIcon />
+        </div>
+        :
+        <div className={classes.toggle} onClick={() => setShowSidebar(true)}>
+          Show Full Sidebar
+          <KeyboardArrowRightIcon />
         </div>}
-        { showUnderbelly ? <div>
-            <KeyboardArrowDownIcon
-              className={classes.toggle}
-              onClick={this.toggleUnderbelly}/>
-            <SunshineListTitle>Hide the Underbelly</SunshineListTitle>
-          </div>
-          :
-          <div>
-            <KeyboardArrowLeftIcon
-              className={classes.toggle}
-              onClick={this.toggleUnderbelly}
-            />
-            <SunshineListTitle>Show the Underbelly</SunshineListTitle>
-          </div>}
+
+      { showSidebar && <div>
+        {!!currentUser.viewUnreviewedComments && <SunshineNewCommentsList terms={{view:"sunshineNewCommentsList"}}/>}
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 50}}/>
+        { currentUser.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>
+          <AFSuggestUsersList terms={{view:"alignmentSuggestedUsers"}}/>
+          <AFSuggestPostsList terms={{view:"alignmentSuggestedPosts"}}/>
+          <AFSuggestCommentsList terms={{view:"alignmentSuggestedComments"}}/>
+        </div>}
+      </div>}
+
+      { showSidebar && <div>
+        { showUnderbelly ? <div onClick={() => setShowUnderbelly(false)}>
+          <SunshineListTitle>
+            Hide the Underbelly
+            <KeyboardArrowDownIcon/>
+          </SunshineListTitle>
+        </div>
+        :
+        <div onClick={() => setShowUnderbelly(true)}>
+          <SunshineListTitle>
+            Show the Underbelly
+            <KeyboardArrowRightIcon/>
+          </SunshineListTitle>
+        </div>}
         { showUnderbelly && <div>
           <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true, includeBioOnlyUsers: true}} allowContentPreview={false}/>
         </div>}
+      </div>}
 
-      </div>
-    )
-  }
+    </div>
+  )
 }
 
 SunshineSidebar.propTypes = {

--- a/packages/lesswrong/lib/collections/users/views.js
+++ b/packages/lesswrong/lib/collections/users/views.js
@@ -72,9 +72,25 @@ Users.addView("sunshineNewUsers", function (terms) {
       needsReview: true,
       reviewedByUserId: null
     },
+    options: {
+      sort: {
+        createdAt: -1
+      }
+    }
   }
 })
-ensureIndex(Users, {needsReview: 1})
+ensureIndex(Users, {needsReview: 1, createdAt: -1})
+
+Users.addView("allUsers", function (terms) {
+  return {
+    options: {
+      sort: {
+        createdAt: -1
+      }
+    }
+  }
+})
+ensureIndex(Users, {createdAt: -1})
 
 Users.addView("usersMapLocations", function () {
   return {


### PR DESCRIPTION
Divides the sunshine sidebar into two sections:

**Inbox:** Always shown, includes new users, new posts, and flagged content
**Optional:** Includes Suggested Curation, Alignment Forum stuff and the Underbelly. (I'm not sure about the right way to handle alignment forum stuff)

The idea being that most of the time the sidebar should be empty, it should almost always be achievable to _make_ it empty (now that we can snooze new users), so it should only show stuff that is relevant.