### PR TITLE
Coronavirus frontpage widget

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -97,13 +97,20 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
       /> Show 'The LessWrong 2018 Review'
     </div>} */}
 
-    {/* disabled during 2018 Review */}
-    {(configName === "frontpage") && <div> 
+    {/* disabled during 2018 Review [and coronavirus]*/}
+    {/* {(configName === "frontpage") && <div> 
       <Checkbox
         checked={!settings.hideFrontpage}
         onChange={(ev, checked) => applyChange({ ...settings, hideFrontpage: !checked })}
       /> Show 'From the Archives' recommendations
-    </div>}
+    </div>} */}
+
+    <div> 
+      <Checkbox
+        checked={!settings.hideCoronavirus}
+        onChange={(ev, checked) => applyChange({ ...settings, hideCoronavirus: !checked })}
+      /> Show 'Coronavirus' recommendations
+    </div>
 
     <div>
       <Checkbox

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -77,7 +77,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
   render() {
     const { continueReading, classes, currentUser, configName } = this.props;
     const { showSettings } = this.state
-    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, SubscribeWidget, SectionTitle, SectionSubtitle, SeparatorBullet, BookmarksList, RecommendationsList, LWTooltip } = Components;
+    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, SubscribeWidget, SectionTitle, SectionSubtitle, SeparatorBullet, BookmarksList, LWTooltip, CoronavirusFrontpageWidget } = Components;
 
     const settings = getRecommendationSettings({settings: this.state.settings, currentUser, configName})
 
@@ -99,14 +99,14 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
       <div><em>(Click to see all)</em></div>
     </div>
 
-    // Disabled during 2018 Review
-    const allTimeTooltip = <div>
-      <div>
-        A weighted, randomized sample of the highest karma posts
-        {settings.onlyUnread && " that you haven't read yet"}.
-      </div>
-      <div><em>(Click to see more recommendations)</em></div>
-    </div>
+    // Disabled during 2018 Review [and coronavirus]
+    // const allTimeTooltip = <div>
+    //   <div>
+    //     A weighted, randomized sample of the highest karma posts
+    //     {settings.onlyUnread && " that you haven't read yet"}.
+    //   </div>
+    //   <div><em>(Click to see more recommendations)</em></div>
+    // </div>
 
     // defaultFrontpageSettings does not contain anything that overrides a user
     // editable setting, so the reverse ordering here is fine
@@ -161,8 +161,14 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
         <FrontpageVotingPhase settings={frontpageRecommendationSettings} />
       </AnalyticsContext> */}
 
-      {/* Disabled during 2018 Review */}
-      {!settings.hideFrontpage && <div className={classes.subsection}>
+      <AnalyticsContext pageSectionContext="Coronavirus Frontpage Widget">
+        <div className={classes.subsection}>
+          <CoronavirusFrontpageWidget settings={frontpageRecommendationSettings} />
+        </div>
+      </AnalyticsContext>
+
+      {/* Disabled during 2018 Review [and coronavirus season] */}
+      {/* {!settings.hideFrontpage && <div className={classes.subsection}>
         <LWTooltip placement="top-start" title={allTimeTooltip}>
           <Link to={"/recommendations"}>
             <SectionSubtitle className={classNames(classes.subtitle, classes.fromTheArchives)} >
@@ -173,7 +179,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
         <AnalyticsContext listContext={"frontpageFromTheArchives"} capturePostItemOnMount>
           <RecommendationsList algorithm={frontpageRecommendationSettings} />
         </AnalyticsContext>
-      </div>}
+      </div>} */}
 
       <AnalyticsContext pageSectionContext={"curatedPosts"}>
         <div className={classes.subsection}>

--- a/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
+++ b/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import {AnalyticsContext} from "../../lib/analyticsEvents";
+import { TagRels } from '../../lib/collections/tagRels/collection';
+import { useMulti } from '../../lib/crud/withMulti';
+import { Link } from '../../lib/reactRouterWrapper';
+import { useCurrentUser } from '../common/withUser'
+
+const CoronavirusFrontpageWidget = ({settings}) => {
+  const { SectionSubtitle, PostsItem2, LWTooltip, SectionFooter } = Components
+
+  const { results } = useMulti({
+    // skip: !(tag?._id),
+    terms: {
+      view: "postsWithTag",
+      tagId: "tNsqhzTibgGJKPEWB",
+    },
+    collection: TagRels,
+    fragmentName: "TagRelFragment",
+    limit: 3,
+    ssr: true,
+  });
+
+  const currentUser = useCurrentUser();
+
+  // if (settings.hideReview) return null
+  if (settings.hideCoronavirus) return null
+
+  return (
+    <div>
+      <SectionSubtitle>
+        <LWTooltip title={"View all posts related to COVID-19"} placement="top">
+          <Link to="/tag/coronavirus">Coronavirus Tag</Link>
+        </LWTooltip>
+      </SectionSubtitle>
+      <AnalyticsContext listContext={"Coronavirus Tag Frontpage"} capturePostItemOnMount>
+        {results && results.map((result,i) =>
+          result.post && <PostsItem2 key={result.post._id} post={result.post} index={i} />
+        )}
+      </AnalyticsContext>
+      {!currentUser && <SectionFooter>
+        <Link to={"/reviews"}>
+          View All Coronavirus Posts
+        </Link>
+      </SectionFooter>}
+    </div>
+  )
+}
+
+const CoronavirusFrontpageWidgetComponent = registerComponent('CoronavirusFrontpageWidget', CoronavirusFrontpageWidget);
+
+declare global {
+  interface ComponentTypes {
+    CoronavirusFrontpageWidget: typeof CoronavirusFrontpageWidgetComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -8,6 +8,7 @@ import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser';
 import { postBodyStyles } from '../../themes/stylePiping'
+import {AnalyticsContext} from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   description: {
@@ -67,9 +68,11 @@ const TagPage = ({classes}: {
       There are no posts with this tag yet.
     </div>}
     {loadingPosts && <Loading/>}
-    {orderByTagScore && orderByTagScore.map((result,i) =>
-      result.post && <PostsItem2 key={result.post._id} tagRel={result} post={result.post} index={i} />
-    )}
+    <AnalyticsContext listContext={`${tag.name} Tag Page`} capturePostItemOnMount>
+      {orderByTagScore && orderByTagScore.map((result,i) =>
+        result.post && <PostsItem2 key={result.post._id} tagRel={result} post={result.post} index={i} />
+      )}
+    </AnalyticsContext>
     <SectionFooter>
       <span className={classes.loadMore}>
         <LoadMore {...loadMoreProps}/>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -414,7 +414,7 @@ importComponent("ManageSubscriptionsLink", () => require('../components/form-com
 // importComponent("PetrovDayButton", () => require('../components/seasonal/PetrovDayButton'));
 // importComponent("PetrovDayLossScreen", () => require('../components/seasonal/PetrovDayLossScreen'));
 importComponent("Covid19Notice", () => require('../components/seasonal/Covid19Notice'));
-
+importComponent("CoronavirusFrontpageWidget", () => require('../components/seasonal/CoronavirusFrontpageWidget'));
 
 import '../components/alignment-forum/withSetAlignmentPost';
 import '../components/alignment-forum/withSetAlignmentComment';


### PR DESCRIPTION
Replaces "From the Archives" with a "Coronavirus Tag" widget, which shows the top 3 most relevant coronavirus tagged posts.

Includes links to the coronavirus tag page, and the ability to toggle it off.