### PR TITLE
Remove unused terms from sunshineNewUsers query

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -92,7 +92,7 @@ class SunshineSidebar extends Component {
             <SunshineListTitle>Show the Underbelly</SunshineListTitle>
           </div>}
         { showUnderbelly && <div>
-          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true}} allowContentPreview={false}/>
+          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30}} allowContentPreview={false}/>
         </div>}
 
       </div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.jsx
@@ -92,7 +92,7 @@ class SunshineSidebar extends Component {
             <SunshineListTitle>Show the Underbelly</SunshineListTitle>
           </div>}
         { showUnderbelly && <div>
-          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true, includeBioOnlyUsers: true}} allowContentPreview={false}/>
+          <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 30, ignoreRecaptcha: true}} allowContentPreview={false}/>
         </div>}
 
       </div>


### PR DESCRIPTION
It's possible you might actually want one or both of to be re-added, based on live slack discussion. Still, unless you're actively working on it, seems worth removing no-ops, you can always put them back in.