### PR TITLE
Fix Add Tag button on mobile

### DIFF
--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -14,7 +14,12 @@ const styles = theme => ({
   card: {
     padding: 16,
     width: 400,
-    ...theme.typography.commentStyle
+    ...theme.typography.commentStyle,
+    
+    // No hover-preview on small phone screens
+    [theme.breakpoints.down('xs')]: {
+      display: "none",
+    },
   },
 });
 


### PR DESCRIPTION
On mobile, when you tapped on a tag in the Add Tag list, the following would happen faster than you could see:

 * A mouse-hover event gets sent to the TagSearchHit, causing a hover preview of that tag to appear
 * The hover preview covered the tag, including the spot you just tapped
 * A mouse-click event gets sent to the hover preview
 * Which a ClickAwayListener interprets as a cue to close the whole tagging menu
 * And no tag is applied.

Fixed by adding a minimum screen width for the hover-preview in TagSearchHit.


