### PR TITLE
EA Sequences

### DIFF
--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -23,10 +23,9 @@ const EASequencesHome = ({classes}) => {
         <SequencesNewButton />
       </SectionTitle>
       <Typography variant='body1' className={classes.description}>
-          Sequences are collections of posts that are structured such that the posts build on top
-          of each other. Anyone can make a sequence. Sequences allow for authors to develop more
-          complex ideas than they could with a single post, but you can also make a sequence if you
-          think that there is a series of other posts that make more sense when read sequentially.
+        Sequences are collections of posts on a common theme, or that build on each other. They
+        help authors to develop ideas in ways that would be difficult in a single post. You can also
+        add posts written by other people to a sequence if you think they should be read together.
       </Typography>
       <div className={classes.sequencesGridWrapperWrapper}>
         <Components.SequencesGridWrapper

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
+import { withStyles, createStyles } from '@material-ui/core/styles';
+import { legacyBreakpoints } from '../../lib/utils/theme';
+import { postBodyStyles } from '../../themes/stylePiping';
+import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { Typography } from '@material-ui/core';
+
+const styles = createStyles(theme => ({
+  description: {
+    marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.unit,
+    ...postBodyStyles(theme),
+  },
+}))
+
+const EASequencesHome = ({classes}) => {
+
+  const { SingleColumnSection, SectionTitle, Divider, SequencesNewButton } = Components
+  return <AnalyticsContext pageContext="eaSequencesHome">
+    <SingleColumnSection>
+      <SectionTitle  title="Sequences" >
+        <SequencesNewButton />
+      </SectionTitle>
+      <Typography variant='body1' className={classes.description}>
+          Sequences are collections of posts that are structured such that the posts build on top
+          of each other. Anyone can make a sequence. Sequences allow for authors to develop more
+          complex ideas than they could with a single post, but you can also make a sequence if you
+          think that there is a series of other posts that make more sense when read sequentially.
+      </Typography>
+      <div className={classes.sequencesGridWrapperWrapper}>
+        <Components.SequencesGridWrapper
+          terms={{'view': 'communitySequences', limit: 12}}
+          listMode={true}
+          showAuthor={true}
+          showLoadMore={true}
+        />
+      </div>
+    </SingleColumnSection>
+  </AnalyticsContext>
+};
+
+registerComponent(
+  'EASequencesHome',
+  EASequencesHome,
+  withStyles(styles, {name: "EASequencesHome"}),
+);

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Components, registerComponent, getSetting } from 'meteor/vulcan:core';
+import { Components, registerComponent } from 'meteor/vulcan:core';
 import { withStyles, createStyles } from '@material-ui/core/styles';
-import { legacyBreakpoints } from '../../lib/utils/theme';
 import { postBodyStyles } from '../../themes/stylePiping';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Typography } from '@material-ui/core';
