### PR TITLE
TabMenuSubItem width / lwTooltip fix

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -7,13 +7,15 @@ import { iconWidth } from './TabNavigationItem'
 import menuTabs from './menuTabs'
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 
+export const TAB_NAVIGATION_MENU_WIDTH = 250
+
 const styles = (theme) => {
   return {
     root: {
       display: "flex",
       flexDirection: "column",
       justifyContent: "space-around",
-      maxWidth: 250,
+      maxWidth: TAB_NAVIGATION_MENU_WIDTH,
     },
     divider: {
       width: 50,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../../lib/vulcan-lib';
 import classNames from 'classnames'
 import { iconWidth } from './TabNavigationItem'
+import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
 
 const styles = (theme) => ({
   root: {
@@ -12,6 +13,10 @@ const styles = (theme) => ({
     paddingLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)),
     paddingRight: theme.spacing.unit*2,
     color: theme.palette.grey[600],
+    width: 
+      TAB_NAVIGATION_MENU_WIDTH - // base width
+      ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft
+      ( theme.spacing.unit*2), //paddingRight
     fontSize: "1rem",
     whiteSpace: "nowrap",
     textOverflow: "ellipsis",


### PR DESCRIPTION
I'm not sure about the right approach here (seems plausible that the TabNavigationMenu could use a simplification rework).

LWTooltip creates an inline-block wrapper for it's object, to prevent a weird flickering effect. This has worked mostly fine so far, but disrupts the CSS cascade for the TabNavigationMenu (it no longer inherits a width properly)