### PR TITLE
Karma tooltip + Coronavirus Cleanup

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -149,11 +149,6 @@ export default {
       divider: true,
       showOnCompressed: true,
     }, {
-      id: 'coronavirus',
-      title: 'Coronavirus',
-      link: '/tag/coronavirus',
-      subItem: true,
-    }, {
       id: 'about',
       title: 'About',
       link: '/about',

--- a/packages/lesswrong/components/posts/PostsItemKarma.tsx
+++ b/packages/lesswrong/components/posts/PostsItemKarma.tsx
@@ -13,11 +13,10 @@ const PostsItemKarma = ({post, hover, anchorEl}: {
   const { LWPopper } = Components
   return (
     <span>
-      <LWPopper open={hover} anchorEl={anchorEl} tooltip placement="top-start">
+      <LWPopper open={hover} anchorEl={anchorEl} tooltip placement="left">
         <div>
-          <div>
-            This post has { baseScore || 0 } karma ({ post.voteCount} votes)
-          </div>
+          <div>{ baseScore || 0 } karma</div>
+          <div>({ post.voteCount} votes)</div>
           {afBaseScore && <div><em>({afBaseScore} karma on AlignmentForum.org)</em></div>}
         </div>
       </LWPopper>

--- a/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
+++ b/packages/lesswrong/components/seasonal/CoronavirusFrontpageWidget.tsx
@@ -29,7 +29,7 @@ const CoronavirusFrontpageWidget = ({settings}) => {
   return (
     <div>
       <SectionSubtitle>
-        <LWTooltip title={"View all posts related to COVID-19"} placement="top">
+        <LWTooltip title={"View all posts related to COVID-19"} placement="top-start">
           <Link to="/tag/coronavirus">Coronavirus Tag</Link>
         </LWTooltip>
       </SectionSubtitle>


### PR DESCRIPTION
Moves karma-tooltip to the left, so it doesn't clash with the Coronavirus Tag tooltip. Also makes it smaller.

Also:
– tweaks positioning of Coronavirus Tag tooltip
– removes Coronavirus from the Nav Menu (don't think it's necessary anymore)
