### PR TITLE
Fix crash with some personal blogpost filter settings

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -149,7 +149,7 @@ function filterSettingsToParams(filterSettings: FilterSettings): any {
   const tagsExcluded = _.filter(filterSettings.tags, t=>t.filterMode==="Hidden");
   
   let frontpageFilter: any;
-  let frontpageSoftFilter: any = null;
+  let frontpageSoftFilter: Array<any> = [];
   if (filterSettings.personalBlog === "Hidden") {
     frontpageFilter = {frontpageDate: {$gt: new Date(0)}}
   } else if (filterSettings.personalBlog === "Required") {


### PR DESCRIPTION
Bug introduced by me, because I assumed that because `...` spreading is null-safe in objects, that it would also be null-safe in arrays. It isn't.