### PR TITLE
Refactor Tag Page Sorting

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -52,7 +52,6 @@ const HomeLatestPosts = ({ classes }: {
   const { query } = location;
   const { SingleColumnSection, SectionTitle, PostsList2, LWTooltip, TagFilterSettings, SettingsIcon } = Components
   const limit = parseInt(query.limit) || 13
-  console.log("ASDF", filterSettings)
   const recentPostsTerms = {
     ...query,
     filterSettings: filterSettings,

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -52,7 +52,7 @@ const HomeLatestPosts = ({ classes }: {
   const { query } = location;
   const { SingleColumnSection, SectionTitle, PostsList2, LWTooltip, TagFilterSettings, SettingsIcon } = Components
   const limit = parseInt(query.limit) || 13
-
+  console.log("ASDF", filterSettings)
   const recentPostsTerms = {
     ...query,
     filterSettings: filterSettings,

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -64,7 +64,8 @@ const PostsList2 = ({
   tagId,
   classes,
   dense,
-  defaultToShowUnreadComments
+  defaultToShowUnreadComments,
+  itemsPerPage=50
 }: {
   children?: React.ReactNode,
   terms?: any,
@@ -82,6 +83,7 @@ const PostsList2 = ({
   classes: ClassesType,
   dense?: boolean,
   defaultToShowUnreadComments?: boolean,
+  itemsPerPage: number
 }) => {
   const [haveLoadedMore, setHaveLoadedMore] = useState(false);
   const { results, loading, error, count, totalCount, loadMore, limit } = useMulti({
@@ -91,6 +93,7 @@ const PostsList2 = ({
     enableTotal: enableTotal,
     fetchPolicy: 'cache-and-network',
     ssr: true,
+    itemsPerPage: itemsPerPage, 
     extraVariables: {
       tagId: "String"
     },

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -61,6 +61,7 @@ const PostsList2 = ({
   enableTotal=false,
   showNominationCount,
   showReviewCount,
+  tagId,
   classes,
   dense,
   defaultToShowUnreadComments
@@ -77,6 +78,7 @@ const PostsList2 = ({
   enableTotal?: boolean,
   showNominationCount?: boolean,
   showReviewCount?: boolean,
+  tagId?: string,
   classes: ClassesType,
   dense?: boolean,
   defaultToShowUnreadComments?: boolean,
@@ -85,10 +87,15 @@ const PostsList2 = ({
   const { results, loading, error, count, totalCount, loadMore, limit } = useMulti({
     terms: terms,
     collection: Posts,
-    fragmentName: 'PostsList',
+    fragmentName: !!tagId ? 'PostsListTag' : 'PostsList',
     enableTotal: enableTotal,
     fetchPolicy: 'cache-and-network',
-    ssr: true
+    ssr: true,
+    itemsPerPage: 50,
+    extraVariables: {
+      tagId: "String"
+    },
+    extraVariablesValues: { tagId }
   });
 
   let hidePosts: Array<boolean>|null = null;
@@ -149,7 +156,7 @@ const PostsList2 = ({
 
 
       {orderedResults && orderedResults.map((post, i) => {
-        const props = { post, index: i, terms, showNominationCount, showReviewCount, dense, defaultToShowUnreadComments, showPostedAt, showQuestionTag: terms.filter!=="questions" }
+        const props = { post, index: i, terms, showNominationCount, showReviewCount, dense, tagRel: post.tagRel, defaultToShowUnreadComments, showPostedAt, showQuestionTag: terms.filter!=="questions" }
 
         if (!(hidePosts && hidePosts[i])) return <PostsItem2 key={post._id} index={i} {...props} />
       })}

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -91,7 +91,6 @@ const PostsList2 = ({
     enableTotal: enableTotal,
     fetchPolicy: 'cache-and-network',
     ssr: true,
-    itemsPerPage: 50,
     extraVariables: {
       tagId: "String"
     },

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -38,13 +38,7 @@ const TagPage = ({classes}: {
     filterSettings: {tags:[{tagId: "tNsqhzTibgGJKPEWB", tagName: "Coronavirus", filterMode: "Required"}]},
     view: "tagRelevance",
     limit: 15,
-    itemsPerPage: 200,
-    extraVariables: {
-      tagId: 'String'
-    },
-    extraVariablesValues: {
-      tagId: tag._id
-    }
+    tagId: tag._id
   }
 
   return <AnalyticsContext pageContext='tagPage' tagContext={tag.name}>
@@ -63,6 +57,7 @@ const TagPage = ({classes}: {
         terms={terms} 
         enableTotal 
         tagId={tag._id}
+        itemsPerPage={200}
       />
     </SingleColumnSection>
   </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -31,10 +31,10 @@ const TagPage = ({classes}: {
     return <Loading/>
   if (!tag)
     return <Error404/>
-
+    
   const terms = {
     ...query,
-    filterSettings: {tags:[{tagId: "tNsqhzTibgGJKPEWB", tagName: "Coronavirus", filterMode: "Required"}]},
+    filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
     view: "tagRelevance",
     limit: 15,
     tagId: tag._id

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useMulti } from '../../lib/crud/withMulti';
 import { useLocation } from '../../lib/routeUtil';
-import { TagRels } from '../../lib/collections/tagRels/collection';
 import { useTagBySlug } from './useTag';
 import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -25,10 +23,9 @@ const styles = theme => ({
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { SingleColumnSection, SectionTitle, PostsList2, SectionButton, ContentItemBody, Loading, Error404, LoadMore } = Components;
+  const { SingleColumnSection, SectionTitle, PostsList2, SectionButton, ContentItemBody, Loading, Error404 } = Components;
   const currentUser = useCurrentUser();
-  const { query, params } = useLocation();
-  const { slug } = params;
+  const { query, params: { slug } } = useLocation();
   const { tag, loading: loadingTag } = useTagBySlug(slug);
 
   if (loadingTag)

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -7,7 +7,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser';
 import { postBodyStyles } from '../../themes/stylePiping'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
-import * as _ from 'underscore';
 
 const styles = theme => ({
   description: {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -132,6 +132,18 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment PostsListTag on Post {
+    ...PostsList
+    tagRel(tagId: $tagId) {
+      tagId
+      baseScore
+      afBaseScore
+      voteCount
+    }
+  }
+`)
+
+registerFragment(`
   fragment PostsDetails on Post {
     ...PostsBase
     ...PostsAuthors

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -503,18 +503,16 @@ const schema = {
     viewableBy: ['guests'],
     graphqlArguments: 'tagId: String',
     resolver: async (post, {tagId}, { Users, Posts, currentUser}) => {
-      const tagRel = await getWithLoader(TagRels,
+      const tagRels = await getWithLoader(TagRels,
         "tagRelByDocument",
         {
           tagId: tagId
         },
         'postId', post._id
       );
-      if (tagRel?.length) {
-        return tagRel[0]
+      if (tagRels?.length) {
+        return Users.restrictViewableFields(currentUser, TagRels, tagRels)[0]
       }
-      // return Users.restrictViewableFields(currentUser, TagRels, tagRel)
-      // if (tagRel) return tagRel
     }
   }),
   

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 import { PostRelations } from "../postRelations/collection"
+import { TagRels } from "../tagRels/collection";
 
 const formGroups = {
   // TODO - Figure out why properly moving this from custom_fields to schema was producing weird errors and then fix it
@@ -494,6 +495,18 @@ const schema = {
     }),
     canRead: ['guests'],
   },
+
+  // tagRelation
+  tagRel: resolverOnlyField({
+    type: "TagRel",
+    graphQLtype: "TagRel",
+    viewableBy: ['guests'],
+    graphqlArguments: 'tagId: String',
+    resolver: (post, {tagId}, context) => {
+      const tagRel = TagRels.findOne({tagId: tagId, postId: post._id})
+      if (tagRel) return tagRel
+    }
+  }),
   
   // Denormalized, with manual callbacks. Mapping from tag ID to baseScore, ie Record<string,number>.
   tagRelevance: {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -267,7 +267,6 @@ ensureIndex(Posts,
   }
 );
 
-
 Posts.addView("new", terms => ({
   options: {sort: setStickies(sortings.new, terms)}
 }))
@@ -314,6 +313,15 @@ ensureIndex(Posts,
     name: "posts.postedAt_baseScore",
   }
 );
+
+Posts.addView("tagRelevance", terms => {
+  const relevance = `tagRelevance.${terms.extraVariablesValues.tagId}`
+  return {
+    options: {
+      sort: { [relevance]: -1}
+    }
+  }
+})
 
 Posts.addView("frontpage", terms => ({
   selector: filters.frontpage,

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -314,14 +314,11 @@ ensureIndex(Posts,
   }
 );
 
-Posts.addView("tagRelevance", terms => {
-  const relevance = `tagRelevance.${terms.tagId}`
-  return {
-    options: {
-      sort: { [relevance]: -1}
-    }
+Posts.addView("tagRelevance", terms => ({
+  options: {
+    sort: { [`tagRelevance.${terms.tagId}`]: -1}
   }
-})
+}));
 
 Posts.addView("frontpage", terms => ({
   selector: filters.frontpage,

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -315,6 +315,7 @@ ensureIndex(Posts,
 );
 
 Posts.addView("tagRelevance", terms => ({
+  // note: this relies on the selector filtering done in the default view
   options: {
     sort: { [`tagRelevance.${terms.tagId}`]: -1}
   }

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -315,7 +315,7 @@ ensureIndex(Posts,
 );
 
 Posts.addView("tagRelevance", terms => {
-  const relevance = `tagRelevance.${terms.extraVariablesValues.tagId}`
+  const relevance = `tagRelevance.${terms.tagId}`
   return {
     options: {
       sort: { [relevance]: -1}

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -316,6 +316,21 @@ interface DbPostRelation extends DbObject {
   order: number
 }
 
+interface TagRelsCollection extends CollectionBase<DbTagRel> {
+}
+
+interface DbTagRel extends DbObject {
+  tagId: string
+  postId: string
+  deleted: boolean
+  userId: string
+  afBaseScore: number
+  voteCount: number
+  baseScore: number
+  score: number
+  inactive: boolean
+}
+
 interface PostsCollection extends CollectionBase<DbPost> {
 }
 
@@ -492,27 +507,13 @@ interface DbLocalgroup extends DbObject {
   contents: any /*{"definitions":[{"type":{"_constructorOptions":{"humanizeAutoLabels":true,"requiredByDefault":true},"_validators":[],"_docValidators":[],"_validationContexts":{},"_cleanOptions":{"filter":true,"autoConvert":true,"removeEmptyStrings":true,"trimStrings":true,"getAutoValues":true,"removeNullsFromArrays":false,"extendAutoValueContext":{}},"_schema":{"originalContents":{"optional":true,"type":{"definitions":[{"type":{"_constructorOptions":{"humanizeAutoLabels":true,"requiredByDefault":true},"_validators":[],"_docValidators":[],"_validationContexts":{},"_cleanOptions":{"filter":true,"autoConvert":true,"removeEmptyStrings":true,"trimStrings":true,"getAutoValues":true,"removeNullsFromArrays":false,"extendAutoValueContext":{}},"_schema":{"type":{"type":{"definitions":[{}]},"optional":false,"label":"Type"},"data":{"type":{"definitions":[{},{"blackbox":true}]},"optional":false,"label":"Data"}},"_depsLabels":{},"_schemaKeys":["type","data"],"_autoValues":[],"_blackboxKeys":["data"],"_firstLevelSchemaKeys":["type","data"],"_objectKeys":{},"messageBox":{"language":"en","messageList":{"en":{"required":"{{{label}}} is required","minString":"{{{label}}} must be at least {{min}} characters","maxString":"{{{label}}} cannot exceed {{max}} characters","minNumber":"{{{label}}} must be at least {{min}}","maxNumber":"{{{label}}} cannot exceed {{max}}","minNumberExclusive":"{{{label}}} must be greater than {{min}}","maxNumberExclusive":"{{{label}}} must be less than {{max}}","minDate":"{{{label}}} must be on or after {{min}}","maxDate":"{{{label}}} cannot be after {{max}}","badDate":"{{{label}}} is not a valid date","minCount":"You must specify at least {{minCount}} values","maxCount":"You cannot specify more than {{maxCount}} values","noDecimal":"{{{label}}} must be an integer","notAllowed":"{{{value}}} is not an allowed value","expectedType":"{{{label}}} must be of type {{dataType}}","keyNotInSchema":"{{name}} is not allowed by the schema"}},"interpolate":{},"escape":{}},"version":2}}]},"label":"Original contents"},"userId":{"optional":true,"type":{"definitions":[{}]},"label":"User ID"},"html":{"optional":true,"denormalized":true,"type":{"definitions":[{}]},"label":"Html"},"updateType":{"optional":true,"type":{"definitions":[{"allowedValues":["initial","patch","minor","major"]}]},"label":"Update type"},"version":{"optional":true,"type":{"definitions":[{}]},"label":"Version"},"editedAt":{"optional":true,"type":{"definitions":[{}]},"label":"Edited at"},"wordCount":{"optional":true,"denormalized":true,"type":{"definitions":[{"type":"SimpleSchema.Integer"}]},"label":"Word count"}},"_depsLabels":{},"_schemaKeys":["originalContents","userId","html","updateType","version","editedAt","wordCount"],"_autoValues":[],"_blackboxKeys":[],"_firstLevelSchemaKeys":["originalContents","userId","html","updateType","version","editedAt","wordCount"],"_objectKeys":{"originalContents.":["type","data"]},"messageBox":{"language":"en","messageList":{"en":{"required":"{{{label}}} is required","minString":"{{{label}}} must be at least {{min}} characters","maxString":"{{{label}}} cannot exceed {{max}} characters","minNumber":"{{{label}}} must be at least {{min}}","maxNumber":"{{{label}}} cannot exceed {{max}}","minNumberExclusive":"{{{label}}} must be greater than {{min}}","maxNumberExclusive":"{{{label}}} must be less than {{max}}","minDate":"{{{label}}} must be on or after {{min}}","maxDate":"{{{label}}} cannot be after {{max}}","badDate":"{{{label}}} is not a valid date","minCount":"You must specify at least {{minCount}} values","maxCount":"You cannot specify more than {{maxCount}} values","noDecimal":"{{{label}}} must be an integer","notAllowed":"{{{value}}} is not an allowed value","expectedType":"{{{label}}} must be of type {{dataType}}","keyNotInSchema":"{{name}} is not allowed by the schema"}},"interpolate":{},"escape":{}},"version":2}}]}*/
 }
 
-interface TagRelsCollection extends CollectionBase<DbTagRel> {
-}
-
-interface DbTagRel extends DbObject {
-  tagId: string
-  postId: string
-  deleted: boolean
-  userId: string
-  afBaseScore: number
-  voteCount: number
-  baseScore: number
-  score: number
-  inactive: boolean
-}
-
 interface TagsCollection extends CollectionBase<DbTag> {
 }
 
 interface DbTag extends DbObject {
   name: string
   slug: string
+  core: boolean
   postCount: number
   deleted: boolean
   description: any /*{"definitions":[{"type":{"_constructorOptions":{"humanizeAutoLabels":true,"requiredByDefault":true},"_validators":[],"_docValidators":[],"_validationContexts":{},"_cleanOptions":{"filter":true,"autoConvert":true,"removeEmptyStrings":true,"trimStrings":true,"getAutoValues":true,"removeNullsFromArrays":false,"extendAutoValueContext":{}},"_schema":{"originalContents":{"optional":true,"type":{"definitions":[{"type":{"_constructorOptions":{"humanizeAutoLabels":true,"requiredByDefault":true},"_validators":[],"_docValidators":[],"_validationContexts":{},"_cleanOptions":{"filter":true,"autoConvert":true,"removeEmptyStrings":true,"trimStrings":true,"getAutoValues":true,"removeNullsFromArrays":false,"extendAutoValueContext":{}},"_schema":{"type":{"type":{"definitions":[{}]},"optional":false,"label":"Type"},"data":{"type":{"definitions":[{},{"blackbox":true}]},"optional":false,"label":"Data"}},"_depsLabels":{},"_schemaKeys":["type","data"],"_autoValues":[],"_blackboxKeys":["data"],"_firstLevelSchemaKeys":["type","data"],"_objectKeys":{},"messageBox":{"language":"en","messageList":{"en":{"required":"{{{label}}} is required","minString":"{{{label}}} must be at least {{min}} characters","maxString":"{{{label}}} cannot exceed {{max}} characters","minNumber":"{{{label}}} must be at least {{min}}","maxNumber":"{{{label}}} cannot exceed {{max}}","minNumberExclusive":"{{{label}}} must be greater than {{min}}","maxNumberExclusive":"{{{label}}} must be less than {{max}}","minDate":"{{{label}}} must be on or after {{min}}","maxDate":"{{{label}}} cannot be after {{max}}","badDate":"{{{label}}} is not a valid date","minCount":"You must specify at least {{minCount}} values","maxCount":"You cannot specify more than {{maxCount}} values","noDecimal":"{{{label}}} must be an integer","notAllowed":"{{{value}}} is not an allowed value","expectedType":"{{{label}}} must be of type {{dataType}}","keyNotInSchema":"{{name}} is not allowed by the schema"}},"interpolate":{},"escape":{}},"version":2}}]},"label":"Original contents"},"userId":{"optional":true,"type":{"definitions":[{}]},"label":"User ID"},"html":{"optional":true,"denormalized":true,"type":{"definitions":[{}]},"label":"Html"},"updateType":{"optional":true,"type":{"definitions":[{"allowedValues":["initial","patch","minor","major"]}]},"label":"Update type"},"version":{"optional":true,"type":{"definitions":[{}]},"label":"Version"},"editedAt":{"optional":true,"type":{"definitions":[{}]},"label":"Edited at"},"wordCount":{"optional":true,"denormalized":true,"type":{"definitions":[{"type":"SimpleSchema.Integer"}]},"label":"Word count"}},"_depsLabels":{},"_schemaKeys":["originalContents","userId","html","updateType","version","editedAt","wordCount"],"_autoValues":[],"_blackboxKeys":[],"_firstLevelSchemaKeys":["originalContents","userId","html","updateType","version","editedAt","wordCount"],"_objectKeys":{"originalContents.":["type","data"]},"messageBox":{"language":"en","messageList":{"en":{"required":"{{{label}}} is required","minString":"{{{label}}} must be at least {{min}} characters","maxString":"{{{label}}} cannot exceed {{max}} characters","minNumber":"{{{label}}} must be at least {{min}}","maxNumber":"{{{label}}} cannot exceed {{max}}","minNumberExclusive":"{{{label}}} must be greater than {{min}}","maxNumberExclusive":"{{{label}}} must be less than {{max}}","minDate":"{{{label}}} must be on or after {{min}}","maxDate":"{{{label}}} cannot be after {{max}}","badDate":"{{{label}}} is not a valid date","minCount":"You must specify at least {{minCount}} values","maxCount":"You cannot specify more than {{maxCount}} values","noDecimal":"{{{label}}} must be an integer","notAllowed":"{{{value}}} is not an allowed value","expectedType":"{{{label}}} must be of type {{dataType}}","keyNotInSchema":"{{name}} is not allowed by the schema"}},"interpolate":{},"escape":{}},"version":2}}]}*/

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -138,6 +138,17 @@ interface PostsList_customHighlight { // fragment on Revisions
   readonly html: string,
 }
 
+interface PostsListTag extends PostsList { // fragment on Posts
+  readonly tagRel: PostsListTag_tagRel,
+}
+
+interface PostsListTag_tagRel { // fragment on TagRels
+  readonly tagId: string,
+  readonly baseScore: number,
+  readonly afBaseScore: number,
+  readonly voteCount: number,
+}
+
 interface PostsDetails extends PostsBase, PostsAuthors { // fragment on Posts
   readonly commentSortOrder: string,
   readonly collectionTitle: string,
@@ -508,6 +519,14 @@ interface PostRelationsDefaultFragment { // fragment on PostRelations
   readonly sourcePostId: string,
   readonly targetPostId: string,
   readonly order: number,
+}
+
+interface TagRelsDefaultFragment { // fragment on TagRels
+  readonly tagId: string,
+  readonly postId: string,
+  readonly deleted: boolean,
+  readonly userId: string,
+  readonly afBaseScore: number,
 }
 
 interface PostsDefaultFragment { // fragment on Posts
@@ -1297,14 +1316,6 @@ interface SuggestAlignmentUser extends UsersMinimumInfo { // fragment on Users
   readonly afSubmittedApplication: boolean,
 }
 
-interface TagRelsDefaultFragment { // fragment on TagRels
-  readonly tagId: string,
-  readonly postId: string,
-  readonly deleted: boolean,
-  readonly userId: string,
-  readonly afBaseScore: number,
-}
-
 interface TagRelFragment { // fragment on TagRels
   readonly _id: string,
   readonly baseScore: number,
@@ -1379,6 +1390,7 @@ interface WithVoteTagRel_currentUserVotes { // fragment on Votes
 interface TagsDefaultFragment { // fragment on Tags
   readonly name: string,
   readonly slug: string,
+  readonly core: boolean,
   readonly postCount: number,
   readonly deleted: boolean,
 }
@@ -1387,6 +1399,7 @@ interface TagFragment { // fragment on Tags
   readonly _id: string,
   readonly name: string,
   readonly slug: string,
+  readonly core: boolean,
   readonly postCount: number,
   readonly deleted: boolean,
   readonly description: TagFragment_description,
@@ -1401,6 +1414,7 @@ interface TagEditFragment { // fragment on Tags
   readonly _id: string,
   readonly name: string,
   readonly slug: string,
+  readonly core: boolean,
   readonly postCount: number,
   readonly deleted: boolean,
   readonly description: RevisionEdit,
@@ -1504,6 +1518,7 @@ interface FragmentTypes {
   PostsBase: PostsBase
   PostsAuthors: PostsAuthors
   PostsList: PostsList
+  PostsListTag: PostsListTag
   PostsDetails: PostsDetails
   PostsRevision: PostsRevision
   PostsRevisionEdit: PostsRevisionEdit
@@ -1533,6 +1548,7 @@ interface FragmentTypes {
   BansAdminPageFragment: BansAdminPageFragment
   SequencesDefaultFragment: SequencesDefaultFragment
   PostRelationsDefaultFragment: PostRelationsDefaultFragment
+  TagRelsDefaultFragment: TagRelsDefaultFragment
   PostsDefaultFragment: PostsDefaultFragment
   ChaptersDefaultFragment: ChaptersDefaultFragment
   BooksDefaultFragment: BooksDefaultFragment
@@ -1589,7 +1605,6 @@ interface FragmentTypes {
   CollectionsEditFragment: CollectionsEditFragment
   SuggestAlignmentPost: SuggestAlignmentPost
   SuggestAlignmentUser: SuggestAlignmentUser
-  TagRelsDefaultFragment: TagRelsDefaultFragment
   TagRelFragment: TagRelFragment
   TagRelMinimumFragment: TagRelMinimumFragment
   WithVoteTagRel: WithVoteTagRel
@@ -1605,5 +1620,5 @@ interface FragmentTypes {
   SuggestAlignmentComment: SuggestAlignmentComment
 }
 
-type CollectionNameString = "Users"|"Votes"|"Notifications"|"Conversations"|"Messages"|"RSSFeeds"|"Reports"|"LWEvents"|"DatabaseMetadata"|"Migrations"|"DebouncerEvents"|"ReadStatuses"|"Bans"|"Sequences"|"PostRelations"|"Posts"|"Chapters"|"Books"|"Collections"|"ReviewVotes"|"Localgroups"|"TagRels"|"Tags"|"Subscriptions"|"Revisions"|"Comments"|"LegacyData"|"EmailTokens"
+type CollectionNameString = "Users"|"Votes"|"Notifications"|"Conversations"|"Messages"|"RSSFeeds"|"Reports"|"LWEvents"|"DatabaseMetadata"|"Migrations"|"DebouncerEvents"|"ReadStatuses"|"Bans"|"Sequences"|"PostRelations"|"TagRels"|"Posts"|"Chapters"|"Books"|"Collections"|"ReviewVotes"|"Localgroups"|"Tags"|"Subscriptions"|"Revisions"|"Comments"|"LegacyData"|"EmailTokens"
 

--- a/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
+++ b/packages/lesswrong/lib/vulcan-lib/fragmentTypes.json
@@ -6,10 +6,10 @@
         "name": "Voteable",
         "possibleTypes": [
           {
-            "name": "Post"
+            "name": "TagRel"
           },
           {
-            "name": "TagRel"
+            "name": "Post"
           },
           {
             "name": "Comment"


### PR DESCRIPTION
This reworks the TagPage to use the new tagRelevance field to fetch and sort post-items, rather than doing client-side sorting.

This is in preparation for some further work that lets you sort the page in different ways.

Note: I'm not sure how to properly index this.