### PR TITLE
Text changes for the EA Forum

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent } from 'meteor/vulcan:core';
+import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import React from 'react';
 import { useCurrentUser } from '../common/withUser';
@@ -28,6 +28,9 @@ const styles = createStyles(theme => ({
     },
   },
 }));
+
+const latestPostsName = getSetting('forumType') === 'EAForum' ? 'Frontpage Posts' : 'Latest Posts'
+const includePersonalName = getSetting('forumType') === 'EAForum' ? 'Include Community' : 'Include Personal Blogposts'
 
 const HomeLatestPosts = ({ classes }) =>
 {
@@ -113,13 +116,13 @@ const HomeLatestPosts = ({ classes }) =>
 
   return (
     <SingleColumnSection>
-      <SectionTitle title={<LWTooltip title={latestTitle} placement="top"><span>Latest Posts</span></LWTooltip>}>
+      <SectionTitle title={<LWTooltip title={latestTitle} placement="top"><span>{latestPostsName}</span></LWTooltip>}>
         <LWTooltip title={personalBlogpostTooltip}>
           <div className={classes.personalBlogpostsCheckbox}>
             <SectionFooterCheckbox
               onClick={toggleFilter}
               value={currentFilter !== "frontpage"}
-              label={<div className={classes.personalBlogpostsCheckboxLabel}>Include Personal Blogposts</div>}
+              label={<div className={classes.personalBlogpostsCheckboxLabel}>{includePersonalName}</div>}
               />
           </div>
         </LWTooltip>

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -63,7 +63,7 @@ const FILTERS_ALL = {
     },
     frontpage: {
       label: "Frontpage",
-      tooltip: "Material selected by moderators as especially interesting or useful to people with interest in doing good effectively."
+      tooltip: "Posts about research and other work in high-impact cause areas."
     },
     questions: {
       label: "Questions",
@@ -71,7 +71,7 @@ const FILTERS_ALL = {
     },
     meta: {
       label: "Community",
-      tooltip: "Posts with topical content or relating to the EA community itself."
+      tooltip: "Posts about the EA community (including jobs, events, and announcements)."
     },
   }
 }

--- a/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.jsx
+++ b/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.jsx
@@ -5,7 +5,7 @@ import withUser from '../common/withUser';
 import { Link } from '../../lib/reactRouterWrapper'
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 
-const recommendedName = getSetting('forumType') === 'EAForum' ? 'Community Favorites' : 'Recommended'
+const recommendedName = getSetting('forumType') === 'EAForum' ? 'Forum Favorites' : 'Recommended'
 
 class ConfigurableRecommendationsList extends PureComponent {
   state = {


### PR DESCRIPTION
The EA Forum's changing the name of some of our homepage sections. I'm submitting this upstream because HomeLatestPosts gets changed enough, I'd rather not have to deal with the merge conflicts.

I'm guessing my reviewer has just as much pursed lips as I do about those ternaries. But given that we're in the world where it's definitely just 2.5 users of this codebase for the foreseeable future, I think it's the best option.