### PR TITLE
permalinked comments are always expanded

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -48,7 +48,7 @@ const CommentPermalink = ({ documentId, post, classes }: {
   return <div className={classes.root}>
       <div className={classes.permalinkLabel}>Comment Permalink</div>
       {loading ? <Loading /> : <div>
-        <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} showTitle={false}/>
+        <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
       </div>}
       {getSetting('forumType') !== 'EAForum' && <div className={classes.dividerMargins}><Divider /></div>}

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -20,7 +20,8 @@ interface ExternalProps {
   comment: CommentWithRepliesFragment,
   post: PostsBase,
   refetch: any,
-  showTitle?: boolean
+  showTitle?: boolean,
+  expandByDefault?: boolean
 }
 interface CommentWithRepliesProps extends ExternalProps, WithUserProps, WithStylesProps {
   recordPostView: any,
@@ -40,7 +41,7 @@ class CommentWithReplies extends PureComponent<CommentWithRepliesProps,CommentWi
   }
 
   render () {
-    const { classes, comment, refetch, post, showTitle=true } = this.props
+    const { classes, comment, refetch, post, showTitle=true, expandByDefault } = this.props
     const { CommentsNode } = Components
     const { markedAsVisitedAt, maxChildren } = this.state
 
@@ -81,6 +82,7 @@ class CommentWithReplies extends PureComponent<CommentWithRepliesProps,CommentWi
           condensed
           shortform
           refetch={refetch}
+          expandByDefault={expandByDefault}
           showExtraChildrenButton={showExtraChildrenButton}
         />
       </div>

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -123,6 +123,7 @@ type ExternalProps = ({
   nestingLevel?: number,
   highlightDate?: Date,
   expandAllThreads?:boolean,
+  expandByDefault?: boolean, // this determines whether this specific comment is expanded, without passing that expanded state to child comments
   muiTheme?: any,
   child?: any,
   showPostTitle?: boolean,
@@ -309,7 +310,7 @@ class CommentsNode extends Component<CommentsNodeProps,CommentsNodeState> {
       comment, children, nestingLevel=1, highlightDate, post,
       muiTheme, postPage=false, classes, child, showPostTitle, unreadComments,
       parentAnswerId, condensed, markAsRead, lastCommentId,
-      loadChildrenSeparately, shortform, refetch, parentCommentId, showExtraChildrenButton, noHash, scrollOnExpand, hoverPreview, hideSingleLineMeta, enableHoverPreview, hideReply
+      loadChildrenSeparately, shortform, refetch, parentCommentId, showExtraChildrenButton, noHash, scrollOnExpand, hoverPreview, hideSingleLineMeta, enableHoverPreview, hideReply, expandByDefault
     } = this.props;
 
     const { SingleLineComment, CommentsItem, RepliesToCommentList, AnalyticsTracker } = Components
@@ -381,7 +382,7 @@ class CommentsNode extends Component<CommentsNodeProps,CommentsNodeState> {
                     </AnalyticsTracker>
                   </AnalyticsContext>
                 : <CommentsItem
-                    truncated={this.isTruncated()}
+                    truncated={this.isTruncated() && !expandByDefault} // expandByDefault checked separately here, so isTruncated can also be passed to child nodes
                     nestingLevel={updatedNestingLevel}
                     parentCommentId={parentCommentId}
                     parentAnswerId={parentAnswerId || (comment.answer && comment._id) || undefined}


### PR DESCRIPTION
Robby had asked if linked to a specific comment could result in that comment always being expanded. This PR makes it so.