### PR TITLE
Fix a timezone-related issue where the Latest Posts list would sometimes blank and then reload after page load

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -6,11 +6,10 @@ import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { useTimezone } from './withTimezone';
-import qs from 'qs'
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 import { defaultFilterSettings, filterSettingsToString } from '../../lib/filterSettings';
-import moment from 'moment';
+import moment from '../../lib/moment-timezone';
 
 const styles = theme => ({
   personalBlogpostsCheckbox: {

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -5,6 +5,7 @@ import { useCurrentUser } from '../common/withUser';
 import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useLocation, useNavigation } from '../../lib/routeUtil';
+import { useTimezone } from './withTimezone';
 import qs from 'qs'
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
@@ -49,11 +50,13 @@ const HomeLatestPosts = ({ classes }: {
 
   const [filterSettings, setFilterSettings] = useFilterSettings(currentUser);
   const [filterSettingsVisible, setFilterSettingsVisible] = useState(false);
+  const { timezone } = useTimezone();
 
   const { query } = location;
   const { SingleColumnSection, SectionTitle, PostsList2, LWTooltip, TagFilterSettings, SettingsIcon } = Components
   const limit = parseInt(query.limit) || 13
-  const dateCutoff = moment().subtract(90, 'days').format("YYYY-MM-DD");
+  const now = moment().tz(timezone);
+  const dateCutoff = now.subtract(90, 'days').format("YYYY-MM-DD");
 
   const recentPostsTerms = {
     ...query,


### PR DESCRIPTION
`HomeLatestPosts` computes a 3-month date cutoff, rounded to the nearest day. Unfortunately the rounding depended on time zone, so if the client and server time zones are different, the client would start with an Apollo store with a query with a slightly-different query in it, and respond to this by putting the Latest Posts list into a loading state while it reran the query.

I tested this fix using Chrome client-side timezone emulation, which was added to Chrome in October 2019 and is hidden in the Sensors tab (if you pick a fake geolocation, it will also add a fake time zone to match).

Bug was introduced by me along with soft filters.