### PR TITLE
Fix links in bookmarks being broken

### DIFF
--- a/packages/lesswrong/components/posts/BookmarksList.tsx
+++ b/packages/lesswrong/components/posts/BookmarksList.tsx
@@ -17,7 +17,7 @@ const BookmarksList = ({limit=50 }) => {
   });
 
   let bookmarkedPosts = user?.bookmarkedPosts || []
-  bookmarkedPosts = bookmarkedPosts.reverse().slice(0, limit)
+  bookmarkedPosts = [...bookmarkedPosts].reverse().slice(0, limit)
 
   if (loading) return <Loading/>
 


### PR DESCRIPTION
The Javascript core library function `Array.reverse` is tricky: it returns a reversed array, but also reverses the array in-place. This is horrible, and if you use it on an array you got from Apollo, subtle bad things will happen because the array order reverses on each rerender. This caused bookmarks in the front-page bookmarks widget to link to the wrong bookmark (the first entry linking to the last bookmarked post and vise versa, etc).

Introduced in https://github.com/LessWrong2/Lesswrong2/pull/2779 .