### PR TITLE
hide ui elements on shortform

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -33,7 +33,7 @@ const PostsItemMeta = ({post, read, classes}: {
   const { MetaInfo, FormatDate, PostsStats, PostsUserAndCoauthors, LWTooltip } = Components;
   return <span className={classNames({[classes.read]:read})}>
 
-      <MetaInfo>
+      {!post.shortform && <MetaInfo>
         <LWTooltip title={<div>
           This post has { baseScore || 0 } karma<br/>
           ({ post.voteCount} votes)
@@ -42,7 +42,7 @@ const PostsItemMeta = ({post, read, classes}: {
             { baseScore || 0 }
           </span>
         </LWTooltip>
-      </MetaInfo>
+      </MetaInfo>}
 
       { post.isEvent && <MetaInfo>
         {post.startTime

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -360,14 +360,14 @@ class PostsPage extends Component<PostsPageProps> {
                         </span>
                       </div>
                     </div>
-                    <div className={classes.headerVote}>
+                    {!post.shortform && <div className={classes.headerVote}>
                       <PostsVote
                         collection={Posts}
                         post={post}
                         />
-                    </div>
+                    </div>}
                   </div>
-                  <hr className={classes.divider}/>
+                  {!post.shortform && <hr className={classes.divider}/>}
                   {post.isEvent && <PostsPageEventData post={post}/>}
                 </div>
               </div></AnalyticsContext>
@@ -397,15 +397,15 @@ class PostsPage extends Component<PostsPageProps> {
                         { html && <ContentItemBody dangerouslySetInnerHTML={{__html: htmlWithAnchors}} description={`post ${post._id}`}/> }
                       </AnalyticsContext>
                     </div>
-                    <AnalyticsContext pageSectionContext="tagFooter">
+                    {!post.shortform && <AnalyticsContext pageSectionContext="tagFooter">
                       <FooterTagList post={post}/>
-                    </AnalyticsContext>
+                    </AnalyticsContext>}
                   </div>
                 </div>
 
                 {/* Footer */}
 
-                {(wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
+                {!post.shortform && (wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
                   <div className={classes.footerSection}>
                     <div className={classes.voteBottom}>
                       <PostsVote


### PR DESCRIPTION
ESRogs mentioned 'tagging on shortform should be hidden if it's not being used'. Meanwhile, we'd also discussed hiding karma on shortform. This PR cleans up shortform post pages a bit, as well as shortform Recent Discussion threads.

![image](https://user-images.githubusercontent.com/3246710/80660613-15b65680-8a41-11ea-8205-e7921edc3e07.png)

I also removed the horizontal bar, because it didn't seem right for what a shortform page should be. (The following screenshot only has an "asdfasdf" text body because there's apparently also a bug right now preventing me from editing posts bodies to become empty. The idea is supposed to be that it's basically just the post title, for most people and most shortforms)

![image](https://user-images.githubusercontent.com/3246710/80660886-ddfbde80-8a41-11ea-8999-43711327107d.png)
