### PR TITLE
change breakpoint for recent discussion indent

### DIFF
--- a/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
@@ -66,12 +66,12 @@ const styles = theme => ({
     opacity: 0,
   },
   content :{
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginLeft: theme.spacing.unit*3,
     }
   },
   commentsList: {
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('sm')]: {
       marginLeft: 0,
       marginRight: 0
     }


### PR DESCRIPTION
Recent discussion's breakpoint for removing the left-indent triggered too early. Changed it to md instead of lg