### PR TITLE
Tag Sorting + Bugfix

### DIFF
--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -86,6 +86,13 @@ const PostsList2 = ({
   itemsPerPage: number
 }) => {
   const [haveLoadedMore, setHaveLoadedMore] = useState(false);
+
+  const tagVariables = tagId ? {
+    extraVariables: {
+      tagId: "String"
+    },
+    extraVariablesValues: { tagId }
+  } : {}
   const { results, loading, error, count, totalCount, loadMore, limit } = useMulti({
     terms: terms,
     collection: Posts,
@@ -94,10 +101,7 @@ const PostsList2 = ({
     fetchPolicy: 'cache-and-network',
     ssr: true,
     itemsPerPage: itemsPerPage, 
-    extraVariables: {
-      tagId: "String"
-    },
-    extraVariablesValues: { tagId }
+    ...tagVariables
   });
 
   let hidePosts: Array<boolean>|null = null;

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -32,14 +32,16 @@ const TagPage = ({classes}: {
   if (!tag)
     return <Error404/>
     
-  const terms = {
+  const sortSettings = query?.sortedBy ? { sortedBy: query.sortedBy } : {view: "tagRelevance"}
+
+  let terms = {
     ...query,
     filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
-    view: "tagRelevance",
     limit: 15,
-    tagId: tag._id
+    tagId: tag._id,
+    ...sortSettings
   }
-
+  
   return <AnalyticsContext pageContext='tagPage' tagContext={tag.name}>
     <SingleColumnSection>
       <SectionTitle title={`${tag.name} Tag`}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -32,12 +32,12 @@ const TagPage = ({classes}: {
   if (!tag)
     return <Error404/>
     
-  let terms = {
+  const terms = {
     ...query,
     filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
+    view: "tagRelevance",
     limit: 15,
     tagId: tag._id,
-    view: "tagRelevance"
   }
   
   return <AnalyticsContext pageContext='tagPage' tagContext={tag.name}>

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -32,14 +32,12 @@ const TagPage = ({classes}: {
   if (!tag)
     return <Error404/>
     
-  const sortSettings = query?.sortedBy ? { sortedBy: query.sortedBy } : {view: "tagRelevance"}
-
   let terms = {
     ...query,
     filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
     limit: 15,
     tagId: tag._id,
-    ...sortSettings
+    view: "tagRelevance"
   }
   
   return <AnalyticsContext pageContext='tagPage' tagContext={tag.name}>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -316,8 +316,9 @@ ensureIndex(Posts,
 
 Posts.addView("tagRelevance", terms => ({
   // note: this relies on the selector filtering done in the default view
+  // sorts by the "sortedBy" parameter if it's been passed in, or otherwise sorts by tag relevance
   options: {
-    sort: { [`tagRelevance.${terms.tagId}`]: -1}
+    sort: terms.sortedBy ? sortings[terms.sortBy] : { [`tagRelevance.${terms.tagId}`]: -1}
   }
 }));
 


### PR DESCRIPTION
The tag page was (apparently) already able to filter itself when passing in the "filter=questions" parameter, but wasn't able to change the sort-order because the tagRelevance view overrode the sortedBy parameter. This allows the sortedBy parameter to instead override the tagRelevance sorting. 

(I'm not quite sure if this should be handled in the tagRelevance view, or instead in the TagPage component)

Meanwhile, also fixing a bug wherein some PostsLists failed to load properly when not passed in a tagId