### PR TITLE
replace LWTooltip with mui one

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from '../../../lib/reactRouterWrapper';
 import { useLocation } from '../../../lib/routeUtil';
 import classNames from 'classnames';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const smallIconSize = 23
 
@@ -52,10 +53,10 @@ const styles = theme => ({
 })
 
 const TabNavigationFooterItem = ({tab, classes}) => {
-  const { TabNavigationSubItem, LWTooltip} = Components
+  const { TabNavigationSubItem } = Components
   const { pathname } = useLocation()
 
-  return <LWTooltip placement='top' title={tab.tooltip || ''}>
+  return <Tooltip placement='top' title={tab.tooltip || ''}>
     <Link
       to={tab.link}
       className={classNames(classes.navButton, {[classes.selected]: pathname === tab.link})}
@@ -75,7 +76,7 @@ const TabNavigationFooterItem = ({tab, classes}) => {
         </span>
       }
     </Link>
-  </LWTooltip>
+  </Tooltip>
 }
 
 const TabNavigationFooterItemComponent = registerComponent(


### PR DESCRIPTION
The LWTooltip has some weird side-effects when used on components that were relying on some particular cascading styles or flex-box interactions. I haven't figured out how to fix it yet but meanwhile am reverting usages of it where that mattered.