### PR TITLE
Filter-by-tag: Progress feedback in migration script; don't crash if user-migration not run

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -29,7 +29,7 @@ const styles = theme => ({
 const latestPostsName = getSetting('forumType') === 'EAForum' ? 'Frontpage Posts' : 'Latest Posts'
 
 const useFilterSettings = (currentUser: UsersCurrent|null) => {
-  const defaultSettings = currentUser ? currentUser.frontpageFilterSettings : defaultFilterSettings;
+  const defaultSettings = currentUser?.frontpageFilterSettings ? currentUser.frontpageFilterSettings : defaultFilterSettings;
   
   return useState(defaultSettings);
 }

--- a/packages/lesswrong/server/migrations/2020-03-11-denormalizeTagRelevance.ts
+++ b/packages/lesswrong/server/migrations/2020-03-11-denormalizeTagRelevance.ts
@@ -9,10 +9,12 @@ registerMigration({
   dateWritten: "2020-03-11",
   idempotent: true,
   action: async () => {
-    forEachDocumentBatchInCollection({
+    await forEachDocumentBatchInCollection({
       collection: Posts,
       batchSize: 100,
       callback: async (posts) => {
+        // eslint-disable-next-line no-console
+        console.log("Migrating post batch");
         await Promise.all(posts.map(post => updatePostDenormalizedTags(post._id)));
       }
     });

--- a/packages/lesswrong/server/migrations/2020-03-11-updateFrontpageFilterSettings.ts
+++ b/packages/lesswrong/server/migrations/2020-03-11-updateFrontpageFilterSettings.ts
@@ -8,10 +8,12 @@ registerMigration({
   dateWritten: "2020-03-11",
   idempotent: true,
   action: async () => {
-    forEachDocumentBatchInCollection({
+    await forEachDocumentBatchInCollection({
       collection: Users,
       batchSize: 100,
       callback: async (users: Array<DbUser>) => {
+        // eslint-disable-next-line no-console
+        console.log("Migrating user batch");
         let changes: Array<any> = [];
         
         for (let user of users) {


### PR DESCRIPTION
If the user migration hasn't been run, so the user doesn't have filter settings, use the default filter settings rather than crash on a null pointer.

Add awaits and console.logs to the migration scripts, so that you can tell when they're finished (they were running fine, but in the background, and you couldn't tell from server console output whether they were done).