### PR TITLE
Fix moderation guidelines crash

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -98,6 +98,7 @@ const ModerationGuidelinesBox = ({classes, post, recordEvent}: {
     documentId: post?._id,
     collection: Posts,
     fetchPolicy: "cache-first",
+    fragmentName: "PostsList",
   });
   
   if (!post)

--- a/packages/lesswrong/components/form-components/SequencesListEditorItem.tsx
+++ b/packages/lesswrong/components/form-components/SequencesListEditorItem.tsx
@@ -57,12 +57,6 @@ const SequencesListEditorItem = ({documentId, classes, ...props}) => {
           <div className="sequences-list-edit-item-author">
             {(document.user && document.user.displayName) || "Undefined Author"}
           </div>
-          <div className="sequences-list-edit-item-karma">
-            {document.karma || "undefined"} points
-          </div>
-          <div className="sequences-list-edit-item-comments">
-            {document.commentCount || "?"} comments
-          </div>
           <div className={classes.remove}>
             <RemoveIcon className={classes.removeIcon} onClick={() => props.removeItem(documentId)} />
           </div>

--- a/packages/lesswrong/components/posts/PostsPage/PostsRevisionsList.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsRevisionsList.tsx
@@ -32,10 +32,10 @@ const PostsRevisionsList = ({documentId, classes}: {
   const MenuItemUntyped = MenuItem as any;
   
   return <React.Fragment>
-    {revisions.map(({editedAt, version, user}) => 
-    <MenuItemUntyped key={version} component={QueryLink} query={{revision: version}} merge>
-      <span className={classes.version}>v{version}</span> <FormatDate date={editedAt}/>
-    </MenuItemUntyped>)}
+    {revisions.map(({editedAt, version}) =>
+      <MenuItemUntyped key={version} component={QueryLink} query={{revision: version}} merge>
+        <span className={classes.version}>v{version}</span> <FormatDate date={editedAt}/>
+      </MenuItemUntyped>)}
   </React.Fragment>
 }
 

--- a/packages/lesswrong/lib/crud/withSingle.ts
+++ b/packages/lesswrong/lib/crud/withSingle.ts
@@ -96,7 +96,7 @@ export function withSingle({
   });
 }
 
-export function useSingle({
+export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
   collectionName, collection,
   fragmentName, fragment,
   extraVariables,
@@ -109,7 +109,7 @@ export function useSingle({
 }: {
   collectionName?: CollectionNameString,
   collection?: any,
-  fragmentName?: string,
+  fragmentName?: FragmentTypeName,
   fragment?: any,
   extraVariables?: Record<string,any>,
   fetchPolicy?: WatchQueryFetchPolicy,
@@ -118,7 +118,15 @@ export function useSingle({
   documentId: string,
   extraVariablesValues?: any,
   skip?: boolean,
-}) {
+}): {
+  document: FragmentTypes[FragmentTypeName]
+  loading: boolean,
+  error?: any,
+  refetch: any,
+  data: {
+    refetch: any,
+  },
+} {
   const query = getGraphQLQueryFromOptions({ extraVariables, extraQueries, collectionName, collection, fragment, fragmentName })
   const resolverName = getResolverNameFromOptions({ collectionName, collection })
   const { data, ...rest } = useQuery(query, {


### PR DESCRIPTION
Fixes a crash in `ModerationGuidelinesBox`, caused by a missing `fragmentName` argument on a new `useSingle` call. The bug was introduced in https://github.com/LessWrong2/Lesswrong2/pull/3028 when I made `ModerationGuidelinesBox` re-load its post with a different fragment, to fix type errors and to fix a bug where the moderation guidelines fail to appear when commenting some non-post-page contexts.

Also added type annotations to `useSingle` to prevent this class of bug, and fixed a few minor things exposed by those type annotations.