### PR TITLE
Only show collaborative editing option to admins

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -5,6 +5,7 @@ import { Votes } from '../votes';
 import { Comments } from '../comments'
 import { Posts } from '../posts'
 import { Meteor } from 'meteor/meteor';
+import { userHasCkEditor } from "../../betas";
 
 // Overwrite user display name getter from Vulcan
 Users.getDisplayName = (user) => {
@@ -28,7 +29,7 @@ Users.isSharedOn = (currentUser, document) => {
 }
 
 Users.canCollaborate = (currentUser, document) => {
-  return Users.isSharedOn(currentUser, document)
+  return userHasCkEditor(currentUser) && Users.isSharedOn(currentUser, document)
 }
 
 Users.canEditUsersBannedUserIds = (currentUser, targetUser) => {

--- a/packages/lesswrong/lib/registerSettings.ts
+++ b/packages/lesswrong/lib/registerSettings.ts
@@ -79,3 +79,7 @@ registerSetting('aboutPostId', 'bJ2haLkcGeLtTWaD5', 'Post ID for the /about rout
 registerSetting('introPostId', null, 'Post ID for the /intro route')
 registerSetting('eaHomeSequenceId', null, 'Sequence ID for the EAHomeHandbook sequence')
 registerSetting('eaHomeSequenceFirstPostId', null, 'Post ID for the first post in the EAHomeHandbook Sequence')
+
+// Custom analytics
+registerSetting('analytics.connectionString', null, 'Postgres connection string to the analytics database');
+registerSetting('analytics.environment', 'misconfigured', 'Environment being used to view the site');


### PR DESCRIPTION
A user reported a very buggy experience when they shared a post with another user.

While I'm at it, register some missing settings.