### PR TITLE
Comments use permalinks all the time

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -40,7 +40,7 @@ const CommentPermalink = (props) => {
   return <div className={classes.root}>
       <div className={classes.permalinkLabel}>Comment Permalink</div>
       {loading ? <Loading /> : <div>
-        <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch}/>
+        <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} showTitle={false}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
       </div>}
       {getSetting('forumType') !== 'EAForum' && <div className={classes.dividerMargins}><Divider /></div>}

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -22,6 +22,7 @@ interface CommentWithRepliesProps extends WithUserProps, WithStylesProps {
   post: any,
   recordPostView: any,
   refetch: any,
+  showTitle: boolean
 }
 interface CommentWithRepliesState {
   markedAsVisitedAt: Date|null,
@@ -38,7 +39,7 @@ class CommentWithReplies extends PureComponent<CommentWithRepliesProps,CommentWi
   }
 
   render () {
-    const { classes, comment, refetch, post: propsPost } = this.props
+    const { classes, comment, refetch, post: propsPost, showTitle=true } = this.props
     const { CommentsNode } = Components
     const { markedAsVisitedAt, maxChildren } = this.state
 
@@ -67,7 +68,7 @@ class CommentWithReplies extends PureComponent<CommentWithRepliesProps,CommentWi
         <CommentsNode
           noHash
           startThreadTruncated={true}
-          showPostTitle
+          showPostTitle={showTitle}
           startCollapsed
           nestingLevel={1}
           lastCommentId={lastCommentId}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -36,7 +36,7 @@ const styles = createStyles(theme => ({
   },
 }));
 
-const CommentsItemDate = ({comment, post, classes, scrollOnClick, scrollIntoView }) => {
+const CommentsItemDate = ({comment, post, classes, scrollOnClick, scrollIntoView, permalink=true }) => {
   const { history } = useNavigation();
   const { location } = useLocation();
   const { captureEvent } = useTracking("dateIconLinkClick");
@@ -48,7 +48,7 @@ const CommentsItemDate = ({comment, post, classes, scrollOnClick, scrollIntoView
     captureEvent("linkClicked", {buttonPressed: event.button, furtherContext: "dateIcon"})
    };
 
-  const url = Comments.getPageUrlFromIds({postId: post._id, postSlug: post.slug, commentId: comment._id, permalink: false})
+  const url = Comments.getPageUrlFromIds({postId: post._id, postSlug: post.slug, commentId: comment._id, permalink})
 
   const date = <span>
     <Components.FormatDate date={comment.postedAt} format={comment.answer && "MMM DD, YYYY"}/>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.tsx
@@ -28,7 +28,7 @@ const CommentsMenu = ({children, classes, className, comment, post, showEdit, ic
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking({eventType: "commentMenuClicked", eventProps: {commentId: comment._id, itemType: "comment"}})
   
-  const { EditCommentMenuItem, ReportCommentMenuItem, DeleteCommentMenuItem, RetractCommentMenuItem, BanUserFromPostMenuItem, BanUserFromAllPostsMenuItem, MoveToAlignmentMenuItem, SuggestAlignmentMenuItem, BanUserFromAllPersonalPostsMenuItem, MoveToAnswersMenuItem, SubscribeTo, CommentsPermalinkMenuItem, ToggleIsModeratorComment } = Components
+  const { EditCommentMenuItem, ReportCommentMenuItem, DeleteCommentMenuItem, RetractCommentMenuItem, BanUserFromPostMenuItem, BanUserFromAllPostsMenuItem, MoveToAlignmentMenuItem, SuggestAlignmentMenuItem, BanUserFromAllPersonalPostsMenuItem, MoveToAnswersMenuItem, SubscribeTo, ToggleIsModeratorComment } = Components
   
   if (!currentUser) return null
   
@@ -74,7 +74,6 @@ const CommentsMenu = ({children, classes, className, comment, post, showEdit, ic
           </MenuItem>
         }
         <ReportCommentMenuItem comment={comment}/>
-        <CommentsPermalinkMenuItem comment={comment} post={post} />
         <MoveToAlignmentMenuItem comment={comment} post={post}/>
         <SuggestAlignmentMenuItem comment={comment} post={post}/>
         { Users.canModeratePost(currentUser, post) && post.user && Users.canModeratePost(post.user, post) && <Divider />}


### PR DESCRIPTION
Makes it so comments-date-links are permalinks.

(Note that this does add an extra step for people who are navigating to the comment via recentDiscussion, since those people may be looking for context on the comment. But I think it's worth it overall because the hash-links make for really bad links, and most people just don't know about the permalink option. 

I think we should improve the overall experience later on by making proper SSR-loaded comments, but I expect that to take awhile)