@@ -16,7 +15,7 @@ const styles = createStyles(theme => ({
 
 const EASequencesHome = ({classes}) => {
 
-  const { SingleColumnSection, SectionTitle, Divider, SequencesNewButton } = Components
+  const { SingleColumnSection, SectionTitle, SequencesNewButton } = Components
   return <AnalyticsContext pageContext="eaSequencesHome">
     <SingleColumnSection>
       <SectionTitle  title="Sequences" >

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -7,9 +7,8 @@ const styles = createStyles(theme => ({
   root: {
     textAlign: 'left',
     display: 'inline',
-     // TODO; ui style
     ...theme.typography.postStyle,
-    fontFamily: theme.typography.fontFamily,
+    ...theme.typography.uiStyle,
   },
   authorName: {
     fontWeight: 600,

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -8,7 +8,7 @@ const styles = createStyles(theme => ({
     textAlign: 'left',
     display: 'inline',
     ...theme.typography.postStyle,
-    ...theme.typography.uiStyle,
+    fontFamily: theme.typography.uiSecondary.fontFamily,
   },
   authorName: {
     fontWeight: 600,

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -7,7 +7,9 @@ const styles = createStyles(theme => ({
   root: {
     textAlign: 'left',
     display: 'inline',
-    ...theme.typography.postStyle
+     // TODO; ui style
+    ...theme.typography.postStyle,
+    fontFamily: theme.typography.fontFamily,
   },
   authorName: {
     fontWeight: 600,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -114,7 +114,7 @@ const styles = createStyles(theme => ({
   },
   secondaryInfo: {
     fontSize: '1.4rem',
-    fontFamily: theme.typography.fontFamily,
+    ...theme.typography.uiStyle,
   },
   commentsLink: {
     marginRight: SECONDARY_SPACING,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -114,6 +114,7 @@ const styles = createStyles(theme => ({
   },
   secondaryInfo: {
     fontSize: '1.4rem',
+    fontFamily: theme.typography.fontFamily,
   },
   commentsLink: {
     marginRight: SECONDARY_SPACING,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -114,7 +114,7 @@ const styles = createStyles(theme => ({
   },
   secondaryInfo: {
     fontSize: '1.4rem',
-    ...theme.typography.uiStyle,
+    fontFamily: theme.typography.uiSecondary.fontFamily,
   },
   commentsLink: {
     marginRight: SECONDARY_SPACING,

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -11,15 +11,19 @@ const styles = createStyles(theme => ({
   root: {
     marginLeft:-20,
     display: "flex",
-    alignItems: "center"
+    alignItems: "center",
+    marginBottom: -1 * theme.spacing.unit,
   },
   title: {
     display: 'inline-block',
     fontSize: 22,
     verticalAlign: '-webkit-baseline-middle',
     fontVariant: 'small-caps',
+    fontFamily: theme.typography.fontFamily,
+    textTransform: 'lowercase',
     lineHeight: '24px',
-    color: 'rgba(0,0,0,0.5)',
+    color: 'rgba(0,0,0,0.7)',
+    fontWeight: 500,
     marginTop: -2,
   }
 }))

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -18,7 +18,7 @@ const styles = createStyles(theme => ({
     fontSize: 22,
     verticalAlign: '-webkit-baseline-middle',
     fontVariant: 'small-caps',
-    ...theme.typography.uiStyle,
+    fontFamily: theme.typography.uiSecondary.fontFamily,
     lineHeight: '24px',
     color: 'rgba(0,0,0,0.5)',
     marginTop: -2,

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -12,18 +12,15 @@ const styles = createStyles(theme => ({
     marginLeft:-20,
     display: "flex",
     alignItems: "center",
-    marginBottom: -1 * theme.spacing.unit,
   },
   title: {
     display: 'inline-block',
     fontSize: 22,
     verticalAlign: '-webkit-baseline-middle',
     fontVariant: 'small-caps',
-    fontFamily: theme.typography.fontFamily,
-    textTransform: 'lowercase',
+    ...theme.typography.uiStyle,
     lineHeight: '24px',
-    color: 'rgba(0,0,0,0.7)',
-    fontWeight: 500,
+    color: 'rgba(0,0,0,0.5)',
     marginTop: -2,
   }
 }))

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
@@ -17,6 +17,7 @@ const styles = theme => ({
     "&:hover, &:visited, &:focus": {
       color: "rgba(0,0,0, 0.5)",
     },
+    fontFamily: theme.typography.fontFamily,
   },
   
   direction: {

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
@@ -17,7 +17,7 @@ const styles = theme => ({
     "&:hover, &:visited, &:focus": {
       color: "rgba(0,0,0, 0.5)",
     },
-    fontFamily: theme.typography.fontFamily,
+    ...theme.typography.uiStyle,
   },
   
   direction: {

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.jsx
@@ -17,7 +17,7 @@ const styles = theme => ({
     "&:hover, &:visited, &:focus": {
       color: "rgba(0,0,0, 0.5)",
     },
-    ...theme.typography.uiStyle,
+    fontFamily: theme.typography.uiSecondary.fontFamily,
   },
   
   direction: {

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -32,7 +32,7 @@ const styles = theme => ({
     ...theme.typography.postStyle,
     fontVariant: "small-caps",
     marginTop: 0,
-    fontFamily: theme.typography.fontFamily,
+    ...theme.typography.uiStyle,
   },
   description: {
     marginTop: theme.spacing.unit * 2,

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -32,7 +32,7 @@ const styles = theme => ({
     ...theme.typography.postStyle,
     fontVariant: "small-caps",
     marginTop: 0,
-    ...theme.typography.uiStyle,
+    fontFamily: theme.typography.uiSecondary.fontFamily,
   },
   description: {
     marginTop: theme.spacing.unit * 2,

--- a/packages/lesswrong/components/sequences/SequencesPage.jsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.jsx
@@ -31,7 +31,8 @@ const styles = theme => ({
   title: {
     ...theme.typography.postStyle,
     fontVariant: "small-caps",
-    marginTop: 0
+    marginTop: 0,
+    fontFamily: theme.typography.fontFamily,
   },
   description: {
     marginTop: theme.spacing.unit * 2,

--- a/packages/lesswrong/lib/components.js
+++ b/packages/lesswrong/lib/components.js
@@ -12,6 +12,7 @@ if(getSetting('forumType') === 'AlignmentForum') {
 
 if (getSetting('forumType') === 'EAForum') {
   importComponent("EAHome", () => require('../components/ea-forum/EAHome'));
+  importComponent("EASequencesHome", () => require('../components/ea-forum/EASequencesHome'));
 }
 
 importComponent("ConversationTitleEditForm", () => require('../components/messaging/ConversationTitleEditForm'));

--- a/packages/lesswrong/lib/routes.js
+++ b/packages/lesswrong/lib/routes.js
@@ -129,12 +129,6 @@ addRoute([
 
   // Sequences
   {
-    name: 'sequencesHome',
-    path: '/library',
-    componentName: 'SequencesHome',
-    title: "The Library"
-  },
-  {
     name: 'sequences.single.old',
     path: '/sequences/:_id',
     componentName: 'SequencesSingle'
@@ -179,27 +173,6 @@ addRoute([
     name: 'collections',
     path: '/collections/:_id',
     componentName: 'CollectionsSingle'
-  },
-  {
-    name: 'Sequences',
-    path: '/sequences',
-    componentName: 'CoreSequences',
-    title: "Rationality: A-Z"
-  },
-  {
-    name: 'Rationality',
-    path: '/rationality',
-    componentName: 'CoreSequences',
-    title: "Rationality: A-Z",
-    ...rationalitySubtitle
-  },
-  {
-    name: 'Rationality.posts.single',
-    path: '/rationality/:slug',
-    componentName: 'PostsSingleSlug',
-    previewComponentName: 'PostLinkPreviewSlug',
-    ...rationalitySubtitle,
-    getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
   },
   {
     name: 'bookmarks',
@@ -261,6 +234,38 @@ addRoute([
     // TODO: Pingback comment
   }
 ]);
+
+if (getSetting('forumType') !== 'EAForum') {
+  addRoute([
+    {
+      name: 'sequencesHome',
+      path: '/library',
+      componentName: 'SequencesHome',
+      title: "The Library"
+    },
+    {
+      name: 'Sequences',
+      path: '/sequences',
+      componentName: 'CoreSequences',
+      title: "Rationality: A-Z"
+    },
+    {
+      name: 'Rationality',
+      path: '/rationality',
+      componentName: 'CoreSequences',
+      title: "Rationality: A-Z",
+      ...rationalitySubtitle
+    },
+    {
+      name: 'Rationality.posts.single',
+      path: '/rationality/:slug',
+      componentName: 'PostsSingleSlug',
+      previewComponentName: 'PostLinkPreviewSlug',
+      ...rationalitySubtitle,
+      getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
+    },
+  ])
+}
 
 if (getSetting('forumType') === 'LessWrong') {
   addRoute([
@@ -487,6 +492,11 @@ switch (getSetting('forumType')) {
         componentName: 'Meta',
         title: "Community"
       },
+      {
+        name: 'eaSequencesHome',
+        path: '/sequences',
+        componentName: 'EASequencesHome'
+      }
     ]);
     break
   default:

--- a/packages/lesswrong/themes/alignmentForumTheme.js
+++ b/packages/lesswrong/themes/alignmentForumTheme.js
@@ -64,7 +64,7 @@ const theme = createLWTheme({
     display3: {
       fontWeight: 500
     },
-    uiStyle: {
+    uiSecondary: {
       fontFamily: sansSerifStack,
     },
   },

--- a/packages/lesswrong/themes/alignmentForumTheme.js
+++ b/packages/lesswrong/themes/alignmentForumTheme.js
@@ -63,7 +63,10 @@ const theme = createLWTheme({
     },
     display3: {
       fontWeight: 500
-    }
+    },
+    uiStyle: {
+      fontFamily: sansSerifStack,
+    },
   },
   overrides: {
     Header: {

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -132,7 +132,9 @@ const createLWTheme = (theme) => {
         fontWeight: 400,
         marginBottom: 3,
       },
-      uiStyle: {
+      // Used for ui text that's (on LW) serifed rather than the primary
+      // sans-serif ui font. On the EA Forum this is overridden with sans-serif
+      uiSecondary: {
         fontFamily: typography.fontFamily,
       },
       caption: {

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -132,6 +132,9 @@ const createLWTheme = (theme) => {
         fontWeight: 400,
         marginBottom: 3,
       },
+      uiStyle: {
+        fontFamily: typography.fontFamily,
+      },
       caption: {
         fontSize: ".9rem"
       },

--- a/packages/lesswrong/themes/eaTheme.js
+++ b/packages/lesswrong/themes/eaTheme.js
@@ -133,6 +133,9 @@ const theme = createLWTheme({
       fontFamily: titleStack,
       fontWeight: 500,
       lineHeight: '1.25em'
+    },
+    uiStyle: {
+      sansSerifStack
     }
   },
   overrides: {
@@ -185,6 +188,16 @@ const theme = createLWTheme({
         paddingRight:0,
         fontSize: '50%',
       },
+    },
+    PostsTopSequencesNav: {
+      root: {
+        marginBottom: -8,
+      },
+      title: {
+        textTransform: 'lowercase',
+        color: 'rgba(0,0,0,.7)',
+        fontWeight: 500,
+      }
     },
     SunshineSidebar: {
       root: {

--- a/packages/lesswrong/themes/eaTheme.js
+++ b/packages/lesswrong/themes/eaTheme.js
@@ -134,7 +134,7 @@ const theme = createLWTheme({
       fontWeight: 500,
       lineHeight: '1.25em'
     },
-    uiStyle: {
+    uiSecondary: {
       sansSerifStack
     }
   },

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -82,7 +82,10 @@ const theme = createLWTheme({
     title: {
       fontFamily: serifStack,
       fontWeight: 500,
-    }
+    },
+    uiStyle: {
+      fontFamily: serifStack,
+    },
   },
   overrides: {
     MuiAppBar: {

--- a/packages/lesswrong/themes/lesswrongTheme.js
+++ b/packages/lesswrong/themes/lesswrongTheme.js
@@ -83,7 +83,7 @@ const theme = createLWTheme({
       fontFamily: serifStack,
       fontWeight: 500,
     },
-    uiStyle: {
+    uiSecondary: {
       fontFamily: serifStack,
     },
   },


### PR DESCRIPTION
And change some fonts away from Times

The largest LW change here is the part where I noticed several times where LW was using Times as a default font. I thought in all those cases I'd rather the EA Forum use a sans serif stack. I introduce a uiSecondary typography, that LW sets to its serifStack and the EA Forum sets to its sansSerifStack.

I suggest using the sans serif stack for the Alignment Forum. I think it looks better in the context of the alignment forum theming. That's what I've put in the theme file, feel free to ask me to change.

![image (2)](https://user-images.githubusercontent.com/10352319/73881569-6d17a280-4815-11ea-8e3d-05aebd5e51ad.png)
