### PR TITLE
Fix crashes introduced by Vulcan unpackaging and TS refactor

### DIFF
--- a/packages/lesswrong/client.js
+++ b/packages/lesswrong/client.js
@@ -1,4 +1,5 @@
 
+import './client/vulcan-lib/main';
 import './lib/vulcan-lib';
 import './client/vulcan-core/start';
 

--- a/packages/lesswrong/lib/vulcan-lib/callbacks.ts
+++ b/packages/lesswrong/lib/vulcan-lib/callbacks.ts
@@ -7,7 +7,7 @@ import { Utils } from './utils';
 /**
  * @summary Format callback hook names
  */
-const formatHookName = (hook: string|null): string => hook?.toLowerCase();
+const formatHookName = (hook: string|null): string => hook?.toLowerCase() || "";
 
 /**
  * @summary A list of all registered callback hooks

--- a/packages/lesswrong/lib/vulcan-lib/callbacks.ts
+++ b/packages/lesswrong/lib/vulcan-lib/callbacks.ts
@@ -7,7 +7,7 @@ import { Utils } from './utils';
 /**
  * @summary Format callback hook names
  */
-const formatHookName = (hook: string): string => hook.toLowerCase();
+const formatHookName = (hook: string|null): string => hook?.toLowerCase();
 
 /**
  * @summary A list of all registered callback hooks


### PR DESCRIPTION
First bug: Failed to import vulcan-core's client code in the right order; all files but one were imported elsewhere, the one missing populated Utils with some functions used only on certain mutations.

Second bug: When adding types to formatHookName, made it no longer accept null, because passing it null would be crazy, but it in fact gets passed null. Oops.


