### PR TITLE
Better R:AZ starting point

### DIFF
--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -238,7 +238,7 @@ const getDefaultResumeSequence = () => {
     {
       // R:A-Z
       collectionId: "oneQyj4pw77ynzwAF",
-      nextPostId: "uXn3LyA8eNqpvdoZw",
+      nextPostId: "2ftJ38y9SRBCBsCzy",
     },
   ]
 }


### PR DESCRIPTION
Replaces [this PR](https://github.com/LessWrong2/Lesswrong2/pull/2972) which was accidentally based on a branch that has been on hold for awhile. Changes the R:A-Z starting post to Scope Insensitivity (the first non-preface post).

(Going forward, I think this is something we should be A/B testing hard. But in the mean time, this seems like a decent substitution.)