### PR TITLE
circle after tagPreview

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -149,18 +149,21 @@ const PostLinkPreviewVariantCheck = ({ href, innerHTML, post, targetLocation, co
 }
 const PostLinkPreviewVariantCheckComponent = registerComponent('PostLinkPreviewVariantCheck', PostLinkPreviewVariantCheck);
 
+export const linkStyle = theme => ({
+  position: "relative",
+  marginRight: 6,
+  '&:after': {
+    content: '"°"',
+    marginLeft: 1,
+    marginRight: 1,
+    color: theme.palette.primary.main,
+    position: "absolute"
+  }
+})
 
 const styles = theme => ({
   link: {
-    position: "relative",
-    marginRight: 6,
-    '&:after': {
-      content: '"°"',
-      marginLeft: 1,
-      marginRight: 1,
-      color: theme.palette.primary.main,
-      position: "absolute"
-    }
+    ...linkStyle(theme)
   }
 })
 

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -3,8 +3,12 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useHover } from '../common/withHover';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useTagBySlug } from './useTag';
+import { linkStyle } from '../linkPreview/PostLinkPreview';
 
 const styles = theme => ({
+  link: {
+    ...linkStyle(theme)
+  },
   card: {
     paddingLeft: 16,
     paddingRight: 16,
@@ -32,7 +36,7 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes}: {
           : <Loading/>}
       </div>
     </PopperCard>
-    <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} />
+    <Link className={classes.link} to={href} dangerouslySetInnerHTML={{__html: innerHTML}} />
   </span>;
 }
 


### PR DESCRIPTION
Straightforwardly copies the existing hover-link styles