### PR TITLE
Use siteNameWithArticle for "view on the forumName"

### DIFF
--- a/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.jsx
+++ b/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.jsx
@@ -64,7 +64,7 @@ registerComponent("EmailListOfUsers", EmailListOfUsers);
 const PrivateMessagesEmailConversation = ({conversation, messages, participantsById, classes}) => {
   const currentUser = useCurrentUser();
   const { EmailUsername, EmailListOfUsers, EmailFormatDate, EmailContentItemBody } = Components;
-  const sitename = getSetting('title');
+  const sitename = getSetting('siteNameWithArticle');
   const conversationLink = Conversations.getPageUrl(conversation, true);
   
   return (<React.Fragment>


### PR DESCRIPTION
On LW this is a no-op, as both the title and siteName with article are "LessWrong". But on the EA Forum, and possibly the AlignmentForum, if you've implemented it, the PM emails will no longer sound like a Russian speaking without articles.