### PR TITLE
Fix an issue where after editing a post with a ToC, the edits don't preview until refresh

### DIFF
--- a/packages/lesswrong/lib/collections/posts/fragments.js
+++ b/packages/lesswrong/lib/collections/posts/fragments.js
@@ -284,6 +284,7 @@ registerFragment(`
     customHighlight {
       ...RevisionEdit
     }
+    tableOfContents
   }
 `);
 


### PR DESCRIPTION
After you edited a post, if that post had a ToC, you would see the client-side cached pre-edit version of the post.

This is a hacky fix. The real fix is deeper in our Apollo code: when a result comes back from a mutation, it should kick everything with the same ID out of the cache, not try to merge the mutated object with cached objects.