### PR TITLE
Fix modal autofocus

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -38,6 +38,7 @@ const ModerationGuidelinesEditForm = ({ postId, onClose, classes }) => {
     <Dialog
       open={true}
       onClose={onClose}
+      disableEnforceFocus
     >
       <DialogTitle>
         Moderation Guidelines Edit Form

--- a/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
@@ -74,6 +74,7 @@ const GroupFormDialog =  ({ onClose, classes, documentId }) => {
   return <Dialog
     open={true}
     onClose={onClose}
+    disableEnforceFocus
   >
     <DialogContent className="local-group-form">
       <WrappedSmartForm

--- a/packages/lesswrong/components/questions/NewQuestionDialog.tsx
+++ b/packages/lesswrong/components/questions/NewQuestionDialog.tsx
@@ -41,6 +41,7 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
       maxWidth={false}
       onClose={onClose}
       fullScreen={fullScreen}
+      disableEnforceFocus
     >
       <DialogContent>
         <Components.WrappedSmartForm

--- a/packages/lesswrong/components/shortform/NewShortformDialog.tsx
+++ b/packages/lesswrong/components/shortform/NewShortformDialog.tsx
@@ -12,6 +12,7 @@ const NewShortformDialog = ({onClose}) => {
     <Dialog open={true}
       onClose={onClose}
       fullWidth maxWidth="sm"
+      disableEnforceFocus
     >
       <DialogContent>
         <ShortformSubmitForm

--- a/packages/lesswrong/components/tagging/EditTagsDialog.tsx
+++ b/packages/lesswrong/components/tagging/EditTagsDialog.tsx
@@ -9,7 +9,7 @@ const EditTagsDialog = ({post, onClose }: {
   onClose: ()=>void
 }) => {
   const { FooterTagList } = Components
-  return <Dialog open={true} onClose={onClose} fullWidth maxWidth="sm">
+  return <Dialog open={true} onClose={onClose} fullWidth maxWidth="sm" disableEnforceFocus>
     <DialogTitle>{post.title}</DialogTitle>
     <DialogContent>
       <FooterTagList post={post}/> 


### PR DESCRIPTION
For the Edit Tags modal and the New Question modal, by default the modal was enforcing an auto-focus on the modal which was preventing some other features from working.

I'm not sure what purpose the autofocus is supposed to be serving, it's possible this should just be disabled all-around by default (currently modals default to 'steal focus')