### PR TITLE
Small spacing improvement

### DIFF
--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -34,4 +34,3 @@ declare global {
     LinkPostMessage: typeof LinkPostMessageComponent
   }
 }
-

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -56,6 +56,9 @@ const styles = createStyles(theme => ({
     gridArea: 'title',
     marginBottom: 32,
     [theme.breakpoints.down('sm')]: {
+      // Matches distance from the bottom of the secondaryInfo to the divider
+      // = 16 (see header and divider) + the ~4 pixel distance from the bottom
+      // of the secondaryInfo text to the bottom of the associated div
       marginBottom: 20,
     }
   },

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -54,7 +54,10 @@ const styles = createStyles(theme => ({
   },
   title: {
     gridArea: 'title',
-    marginBottom: 32
+    marginBottom: 32,
+    [theme.breakpoints.down('sm')]: {
+      marginBottom: 20,
+    }
   },
   toc: {
     '@supports (grid-template-areas: "title")': {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -56,10 +56,7 @@ const styles = createStyles(theme => ({
     gridArea: 'title',
     marginBottom: 32,
     [theme.breakpoints.down('sm')]: {
-      // Matches distance from the bottom of the secondaryInfo to the divider
-      // = 16 (see header and divider) + the ~4 pixel distance from the bottom
-      // of the secondaryInfo text to the bottom of the associated div
-      marginBottom: 20,
+      marginBottom: theme.spacing.titleDividerSpacing,
     }
   },
   toc: {

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -87,7 +87,7 @@ const createLWTheme = (theme) => {
         fontStyle: "italic",
         color: grey[600],
         fontSize:".9em",
-        marginBottom: spacingUnit*2,
+        marginBottom: 20,
         wordBreak: "break-word"
       },
       body1: body1FontSize,

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -87,6 +87,9 @@ const createLWTheme = (theme) => {
         fontStyle: "italic",
         color: grey[600],
         fontSize:".9em",
+        // This should be at least as big as the margin-bottom of <p> tags (18.1
+        // on LW), and the distance on mobile between the divider and the top of
+        // the notice is as good as any
         marginBottom: 20,
         wordBreak: "break-word"
       },
@@ -219,6 +222,10 @@ const createLWTheme = (theme) => {
   const mergedTheme = deepmerge(defaultLWTheme, theme, {isMergeableObject:isPlainObject})
 
   const newTheme = createMuiTheme(mergedTheme)
+  
+  console.log('keys(newTheme)', Object.keys(newTheme))
+  console.log('newTheme.typography', newTheme.typography)
+  console.log('newTheme.spacing', newTheme.typography)
 
   return newTheme
 }

--- a/packages/lesswrong/themes/createThemeDefaults.js
+++ b/packages/lesswrong/themes/createThemeDefaults.js
@@ -10,6 +10,13 @@ const monoStack = [
   'monospace'
 ].join(',')
 
+// Will be used for the distance between the post title divider and the text on
+// mobile
+// Matches distance from the bottom of the secondaryInfo to the divider
+// = 16 (see header and divider) + the ~4 pixel distance from the bottom
+// of the secondaryInfo text to the bottom of the associated div
+const titleDividerSpacing = 20
+
 export const zIndexes = {
   continueReadingImage: -1,
   commentsMenu: 1,
@@ -77,7 +84,8 @@ const createLWTheme = (theme) => {
       },
     },
     spacing: {
-      unit: spacingUnit
+      unit: spacingUnit,
+      titleDividerSpacing,
     },
     typography: {
       postStyle: {
@@ -90,7 +98,7 @@ const createLWTheme = (theme) => {
         // This should be at least as big as the margin-bottom of <p> tags (18.1
         // on LW), and the distance on mobile between the divider and the top of
         // the notice is as good as any
-        marginBottom: 20,
+        marginBottom: titleDividerSpacing,
         wordBreak: "break-word"
       },
       body1: body1FontSize,
@@ -222,10 +230,6 @@ const createLWTheme = (theme) => {
   const mergedTheme = deepmerge(defaultLWTheme, theme, {isMergeableObject:isPlainObject})
 
   const newTheme = createMuiTheme(mergedTheme)
-  
-  console.log('keys(newTheme)', Object.keys(newTheme))
-  console.log('newTheme.typography', newTheme.typography)
-  console.log('newTheme.spacing', newTheme.typography)
 
   return newTheme
 }


### PR DESCRIPTION
I felt like the spacing on my mobile view of a linkpost was wrong, specifically that it was uneven. I've made some changes that I think will help mobile LessWrong as well. The changes regularize the spacing between the bottom divider line of the title section, content notice, start of text, and spacing between paragraphs.  See before and after below. Obviously feel free to tell me to put them into `eaThemes.js`.
![image](https://user-images.githubusercontent.com/10352319/74109794-605bbd00-4b3b-11ea-8832-dc3f3b8e9c81.png)
