### PR TITLE
More visibility on related questions

### DIFF
--- a/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
@@ -46,12 +46,9 @@ const NewRelatedQuestionForm = ({ post, classes, refetch }: {
         fieldName="hiddenRelatedQuestion"
         tooltip={<div>
           <div>
-            To avoid cluttering the home page with questions (while encouraging people to liberally use the "related question" feature), related questions by default are hidden from the 'Latest Posts' section. 
+            Hide this question from the home page
           </div>
-          <br/>
-          <div>
-            Toggle this off if you'd like to display your question.
-          </div>
+          <div><em>(useful if you have lots of related questions and don't want to avoid spamming)</em></div>
         </div>}
       />
       <PostSubmit {...props} />
@@ -68,7 +65,7 @@ const NewRelatedQuestionForm = ({ post, classes, refetch }: {
         prefilledProps={{
           userId: currentUser._id,
           question: true,
-          hiddenRelatedQuestion: true,
+          hiddenRelatedQuestion: false,
           originalPostRelationSourceId: post._id
         }}
         successCallback={(...args) => {

--- a/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
+++ b/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
@@ -42,12 +42,9 @@ const styles = theme => ({
   subQuestion: {
     marginBottom: theme.spacing.unit,
   },
-  hasSubSubQuestions: {
-    borderLeft: "solid 2px rgba(0,0,0,.15)"
-  },
   subSubQuestions: {
-    marginLeft: theme.spacing.unit,
-    background: "rgba(0,0,0,.05)"
+    paddingLeft: theme.spacing.unit,
+    borderLeft: "solid 1px rgba(0,0,0,.15)"
   }
 })
 
@@ -84,7 +81,7 @@ const RelatedQuestionsList = ({ post, classes }: {
 
         const showSubQuestions = subQuestionTargetPostRelations.length >= 1
         return (
-          <div key={rel._id} className={classNames(classes.subQuestion, {[classes.hasSubSubQuestions]:showSubQuestions})} >
+          <div key={rel._id} className={classes.subQuestion} >
             <PostsItem2 
               post={rel.targetPost} 
               index={i}
@@ -92,7 +89,7 @@ const RelatedQuestionsList = ({ post, classes }: {
               showPostedAt={false}
               showIcons={false}
               showBottomBorder={!showSubQuestions}
-              defaultToShowUnreadComments={true}
+              defaultToShowComments={true}
             />
             {showSubQuestions && <div className={classes.subSubQuestions}>
               {subQuestionTargetPostRelations.map((rel, i) => <PostsItem2 
@@ -101,7 +98,7 @@ const RelatedQuestionsList = ({ post, classes }: {
                 showQuestionTag={false}
                 showPostedAt={false}
                 showIcons={false}
-                defaultToShowUnreadComments={true}
+                defaultToShowComments={true}
                 index={i}
               />)}
             </div>}

--- a/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
+++ b/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
@@ -1,7 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import withErrorBoundary from '../common/withErrorBoundary';
-import classNames from 'classnames';
 import * as _ from 'underscore';
 
 const styles = theme => ({


### PR DESCRIPTION
Related questions are now expanded by default (showing the most recent comments), and the "hiddenRelatedQuestion" field is false instead of true by default.