### PR TITLE
Sunshine Sidebar: Sunshines go through checklist of core tags when reviewing posts

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from 'react';
+import React, { useState } from 'react';
 import { Components, registerComponent, getSetting } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { useMutation } from 'react-apollo';
@@ -66,6 +66,22 @@ const SunshineNewPostsItem = ({post}: {
       },
     })
   }
+  
+  // ea-forum-look-here This widget/form was redesigned to support core tags, and
+  // had some EA-forum specific customization (for the "Move to Community"
+  // button). Make sure the set of buttons here is right.
+  const handleMoveToCommunity = () => {
+    applyTags();
+    
+    updatePost({
+      selector: { _id: post._id},
+      data: {
+        meta: true,
+        reviewedByUserId: currentUser!._id,
+        authorIsUnreviewed: false
+      },
+    })
+  }
 
   const handleDelete = () => {
     if (confirm("Are you sure you want to move this post to the author's draft?")) {
@@ -80,7 +96,7 @@ const SunshineNewPostsItem = ({post}: {
     }
   }
 
-  const { MetaInfo, FooterTagList, PostsHighlight, SunshineListItem, SidebarHoverOver, SidebarActionMenu, SidebarAction, SidebarInfo, CoreTagsChecklist } = Components
+  const { MetaInfo, FooterTagList, PostsHighlight, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
   const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
   const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
 
@@ -117,9 +133,12 @@ const SunshineNewPostsItem = ({post}: {
           <Button onClick={handleReview}>
             Leave on Personal Blog
           </Button>
-          <Button onClick={handlePromote}>
+          {post.submitToFrontpage && <Button onClick={handlePromote}>
             Move to Frontpage
-          </Button>
+          </Button>}
+          {getSetting('forumType') === 'EAForum' && post.submitToFrontpage && <Button onClick={handleMoveToCommunity}>
+            Move to Community
+          </Button>}
           <Button onClick={handleDelete}>
             Move to Drafts
           </Button>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -23,9 +23,9 @@ const SunshineNewPostsItem = ({post}: {
     collection: Posts,
     fragmentName: 'PostsList',
   });
-  const [applyCoreTagsMutation] = useMutation(gql`
-    mutation applyCoreTagsMutation($postId: String, $tagIds: [String]) {
-      applyCoreTags(postId: $postId, tagIds: $tagIds)
+  const [addTagsMutation] = useMutation(gql`
+    mutation addTagsMutation($postId: String, $tagIds: [String]) {
+      addTags(postId: $postId, tagIds: $tagIds)
     }
   `);
 
@@ -35,7 +35,7 @@ const SunshineNewPostsItem = ({post}: {
       if (selectedTags[tagId])
         tagsApplied.push(tagId);
     }
-    applyCoreTagsMutation({
+    addTagsMutation({
       variables: {
         postId: post._id,
         tagIds: tagsApplied,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -1,28 +1,50 @@
+import React, { Component, useState } from 'react';
 import { Components, registerComponent, getSetting } from '../../lib/vulcan-lib';
-import { withUpdate } from '../../lib/crud/withUpdate';
-import React, { Component } from 'react';
+import { useUpdate } from '../../lib/crud/withUpdate';
+import { useMutation } from 'react-apollo';
 import { Posts } from '../../lib/collections/posts';
 import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper'
 import Typography from '@material-ui/core/Typography';
-import withUser from '../common/withUser';
-import withHover from '../common/withHover'
+import { useCurrentUser } from '../common/withUser';
+import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary';
-import DoneIcon from '@material-ui/icons/Done';
-import ClearIcon from '@material-ui/icons/Clear';
-import ThumbUpIcon from '@material-ui/icons/ThumbUp';
-import GroupIcon from '@material-ui/icons/Group';
+import Button from '@material-ui/core/Button';
+import gql from 'graphql-tag';
 
-interface ExternalProps {
+const SunshineNewPostsItem = ({post}: {
   post: PostsList,
-}
-interface SunshineNewPostsItemProps extends ExternalProps, WithUserProps, WithHoverProps {
-  updatePost: any,
-}
+}) => {
+  const [selectedTags, setSelectedTags] = useState<Record<string,boolean>>({});
+  const currentUser = useCurrentUser();
+  const {eventHandlers, hover, anchorEl} = useHover();
+  
+  const {mutate: updatePost} = useUpdate({
+    collection: Posts,
+    fragmentName: 'PostsList',
+  });
+  const [applyCoreTagsMutation] = useMutation(gql`
+    mutation applyCoreTagsMutation($postId: String, $tagIds: [String]) {
+      applyCoreTags(postId: $postId, tagIds: $tagIds)
+    }
+  `);
 
-class SunshineNewPostsItem extends Component<SunshineNewPostsItemProps> {
-  handleReview = () => {
-    const { currentUser, post, updatePost } = this.props
+  const applyTags = () => {
+    const tagsApplied: Array<string> = [];
+    for (let tagId of Object.keys(selectedTags)) {
+      if (selectedTags[tagId])
+        tagsApplied.push(tagId);
+    }
+    applyCoreTagsMutation({
+      variables: {
+        postId: post._id,
+        tagIds: tagsApplied,
+      }
+    });
+  }
+  
+  const handleReview = () => {
+    applyTags();
     updatePost({
       selector: { _id: post._id},
       data: {
@@ -32,25 +54,22 @@ class SunshineNewPostsItem extends Component<SunshineNewPostsItemProps> {
     })
   }
 
-  handlePromote = destination => () => {
-    const { currentUser, post, updatePost } = this.props
-    const destinationData = {
-      'frontpage': {frontpageDate: new Date()},
-      'community': {meta: true}
-    }[destination]
+  const handlePromote = () => {
+    applyTags();
+    
     updatePost({
       selector: { _id: post._id},
       data: {
-        ...destinationData,
+        frontpageDate: new Date(),
         reviewedByUserId: currentUser!._id,
         authorIsUnreviewed: false
       },
     })
   }
 
-  handleDelete = () => {
-    const { updatePost, post } = this.props
+  const handleDelete = () => {
     if (confirm("Are you sure you want to move this post to the author's draft?")) {
+      applyTags();
       window.open(Users.getProfileUrl(post.user), '_blank');
       updatePost({
         selector: { _id: post._id},
@@ -61,13 +80,12 @@ class SunshineNewPostsItem extends Component<SunshineNewPostsItemProps> {
     }
   }
 
-  render () {
-    const { post, hover, anchorEl } = this.props
-    const { MetaInfo, FooterTagList, PostsHighlight, SunshineListItem, SidebarHoverOver, SidebarActionMenu, SidebarAction, SidebarInfo } = Components
-    const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
-    const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
+  const { MetaInfo, FooterTagList, PostsHighlight, SunshineListItem, SidebarHoverOver, SidebarActionMenu, SidebarAction, SidebarInfo, CoreTagsChecklist } = Components
+  const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
+  const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
 
-    return (
+  return (
+    <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
           <Typography variant="title">
@@ -92,49 +110,40 @@ class SunshineNewPostsItem extends Component<SunshineNewPostsItemProps> {
           </div>
           <FooterTagList post={post} />
           <PostsHighlight post={post}/>
+          <CoreTagsChecklist onSetTagsSelected={(selectedTags) => {
+            setSelectedTags(selectedTags);
+          }}/>
+          
+          <Button onClick={handleReview}>
+            Leave on Personal Blog
+          </Button>
+          <Button onClick={handlePromote}>
+            Move to Frontpage
+          </Button>
+          <Button onClick={handleDelete}>
+            Move to Drafts
+          </Button>
         </SidebarHoverOver>
         <Link to={Posts.getPageUrl(post)}>
-            {post.title}
+          {post.title}
         </Link>
         <div>
           <SidebarInfo>
             { post.baseScore }
           </SidebarInfo>
           <SidebarInfo>
-            <Link
-              className="sunshine-sidebar-posts-author"
-              to={Users.getProfileUrl(post.user)}>
-                {post.user && post.user.displayName}
+            <Link to={Users.getProfileUrl(post.user)}>
+              {post.user && post.user.displayName}
             </Link>
           </SidebarInfo>
         </div>
-        { hover && <SidebarActionMenu>
-          <SidebarAction title="Leave on Personal Blog" onClick={this.handleReview}>
-            <DoneIcon />
-          </SidebarAction>
-          {post.submitToFrontpage && <SidebarAction title="Move to Frontpage" onClick={this.handlePromote('frontpage')}>
-            <ThumbUpIcon />
-          </SidebarAction>}
-          {getSetting('forumType') === 'EAForum' && post.submitToFrontpage && <SidebarAction title="Move to Community" onClick={this.handlePromote('community')}>
-            <GroupIcon />
-          </SidebarAction>}
-          <SidebarAction title="Move to Drafts" onClick={this.handleDelete} warningHighlight>
-            <ClearIcon />
-          </SidebarAction>
-        </SidebarActionMenu>}
       </SunshineListItem>
-    )
-  }
+    </span>
+  )
 }
 
-const SunshineNewPostsItemComponent = registerComponent<ExternalProps>('SunshineNewPostsItem', SunshineNewPostsItem, {
-  hocs: [
-    withUpdate({
-      collection: Posts,
-      fragmentName: 'PostsList',
-    }),
-    withUser, withHover(), withErrorBoundary
-  ]
+const SunshineNewPostsItemComponent = registerComponent('SunshineNewPostsItem', SunshineNewPostsItem, {
+  hocs: [withErrorBoundary]
 });
 
 declare global {

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { useMulti } from '../../lib/crud/withMulti';
+import Checkbox from '@material-ui/core/Checkbox';
+import { Tags } from '../../lib/collections/tags/collection';
+
+const styles = theme => ({
+  root: {
+  },
+  checkbox: {
+    padding: 4,
+  },
+});
+
+const CoreTagsChecklist = ({onSetTagsSelected, classes}: {
+  onSetTagsSelected: (selectedTags: Record<string,boolean>)=>void,
+  classes: ClassesType,
+}) => {
+  const { results, loading } = useMulti({
+    terms: {
+      view: "coreTags",
+    },
+    collection: Tags,
+    fragmentName: "TagFragment",
+    limit: 100,
+    ssr: true,
+  });
+  
+  const { Loading } = Components;
+  const [selections, setSelections] = useState<Record<string,boolean>>({});
+  
+  if (loading)
+    return <Loading/>
+  
+  return <div className={classes.root}>
+    {results.map(tag => <div key={tag._id}>
+      <Checkbox
+        className={classes.checkbox}
+        checked={selections[tag._id]}
+        onChange={(event, checked) => {
+          const newSelections = {...selections, [tag._id]: checked};
+          setSelections(newSelections);
+          onSetTagsSelected(newSelections);
+        }}
+      />
+      {tag.name}
+    </div>)}
+  </div>
+}
+
+
+const CoreTagsChecklistComponent = registerComponent("CoreTagsChecklist", CoreTagsChecklist, {styles});
+
+declare global {
+  interface ComponentTypes {
+    CoreTagsChecklist: typeof CoreTagsChecklistComponent
+  }
+}
+

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -33,6 +33,15 @@ const schema = {
       }
     }
   },
+  core: {
+    label: "Core Tag (moderators check whether it applies when reviewing new posts)",
+    type: Boolean,
+    viewableBy: ['guests'],
+    insertableBy: ['admins', 'sunshineRegiment'],
+    editableBy: ['admins', 'sunshineRegiment'],
+    group: formGroups.advancedOptions,
+    ...schemaDefaultValue(false),
+  },
   postCount: {
     ...denormalizedCountOfReferences({
       fieldName: "postCount",

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -5,6 +5,7 @@ registerFragment(`
     _id
     name
     slug
+    core
     postCount
     deleted
     description {
@@ -19,6 +20,7 @@ registerFragment(`
     _id
     name
     slug
+    core
     postCount
     deleted
     description {

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -24,4 +24,18 @@ Tags.addView('tagBySlug', terms => {
   };
 });
 
+Tags.addView('coreTags', terms => {
+  return {
+    selector: {
+      core: true,
+    },
+    options: {
+      sort: {
+        name: 1
+      }
+    },
+  }
+});
+
 ensureIndex(Tags, {slug:1, deleted:1});
+ensureIndex(Tags, {core:1, deleted:1});

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -341,6 +341,7 @@ importComponent(["EmailHistory", "EmailHistoryPage"], () => require('../componen
 
 importComponent("AddTag", () => require('../components/tagging/AddTag'));
 importComponent("AddTagButton", () => require('../components/tagging/AddTagButton'));
+importComponent("CoreTagsChecklist", () => require('../components/tagging/CoreTagsChecklist'));
 importComponent("TagPage", () => require('../components/tagging/TagPage'));
 importComponent("TagPageTitle", () => require('../components/tagging/TagPageTitle'));
 importComponent("FooterTagList", () => require('../components/tagging/FooterTagList'));

--- a/packages/lesswrong/server/tagging/tagsGraphQL.ts
+++ b/packages/lesswrong/server/tagging/tagsGraphQL.ts
@@ -5,6 +5,44 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { performVoteServer } from '../voteServer';
 import { accessFilterSingle } from '../../lib/utils/schemaUtils';
 
+const addOrUpvoteTag = async ({tagId, postId, currentUser}: {
+  tagId: string,
+  postId: string,
+  currentUser: UsersCurrent,
+}): Promise<any> => {
+  // Validate that tagId and postId refer to valid non-deleted documents
+  // and that this user can see both.
+  const post = Posts.findOne({_id: postId});
+  const tag = Tags.findOne({_id: tagId});
+  if (!accessFilterSingle(currentUser, Posts, post))
+    throw new Error("Invalid postId");
+  if (!accessFilterSingle(currentUser, Tags, tag))
+    throw new Error("Invalid tagId");
+  
+  // Check whether this document already has this tag applied
+  const existingTagRel = TagRels.findOne({ tagId, postId });
+  if (!existingTagRel) {
+    const tagRel = await newMutation({
+      collection: TagRels,
+      document: { tagId, postId, userId: currentUser._id },
+      validate: false,
+      currentUser,
+    });
+    return tagRel.data;
+  } else {
+    // Upvote the tag
+    // TODO: Don't *remove* an upvote in this case
+    const votedTagRel = await performVoteServer({
+      document: existingTagRel,
+      voteType: 'smallUpvote',
+      collection: TagRels,
+      user: currentUser,
+      toggleIfAlreadyVoted: false,
+    });
+    return votedTagRel;
+  }
+}
+
 addGraphQLResolvers({
   Mutation: {
     addOrUpvoteTag: async (root, { tagId, postId }, { currentUser }) => {
@@ -12,38 +50,21 @@ addGraphQLResolvers({
       if (!postId) throw new Error("Missing argument: postId");
       if (!tagId) throw new Error("Missing argument: tagId");
       
-      // Validate that tagId and postId refer to valid non-deleted documents
-      // and that this user can see both.
-      const post = Posts.findOne({_id: postId});
-      const tag = Tags.findOne({_id: tagId});
-      if (!accessFilterSingle(currentUser, Posts, post))
-        throw new Error("Invalid postId");
-      if (!accessFilterSingle(currentUser, Tags, tag))
-        throw new Error("Invalid tagId");
+      return addOrUpvoteTag({tagId, postId, currentUser});
+    },
+    
+    applyCoreTags: async (root, {postId, tagIds}: {postId: string, tagIds: Array<string>}, {currentUser}) => {
+      if (!currentUser) throw new Error("You must be logged in to tag");
+      if (!postId) throw new Error("Missing argument: postId");
+      if (!tagIds) throw new Error("Missing argument: tagIds");
       
-      // Check whether this document already has this tag applied
-      const existingTagRel = TagRels.findOne({ tagId, postId });
-      if (!existingTagRel) {
-        const tagRel = await newMutation({
-          collection: TagRels,
-          document: { tagId, postId, userId: currentUser._id },
-          validate: false,
-          currentUser,
-        });
-        return tagRel.data;
-      } else {
-        // Upvote the tag
-        // TODO: Don't *remove* an upvote in this case
-        const votedTagRel = await performVoteServer({
-          document: existingTagRel,
-          voteType: 'smallUpvote',
-          collection: TagRels,
-          user: currentUser,
-          toggleIfAlreadyVoted: false,
-        });
-        return votedTagRel;
-      }
-    }
+      await Promise.all(tagIds.map(tagId =>
+        addOrUpvoteTag({ tagId, postId, currentUser })
+      ));
+      
+      return true;
+    },
   }
 });
 addGraphQLMutation('addOrUpvoteTag(tagId: String, postId: String): TagRel');
+addGraphQLMutation('applyCoreTags(postId: String, tagIds: [String]): Boolean');

--- a/packages/lesswrong/server/tagging/tagsGraphQL.ts
+++ b/packages/lesswrong/server/tagging/tagsGraphQL.ts
@@ -53,7 +53,7 @@ addGraphQLResolvers({
       return addOrUpvoteTag({tagId, postId, currentUser});
     },
     
-    applyCoreTags: async (root, {postId, tagIds}: {postId: string, tagIds: Array<string>}, {currentUser}) => {
+    addTags: async (root, {postId, tagIds}: {postId: string, tagIds: Array<string>}, {currentUser}) => {
       if (!currentUser) throw new Error("You must be logged in to tag");
       if (!postId) throw new Error("Missing argument: postId");
       if (!tagIds) throw new Error("Missing argument: tagIds");
@@ -67,4 +67,4 @@ addGraphQLResolvers({
   }
 });
 addGraphQLMutation('addOrUpvoteTag(tagId: String, postId: String): TagRel');
-addGraphQLMutation('applyCoreTags(postId: String, tagIds: [String]): Boolean');
+addGraphQLMutation('addTags(postId: String, tagIds: [String]): Boolean');


### PR DESCRIPTION
Adds a field "core" to tags, and modifies the Unreviewed Posts queue so that before you decide whether to frontpage a post or not, you go through a checklist of core tags.

A minor UI problem this has right now is the hover disappearing if the mouse strays outside the boundaries, which can happen while you're going through the checklist. A possible solution to this is to pin the hover open if you clock on the SunshineNewPostsItem or if you check off one of the tags.