### PR TITLE
fix posts-list hoverover bugs

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -49,7 +49,7 @@ const PostsItemDate = ({post, classes, hover, anchorEl, stopHover}: PostsItemDat
 
   if (post.isEvent && post.startTime) {
     return <PostsItem2MetaInfo className={classes.startTime}>
-      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="top">
+      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="right">
         <span>
           <div className={classes.tooltipSmallText}>Event starts at</div>
           <Components.EventTime post={post} />
@@ -61,7 +61,7 @@ const PostsItemDate = ({post, classes, hover, anchorEl, stopHover}: PostsItemDat
 
   if (post.isEvent && !post.startTime) {
     return <PostsItem2MetaInfo className={classes.startTime}>
-      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="top">
+      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="right">
         <span>To Be Determined</span>
       </LWPopper>
       <span>TBD</span>
@@ -70,7 +70,7 @@ const PostsItemDate = ({post, classes, hover, anchorEl, stopHover}: PostsItemDat
 
   if (post.curatedDate) {
     return <PostsItem2MetaInfo className={classes.postedAt}>
-      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="top">
+      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="right">
         <div>
           <div>Curated on <ExpandedDate date={post.curatedDate}/></div>
           <div>Posted on <ExpandedDate date={post.postedAt}/></div>
@@ -81,7 +81,7 @@ const PostsItemDate = ({post, classes, hover, anchorEl, stopHover}: PostsItemDat
   }
 
   return <PostsItem2MetaInfo className={classes.postedAt}>
-      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="top">
+      <LWPopper open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip placement="right">
         <ExpandedDate date={post.postedAt}/>
       </LWPopper>
       <span>{moment(new Date(post.postedAt)).fromNow()}</span>

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -50,7 +50,7 @@ interface UsersNameDisplayProps extends ExternalProps, WithStylesProps, WithHove
 const UsersNameDisplay = ({user, classes, nofollow=false, simple=false, hover, anchorEl, stopHover}: UsersNameDisplayProps) => {
 
   if (!user) return <Components.UserNameDeleted/>
-  const { FormatDate, LWPopper } = Components
+  const { FormatDate, LWTooltip } = Components
   const { htmlBio } = user
 
   const truncatedBio = truncate(htmlBio, 500)
@@ -73,14 +73,13 @@ const UsersNameDisplay = ({user, classes, nofollow=false, simple=false, hover, a
   }
 
   return <AnalyticsContext pageElementContext="userNameDisplay" userIdDisplayed={user._id}>
+    <LWTooltip title={tooltip} placement="left">
       <Link to={Users.getProfileUrl(user)} className={classes.userName}
-        {...(nofollow ? {rel:"nofollow"} : {})}
-      >
-        <LWPopper className={classes.tooltip} placement="top" open={hover} anchorEl={anchorEl} onMouseEnter={stopHover} tooltip>
-          {tooltip}
-        </LWPopper>
+          {...(nofollow ? {rel:"nofollow"} : {})}
+        >
         {Users.getDisplayName(user)}
       </Link>
+    </LWTooltip>
   </AnalyticsContext>
 }
 

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -6,6 +6,7 @@ import moment from '../../lib/moment-timezone';
 import { useHover } from '../common/withHover';
 import { useCurrentUser } from '../common/withUser';
 import { useVote } from './withVote';
+import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = theme => ({
   vote: {
@@ -59,7 +60,7 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
     <span className={classes.vote} {...eventHandlers}>
       {(getSetting('forumType') !== 'AlignmentForum' || !!comment.af) &&
         <span>
-          <LWTooltip
+          <Tooltip
             title={<div>Downvote<br /><em>For strong downvote, click-and-hold<br />(Click twice on mobile)</em></div>}
             placement="bottom"
             >
@@ -74,18 +75,18 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 vote={vote}
               />
             </span>
-          </LWTooltip>
+          </Tooltip>
           {hideKarma ?
-            <LWTooltip title={'The author of this post has disabled karma visibility'}>
+            <Tooltip title={'The author of this post has disabled karma visibility'}>
               <span>{' '}</span>
-            </LWTooltip> :
-            <LWTooltip title={`This comment has ${karma} karma (${voteCount} ${voteCount == 1 ? "Vote" : "Votes"})`} placement="bottom">
+            </Tooltip> :
+            <Tooltip title={`This comment has ${karma} karma (${voteCount} ${voteCount == 1 ? "Vote" : "Votes"})`} placement="bottom">
               <span className={classes.voteScore}>
                 {karma}
               </span>
-            </LWTooltip>
+            </Tooltip>
           }
-          <LWTooltip
+          <Tooltip
             title={<div>Upvote<br /><em>For strong upvote, click-and-hold<br /> (Click twice on mobile)</em></div>}
             placement="bottom">
             <span>
@@ -99,11 +100,11 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 vote={vote}
               />
             </span>
-          </LWTooltip>
+          </Tooltip>
         </span>
       }
       {!!comment.af && getSetting('forumType') !== 'AlignmentForum' &&
-        <LWTooltip placement="bottom" title={
+        <Tooltip placement="bottom" title={
           <div>
             <p>AI Alignment Forum Karma</p>
             { moveToAfInfo }
@@ -113,15 +114,15 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
             <span className={classes.secondarySymbol}>Ω</span>
             <span className={classes.secondaryScoreNumber}>{comment.afBaseScore || 0}</span>
           </span>
-        </LWTooltip>
+        </Tooltip>
       }
       {!comment.af && (getSetting('forumType') === 'AlignmentForum') &&
-        <LWTooltip title="LessWrong Karma" placement="bottom">
+        <Tooltip title="LessWrong Karma" placement="bottom">
           <span className={classes.secondaryScore}>
             <span className={classes.secondarySymbol}>LW</span>
             <span className={classes.secondaryScoreNumber}>{comment.baseScore || 0}</span>
           </span>
-        </LWTooltip>
+        </Tooltip>
       }
     </span>)
 }

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -46,7 +46,7 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
   
   if (!comment) return null;
 
-  const { VoteButton, LWTooltip } = Components
+  const { VoteButton } = Components
   const voteCount = comment.voteCount;
   const karma = Comments.getKarma(comment)
 


### PR DESCRIPTION
The posts-list was sometimes leaving orphaned hover-over cards (it turns out that while LWTooltip was a significant improvement over MUITooltip in terms of this bug, it's not sufficient). 

Moving the tooltips to the left/right instead of top alleviates the bug (since it's much harder to mouseover multiple tooltips while wiggling your cursor around)

Also reverts some LWTooltips in the CommentsVote that weren't quite working right.