### PR TITLE
Add better local storage ids for sequences and books

### DIFF
--- a/packages/lesswrong/lib/collections/books/collection.ts
+++ b/packages/lesswrong/lib/collections/books/collection.ts
@@ -14,7 +14,7 @@ export const Books: BooksCollection = createCollection({
 export const makeEditableOptions = {
   order: 20,
   getLocalStorageId: (book, name) => {
-    if (book._id) { return {id: `${book._id}_${name}`, verify: false} }
+    if (book._id) { return {id: `${book._id}_${name}`, verify: true} }
     return {id: `collection: ${book.collectionId}_${name}`, verify: false}
   },
 }

--- a/packages/lesswrong/lib/collections/books/collection.ts
+++ b/packages/lesswrong/lib/collections/books/collection.ts
@@ -12,7 +12,11 @@ export const Books: BooksCollection = createCollection({
 });
 
 export const makeEditableOptions = {
-  order: 20
+  order: 20,
+  getLocalStorageId: (book, name) => {
+    if (book._id) { return {id: `${book._id}_${name}`, verify: false} }
+    return {id: `collection: ${book.collectionId}_${name}`, verify: false}
+  },
 }
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/chapters/collection.ts
+++ b/packages/lesswrong/lib/collections/chapters/collection.ts
@@ -35,6 +35,10 @@ export const Chapters: ChaptersCollection = createCollection({
 
 export const makeEditableOptions = {
   order: 30,
+  getLocalStorageId: (chapter, name) => {
+    if (chapter._id) { return {id: `${chapter._id}_${name}`, verify: true} }
+    return {id: `sequence: ${chapter.sequenceId}_${name}`, verify: false}
+  },
 }
 
 makeEditable({


### PR DESCRIPTION
Fixes the annoying bug where every time you go to any sequences page, admins get notifications to restore some random local storage state