### PR TITLE
Fix "Unread Answer" left-green bar

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -28,9 +28,9 @@ const styles = createStyles(theme => ({
     borderBottom: `solid 1px ${theme.palette.grey[300]}`,
   },
   new: {
-    '&': {
+    '&&': {
       borderLeft: `solid 5px ${theme.palette.secondary.light}`,
-      '&:hover': {
+      '&&:hover': {
         borderLeft: `solid 5px ${theme.palette.secondary.main}`
       },
     }
@@ -149,6 +149,7 @@ interface CommentsNodeProps extends WithUserProps, WithStylesProps, WithLocation
   forceNotSingleLine: boolean,
   postPage: boolean,
   children: any,
+  hideReply: boolean
 }
 interface CommentsNodeState {
   collapsed: boolean,

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -30,7 +30,7 @@ const styles = createStyles(theme => ({
   new: {
     '&&': {
       borderLeft: `solid 5px ${theme.palette.secondary.light}`,
-      '&&:hover': {
+      '&:hover': {
         borderLeft: `solid 5px ${theme.palette.secondary.main}`
       },
     }


### PR DESCRIPTION
The answer border-jss was overriding the "unread comment" border-jss. Fixed specificity.

Also fixed a random typescript warning