### PR TITLE
add error throwing to convertTimeOfWeekTimezone

### DIFF
--- a/packages/lesswrong/lib/utils/timeUtil.ts
+++ b/packages/lesswrong/lib/utils/timeUtil.ts
@@ -4,6 +4,11 @@ import moment from '../moment-timezone';
 // number 0-6), and a pair of timezones, convert the time/day to the new time
 // zone.
 export const convertTimeOfWeekTimezone = (timeOfDay, dayOfWeek, fromTimezone, toTimezone) => {
+  if (!timeOfDay) throw Error("convertTimeOfWeekTimezone was not provided a timeOfDay")
+  if (!dayOfWeek) throw Error("convertTimeOfWeekTimezone was not provided a dayOfWeek")
+  if (!fromTimezone) throw Error("convertTimeOfWeekTimezone was not provided a fromTimezone")
+  if (!toTimezone) throw Error("convertTimeOfWeekTimezone was not provided a toTimezone")
+
   let time = moment()
     .tz(fromTimezone)
     .day(dayOfWeek).hour(timeOfDay).minute(0)


### PR DESCRIPTION
Not 100% sure this function always requires all four parameters, but I think it does.