### PR TITLE
Fix assorted type errors

### DIFF
--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -18,11 +18,13 @@ interface ExternalProps {
   placement?: string,
   tooltip?: boolean,
   flip?: boolean,
+  muiClasses?: any,
+  enterDelay?: number,
 }
 interface LWTooltipProps extends ExternalProps, WithStylesProps, WithHoverProps {
 }
 
-const LWTooltip = ({classes, children, title, placement="bottom-start", hover, anchorEl, stopHover, tooltip=true, flip=true}: LWTooltipProps) => {
+const LWTooltip = ({classes, children, title, placement="bottom-start", hover, anchorEl, stopHover, tooltip=true, flip=true, muiClasses=undefined, enterDelay=undefined}: LWTooltipProps) => {
   const { LWPopper } = Components
   return <span className={classes.root}>
     <LWPopper 
@@ -36,6 +38,8 @@ const LWTooltip = ({classes, children, title, placement="bottom-start", hover, a
           enabled: flip
         }
       }}
+      classes={muiClasses}
+      enterDelay={enterDelay}
     >
       <div className={classes.tooltip}>{title}</div>
     </LWPopper>

--- a/packages/lesswrong/components/ea-forum/EAHomeHandbook.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeHandbook.tsx
@@ -3,9 +3,9 @@ import { Components, registerComponent, getSetting } from '../../lib/vulcan-lib'
 import { createStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
-import { withSingle } from '../../lib/crud/withSingle';
-import { withCookies } from 'react-cookie'
-import { withMessages } from '../common/withMessages';
+import { useSingle } from '../../lib/crud/withSingle';
+import { useCookies } from 'react-cookie'
+import { useMessages } from '../common/withMessages';
 import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 import Sequences from '../../lib/collections/sequences/collection';
@@ -115,8 +115,15 @@ const COOKIE_NAME = 'hide_home_handbook'
 const END_OF_TIME = new Date('2038-01-18')
 const FIRST_POST_ID = getSetting('eaHomeSequenceFirstPostId')
 
-const EAHomeHandbook = ({ classes, cookies, flash, document, loading }) => {
+const EAHomeHandbook = ({ classes, documentId }) => {
   const { SingleColumnSection, CloudinaryImage2, Loading } = Components
+  const { document, loading } = useSingle({
+    documentId,
+    collection: Sequences,
+    fragmentName: 'SequencesPageFragment',
+  });
+  const { flash } = useMessages();
+  const [cookies] = useCookies([COOKIE_NAME]);
   const hideHandbook = cookies.get(COOKIE_NAME)
   if (hideHandbook) return null
   if (loading || !document) return <Loading />
@@ -169,17 +176,8 @@ const EAHomeHandbook = ({ classes, cookies, flash, document, loading }) => {
   </React.Fragment>
 }
 
-const options = {
-  collection: Sequences,
-  queryName: 'SequencesPageQuery',
-  fragmentName: 'SequencesPageFragment',
-  enableTotal: false,
-  ssr: true,
-};
-
 const EAHomeHandbookComponent = registerComponent(
-  'EAHomeHandbook', EAHomeHandbook,
-  {styles, hocs: [withCookies, withMessages, [withSingle, options]]},
+  'EAHomeHandbook', EAHomeHandbook, {styles},
 )
 
 declare global {

--- a/packages/lesswrong/components/sunshineDashboard/SidebarAction.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarAction.tsx
@@ -36,7 +36,7 @@ const SidebarAction = ({children, classes, title, warningHighlight, onClick}: {
   onClick: ()=>void,
 }) => {
   const { LWTooltip } = Components
-  return <LWTooltip title={title} placement="bottom" classes={{tooltip: classes.tooltip}} enterDelay={200}>
+  return <LWTooltip title={title} placement="bottom" muiClasses={{tooltip: classes.tooltip}} enterDelay={200}>
     <div onClick={onClick} className={classes.root}>
       {children}
       {warningHighlight && <div className={classes.warningHighlight}/>}

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -9,7 +9,7 @@ import * as _ from 'underscore';
 
 import { addEditableCallbacks } from '../editor/make_editable_callbacks'
 import { makeEditableOptions } from '../../lib/collections/comments/custom_fields'
-import { shouldNewDocumentTriggerReview } from './postCallbacks';
+import { newDocumentMaybeTriggerReview } from './postCallbacks';
 
 const MINIMUM_APPROVAL_KARMA = 5
 
@@ -415,4 +415,4 @@ async function updateTopLevelCommentLastCommentedAt (comment) {
 }
 addCallback("comment.create.after", updateTopLevelCommentLastCommentedAt)
 
-addCallback("comment.create.after", shouldNewDocumentTriggerReview)
+addCallback("comment.create.after", newDocumentMaybeTriggerReview)


### PR DESCRIPTION
Fix assorted type errors on devel, from other developers not yet having type-checking as part of their workflow. One of these (incorrectly named import of a function in commentCallbacks) was a real bug, causing comments to not un-snooze users. The missing props on LWTooltip were a very minor bug, causing a font-size modifier and 200ms delay to not get applied on the Sunshine Sidebar.


