### PR TITLE
Attempt to prevent duplicate google tag managers

### DIFF
--- a/packages/lesswrong/client/ga.ts
+++ b/packages/lesswrong/client/ga.ts
@@ -6,13 +6,21 @@ function googleTagManagerInit() {
   const googleTagManagerId = getSetting('googleTagManager.apiKey')
   if (googleTagManagerId) {
     (function (w, d, s, l, i) {
-    w[l] = w[l] || []; w[l].push({
-      'gtm.start':
-        new Date().getTime(), event: 'gtm.js'
-    }); var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; 
-      (j as any).async = true; 
-      (j as any).src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;         
+      w[l] = w[l] || [];
+      if (w[l]?.[0]?.['gtm.start']) {
+        //eslint-disable-next-line no-console
+        console.warn('googleTagManagerInit has already run, aborting')
+        return
+      }
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0]
+      var j = d.createElement(s)
+      var dl = l != 'dataLayer' ? '&l=' + l : '';
+      (j as any).async = true;
+      (j as any).src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
       (f as any).parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', googleTagManagerId)
   }
@@ -37,4 +45,3 @@ const identifyLogRocketCallback = (currentUser) => {
 }
 
 addIdentifyFunction(identifyLogRocketCallback)
-


### PR DESCRIPTION
While I'm not sure this will fix the problem, if you have a problem with two google tag managers, preventing your gtmInit function from making duplicates seems like a good start.