### PR TITLE
Fix bug which made React Headroom not appear when scrolling up

### DIFF
--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -256,6 +256,7 @@ class Header extends PureComponent<HeaderProps,HeaderState> {
             <Headroom
               disableInlineStyles
               downTolerance={10} upTolerance={10}
+              height={64}
               className={classNames(
                 classes.headroom,
                 { [classes.headroomPinnedOpen]: searchOpen }

--- a/packages/lesswrong/lib/react-headroom/index.js
+++ b/packages/lesswrong/lib/react-headroom/index.js
@@ -62,6 +62,7 @@ export default class Headroom extends Component {
       state: 'unfixed',
       translateY: 0,
       className: 'headroom headroom--unfixed',
+      height: props.height,
     }
   }
 


### PR DESCRIPTION
Fixes a bug which made the Headroom header not appear when scrolling up, introduced by me (in the process of fixing a slow relayout during pageload). This preserves the performance improvement, but makes it appear properly.

Note that this works by passing Headroom information about its height (64) in a way which ignores a breakpoint (on small phones the height is 56). Theory predicts that this slightly changes the sensitivity to scroll gestures, but it isn't changed in a way I was able to notice by playing with it.