### PR TITLE
Access EventVicinity from Components to protect from unimported case

### DIFF
--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -415,7 +415,7 @@ const PostsItem2 = ({
 
   const { PostsItemComments, PostsItemKarma, PostsTitle, PostsUserAndCoauthors, LWTooltip, 
     PostsPageActions, PostsItemIcons, PostsItem2MetaInfo, PostsItemTooltipWrapper,
-    BookmarkButton, EventVicinity, PostsItemDate, PostsItemNewCommentsWrapper, AnalyticsTracker } = (Components as ComponentTypes)
+    BookmarkButton, PostsItemDate, PostsItemNewCommentsWrapper, AnalyticsTracker } = (Components as ComponentTypes)
 
   const postLink = Posts.getPageUrl(post, false, sequenceId || chapter?.sequenceId);
 
@@ -496,7 +496,7 @@ const PostsItem2 = ({
                 </PostsItem2MetaInfo>}
 
                 { post.isEvent && <PostsItem2MetaInfo className={classes.event}>
-                  <EventVicinity post={post} />
+                  <Components.EventVicinity post={post} />
                 </PostsItem2MetaInfo>}
 
                 {showPostedAt && !resumeReading && <PostsItemDate post={post} />}


### PR DESCRIPTION
We currently have the ability to turn off the importing of local-event-specific code. If we do so, event components cannot be destructured from the Components object, except after a check for the presence of events. The current pattern we've used is to (in mixed events and non-events use components) access the event components off the Components object at their use. Their use will be behind a check for something like `post.isEvent` that serves to ensure that events are being used by this forum instance.