### PR TITLE
Fix useCreate calling convention

### DIFF
--- a/packages/lesswrong/lib/crud/withCreate.tsx
+++ b/packages/lesswrong/lib/crud/withCreate.tsx
@@ -92,7 +92,7 @@ export const useCreate = ({
     ${fragment}
   `;
   const [mutate, {loading, error, called, data}] = useMutation(query);
-  const wrappedCreate = (data) => {
+  const wrappedCreate = ({ data }) => {
     return mutate({
       variables: { data },
       update: cacheUpdateGenerator(typeName, 'create')


### PR DESCRIPTION
When Typescriptifying, I made some components use `useCreate` instead of `withCreate`. Unfortunately `useCreate` wasn't used anywhere else and wasn't tested, so it had a bug (incorrect calling convention for the create function itself).