### PR TITLE
Improve post meta description by omitting links

### DIFF
--- a/packages/lesswrong/server/resolvers/revisionResolvers.ts
+++ b/packages/lesswrong/server/resolvers/revisionResolvers.ts
@@ -99,7 +99,7 @@ addFieldsDict(Revisions, {
         if (!html) return
         const truncatedHtml = truncate(sanitize(html), PLAINTEXT_HTML_TRUNCATION_LENGTH)
         return htmlToText
-          .fromString(truncatedHtml)
+          .fromString(truncatedHtml, {ignoreHref: true, ignoreImage: true})
           .substring(0, PLAINTEXT_DESCRIPTION_LENGTH)
       }
     }


### PR DESCRIPTION
See https://github.com/LessWrong2/Lesswrong2/issues/889
Note: I have not tested this

This changes improves the experience of sharing links to posts on platforms that scrape descriptions (e.g. Discord).


