### PR TITLE
conditional sunshine loading, fix height

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Posts } from '../../lib/collections/posts';
 
 const SunshineCuratedSuggestionsList = ({ terms }) => {
-  const { results, loading, count, totalCount, loadMore } = useMulti({
+  const { results, loading, count, totalCount, loadMore, showLoadMore } = useMulti({
     terms,
     collection: Posts,
     fragmentName: 'PostsList',
@@ -15,9 +15,7 @@ const SunshineCuratedSuggestionsList = ({ terms }) => {
   if (loading) return <Components.Loading/>;
   
   const { SunshineListTitle, SunshineCuratedSuggestionsItem, LastCuratedDate, LoadMore } = Components
-  
-  const showLoading = totalCount && count && totalCount > count
-  
+    
   if (results && results.length) {
     return (
       <div>
@@ -30,7 +28,7 @@ const SunshineCuratedSuggestionsList = ({ terms }) => {
             <SunshineCuratedSuggestionsItem post={post}/>
           </div>
         )}
-        {showLoading && <LoadMore
+        {showLoadMore && <LoadMore
           loadMore={() => {
             loadMore();
           }}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -4,15 +4,20 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Posts } from '../../lib/collections/posts';
 
 const SunshineCuratedSuggestionsList = ({ terms }) => {
-  const { results, loading } = useMulti({
+  const { results, loading, count, totalCount, loadMore } = useMulti({
     terms,
     collection: Posts,
-    fragmentName: 'PostsList'
+    fragmentName: 'PostsList',
+    enableTotal: true,
+    itemsPerPage: 60
   });
   
   if (loading) return <Components.Loading/>;
   
-  const { SunshineListTitle, SunshineCuratedSuggestionsItem, LastCuratedDate } = Components
+  const { SunshineListTitle, SunshineCuratedSuggestionsItem, LastCuratedDate, LoadMore } = Components
+  
+  const showLoading = totalCount && count && totalCount > count
+  
   if (results && results.length) {
     return (
       <div>
@@ -25,6 +30,13 @@ const SunshineCuratedSuggestionsList = ({ terms }) => {
             <SunshineCuratedSuggestionsItem post={post}/>
           </div>
         )}
+        {showLoading && <LoadMore
+          loadMore={() => {
+            loadMore();
+          }}
+          count={count}
+          totalCount={totalCount}
+        />}
       </div>
     )
   } else {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -25,7 +25,7 @@ const styles = theme => ({
     display: "inline-block"
   },
   truncated: {
-    maxHeight: 300,
+    maxHeight: 800,
     overflow: "hidden"
   }
 })

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -9,7 +9,7 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
   allowContentPreview?: boolean,
 }) => {
   const currentUser = useCurrentUser();
-  const { results, loadMore, count, totalCount } = useMulti({
+  const { results, loadMore, count, totalCount, showLoadMore } = useMulti({
     terms,
     collection: Users,
     fragmentName: 'SunshineUsersList',
@@ -18,8 +18,6 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
     itemsPerPage: 60
   });
   const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem, LoadMore } = Components
-
-  const showLoading = totalCount && count && totalCount > count
 
   if (results && results.length && Users.canDo(currentUser, "posts.moderate.all")) {
     return (
@@ -33,7 +31,7 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
             <SunshineNewUsersItem user={user} allowContentPreview={allowContentPreview}/>
           </div>
         )}
-        {showLoading && <LoadMore
+        {showLoadMore && <LoadMore
           loadMore={() => {
             loadMore();
           }}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -18,6 +18,9 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
     itemsPerPage: 60
   });
   const { SunshineListCount, SunshineListTitle, SunshineNewUsersItem, LoadMore } = Components
+
+  const showLoading = totalCount && count && totalCount > count
+
   if (results && results.length && Users.canDo(currentUser, "posts.moderate.all")) {
     return (
       <div>
@@ -30,13 +33,13 @@ const SunshineNewUsersList = ({ terms, allowContentPreview }: {
             <SunshineNewUsersItem user={user} allowContentPreview={allowContentPreview}/>
           </div>
         )}
-        <LoadMore
+        {showLoading && <LoadMore
           loadMore={() => {
             loadMore();
           }}
           count={count}
           totalCount={totalCount}
-        />
+        />}
       </div>
     )
   } else {


### PR DESCRIPTION
– adds loadMore to sunshine curated (which has sometimes needed it)
– loadMore only appears when needed

Also changes the truncate height for the "show user content" feature large enough that I'm pretty confident it'll be an identical experience to before I added the truncate-option, which I'm also pretty confident will fix my problem with false positives.