### PR TITLE
Untagged filtering

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -46,6 +46,12 @@ const filters: Record<string,any> = {
   "meta": {
     meta: true
   },
+  "untagged": {
+    tagRelevance: null
+  },
+  "tagged": {
+    tagRelevance: {$exists: true}
+  },
   "includeMetaAndPersonal": {},
 }
 if (getSetting('forumType') === 'EAForum') filters.frontpage.meta = {$ne: true}

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -43,14 +43,14 @@ const filters: Record<string,any> = {
   "events": {
     isEvent: true
   },
-  "meta": {
+  "meta": { 
     meta: true
   },
   "untagged": {
-    tagRelevance: null
+    tagRelevance: {}
   },
   "tagged": {
-    tagRelevance: {$exists: true}
+    tagRelevance: {$ne: {}}
   },
   "includeMetaAndPersonal": {},
 }


### PR DESCRIPTION
simple filter we can put on the /allPosts page to look for untagged or tagged posts, so that we can work our way through the top 100-by-karma untagged posts and see what sort of tags they warrant.