### PR TITLE
Fixes description = 'undefined' on shortform

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -300,7 +300,7 @@ class PostsPage extends Component<PostsPageProps> {
     if (this.shouldHideAsSpam()) {
       throw new Error("Logged-out users can't see unreviewed (possibly spam) posts");
     } else {
-      const { html, plaintextDescription, wordCount = 0 } = post.contents || {}
+      const { html, wordCount = 0 } = post.contents || {}
       const view = _.clone(query).view || Comments.getDefaultView(post, currentUser)
       const commentTerms = _.isEmpty(query.view) ? {view: view, limit: 500} : {...query, limit:500}
       const sequenceId = this.getSequenceId();

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -283,6 +283,12 @@ class PostsPage extends Component<PostsPageProps> {
     return false;
   }
 
+  getDescription = post => {
+    if (post.contents?.plaintextDescription) return post.contents.plaintextDescription
+    if (post.shortform) return `A collection of shorter posts by ${getSetting('title')} user ${post.user.displayName}`
+    return null
+  }
+
   render() {
     const { post, refetch, currentUser, classes, location: { query, params } } = this.props
     const { PostsPageTitle, PostsAuthors, HeadTags, PostsVote, ContentType,
@@ -307,10 +313,13 @@ class PostsPage extends Component<PostsPageProps> {
       const contentType = getContentType(post)
 
       const commentId = query.commentId || params.commentId
+
+      const description = this.getDescription(post)
+
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>
             <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
-              <HeadTags url={Posts.getPageUrl(post, true)} canonicalUrl={post.canonicalSource} title={post.title} description={plaintextDescription}/>
+              <HeadTags url={Posts.getPageUrl(post, true)} canonicalUrl={post.canonicalSource} title={post.title} description={description}/>
               {/* Header/Title */}
               <AnalyticsContext pageSectionContext="postHeader"><div className={classes.title}>
                 <div className={classes.post}>

--- a/packages/lesswrong/server/resolvers/revisionResolvers.ts
+++ b/packages/lesswrong/server/resolvers/revisionResolvers.ts
@@ -29,7 +29,7 @@ export function htmlToDraftServer(...args) {
   (global as any).HTMLElement = globalHTMLElement;
   // And alas, it looks like we have to add this global. This seems quite bad, and I am not fully sure what to do about it.
   (global as any).document = jsdom.window.document
-  const result = htmlToDraft(...args) 
+  const result = htmlToDraft(...args)
   // We do however at least remove it right afterwards
   delete (global as any).document
   delete (global as any).HTMLElement
@@ -38,7 +38,7 @@ export function htmlToDraftServer(...args) {
 
 export function dataToDraftJS(data, type) {
   if (data===undefined || data===null) return null;
-  
+
   switch (type) {
     case "draftJS": {
       return data
@@ -55,7 +55,7 @@ export function dataToDraftJS(data, type) {
     case "markdown": {
       const html = markdownToHtmlNoLaTeX(data)
       const draftJSContentState = htmlToDraftServer(html, {}, domBuilder) // On the server have to parse in a JS-DOM implementation to make htmlToDraft work
-      return convertToRaw(draftJSContentState) 
+      return convertToRaw(draftJSContentState)
     }
     default: {
       throw new Error(`Unrecognized type: ${type}`);
@@ -97,21 +97,22 @@ addFieldsDict(Revisions, {
     resolveAs: {
       type: 'String',
       resolver: ({html}) => {
+        if (!html) return
         const truncatedHtml = truncate(sanitize(html), PLAINTEXT_HTML_TRUNCATION_LENGTH)
         return htmlToText
           .fromString(truncatedHtml)
           .substring(0, PLAINTEXT_DESCRIPTION_LENGTH)
-      } 
+      }
     }
   },
   // Plaintext version, except that specially-formatted blocks like blockquotes are filtered out, for use in highly-abridged displays like SingleLineComment.
   plaintextMainText: {
-    type: String, 
+    type: String,
     resolveAs: {
       type: 'String',
       resolver: ({html}) => {
         const mainTextHtml = sanitizeHtml(
-          html, { 
+          html, {
             allowedTags: _.without(sanitizeAllowedTags, 'blockquote', 'img'),
             nonTextTags: ['blockquote', 'img', 'style']
           }


### PR DESCRIPTION
Currently posts that don't have a body (typically shortforms) have the string `'undefined'` as the OpenGraph description, because the HTML-text parser calls `.toString()` somewhere. This fix:
- Short circuits the resolved `plaintextDescription` field if there's no HTML body in the post
- Adds a `getDescription` field to add a nicer OG description to shortform posts