### PR TITLE
Add a COVID-19 warning to the Community section and to event pages

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -89,6 +89,7 @@ class CommunityHome extends Component<CommunityHomeProps,CommunityHomeState> {
             terms={mapEventTerms}
           />
             <SingleColumnSection>
+              <Components.Covid19Notice/>
               <SectionTitle title="Welcome to the Community Section"/>
               <Typography variant="body2" className={classes.welcomeText}>
                 On the map above you can find nearby events (blue arrows), local groups (green house icons) and other users who have added themselves to the map (purple person icons)

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -19,6 +19,7 @@ const PostsPageEventData = ({classes, post}: {
       <div className={classes.eventTimes}> <Components.EventTime post={post} dense={false} /> </div>
       { location && <div className={classes.eventLocation}> {location} </div> }
       { contactInfo && <div className={classes.eventContact}> Contact: {contactInfo} </div> }
+      <Components.Covid19Notice/>
   </Typography>
 }
 

--- a/packages/lesswrong/components/seasonal/Covid19Notice.tsx
+++ b/packages/lesswrong/components/seasonal/Covid19Notice.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+
+const styles = theme => ({
+  root: {
+    background: "#ffe5b4",
+    border: "1px solid #888",
+    borderRadius: 15,
+    margin: 16,
+    padding: 16,
+    ...theme.typography.body2,
+  }
+});
+
+const Covid19Notice = ({ classes }: {
+  classes: ClassesType
+}) => {
+  return <div className={classes.root}>
+    Check the number of COVID-19 cases in your area before hosting or attending in-person events.
+    Do not host or attend gatherings in places where COVID-19 is widespread. In places where
+    COVID-19 is not yet widespread, turn away attendees who are coughing or have a fever, and
+    encourage attendees to wash their hands frequently.
+  </div>
+}
+
+
+const Covid19NoticeComponent = registerComponent('Covid19Notice', Covid19Notice, {styles});
+
+declare global {
+  interface ComponentTypes {
+    Convid19Notice: typeof Convid19NoticeComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -413,6 +413,7 @@ importComponent("ManageSubscriptionsLink", () => require('../components/form-com
 
 // importComponent("PetrovDayButton", () => require('../components/seasonal/PetrovDayButton'));
 // importComponent("PetrovDayLossScreen", () => require('../components/seasonal/PetrovDayLossScreen'));
+importComponent("Covid19Notice", () => require('../components/seasonal/Covid19Notice'));
 
 
 import '../components/alignment-forum/withSetAlignmentPost';


### PR DESCRIPTION
Adds a COVID-19 warning to the Community section and to event pages. Styling could maybe use some tweaks, but is unimportant compared to the text. Text is pretty minimal in what it says; it'd be nice to have a suitable post to link to.

![Screen Shot 2020-03-04 at 13 29 30](https://user-images.githubusercontent.com/101191/75925199-240b3c00-5e1d-11ea-9128-9eda62c03202.png)
