### PR TITLE
Improve Sunshine Underbelly

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -25,7 +25,7 @@ const styles = theme => ({
     display: "inline-block"
   },
   truncated: {
-    maxHeight: 160,
+    maxHeight: 300,
     overflow: "hidden"
   }
 })
@@ -94,6 +94,7 @@ const SunshineNewUsersItem = ({ user, classes, updateUser, allowContentPreview=t
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
           <Typography variant="body2">
             <MetaInfo>
+              {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by {user.reviewedByUserId}</em></p> : null }
               <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
               <div>Posts: { user.postCount || 0 }</div>
               <div>Comments: { user.commentCount || 0 }</div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -95,6 +95,7 @@ const SunshineNewUsersItem = ({ user, classes, updateUser, allowContentPreview=t
           <Typography variant="body2">
             <MetaInfo>
               {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by {user.reviewedByUserId}</em></p> : null }
+              {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
               <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
               <div>Posts: { user.postCount || 0 }</div>
               <div>Comments: { user.commentCount || 0 }</div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -14,7 +14,8 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
     collection: Users,
     fragmentName: 'SunshineUsersList',
     enableTotal: true,
-    ssr: true
+    ssr: true,
+    itemsPerPage: 60
   });
   const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem, LoadMore } = Components
   if (results && results.length && Users.canDo(currentUser, "posts.moderate.all")) {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -9,14 +9,14 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
   allowContentPreview?: boolean,
 }) => {
   const currentUser = useCurrentUser();
-  const { results, totalCount } = useMulti({
+  const { results, loadMore, count, totalCount } = useMulti({
     terms,
     collection: Users,
     fragmentName: 'SunshineUsersList',
     enableTotal: true,
     ssr: true
   });
-  const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem } = Components
+  const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem, LoadMore } = Components
   if (results && results.length && Users.canDo(currentUser, "posts.moderate.all")) {
     return (
       <div>
@@ -29,6 +29,13 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
             <SunshineNewUsersItem user={user} allowContentPreview={allowContentPreview}/>
           </div>
         )}
+        <LoadMore
+          loadMore={() => {
+            loadMore();
+          }}
+          count={count}
+          totalCount={totalCount}
+        />
       </div>
     )
   } else {

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -86,12 +86,13 @@ Users.addView("allUsers", function (terms) {
   return {
     options: {
       sort: {
+        reviewedAt: -1,
         createdAt: -1
       }
     }
   }
 })
-ensureIndex(Users, {createdAt: -1})
+ensureIndex(Users, {reviewedAt: -1, createdAt: -1})
 
 Users.addView("usersMapLocations", function () {
   return {

--- a/packages/lesswrong/lib/fragments.ts
+++ b/packages/lesswrong/lib/fragments.ts
@@ -278,6 +278,7 @@ registerFragment(`
     bigDownvoteCount
     banned
     reviewedByUserId
+    reviewedAt
     signUpReCaptchaRating
     needsReview
     sunshineSnoozed


### PR DESCRIPTION
– Sorts underbelly first by "reviewedAt" date, then createdAt
– Extends the truncate height more to make it easier to evaluate what sort of post you're looking at in new user content
– Sunshine New Users loads 60 additional users when you click "load more"
– Underbelly displays "reviewedAt", "reviewedByUserId", and "banned" status