### PR TITLE
Add link preview for metaculus question links

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -80,6 +80,9 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }: {
       if (linkTargetAbsolute.host === "hubs.mozilla.com") {
         return <Components.MozillaHubPreview href={href} innerHTML={innerHTML} id={id} />
       }
+      if (linkTargetAbsolute.host === "metaculus.com" || linkTargetAbsolute.host === "www.metaculus.com") {
+        return <Components.MetaculusPreview href={href} innerHTML={innerHTML} id={id} />
+      }
       return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} />
     }
     return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -304,7 +304,7 @@ const DefaultPreview = ({classes, href, innerHTML, onsite=false, id}: {
       <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start" onMouseEnter={stopHover}>
         <Card>
           <div className={classes.hovercard}>
-            {href}
+            {decodeURIComponent(href)}
           </div>
         </Card>
       </LWPopper>
@@ -386,8 +386,7 @@ const MozillaHubPreview = ({classes, href, innerHTML, id}: {
   });
   
   const data = rawData?.MozillaHubsRoomData
-  const { AnalyticsTracker } = Components
-  const { LWPopper } = Components
+  const { AnalyticsTracker, LWPopper } = Components
   const { anchorEl, hover, eventHandlers } = useHover();
   if (loading || !data) return <a href={href}>
     <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
@@ -426,6 +425,54 @@ const MozillaHubPreviewComponent = registerComponent('MozillaHubPreview', Mozill
   styles: mozillaHubStyles
 })
 
+const metaculusStyles = (theme) => ({
+  background: {
+    backgroundColor: "#2c3947"
+  },
+  iframeStyling: {
+    width: 400,
+    height: 250, 
+    border: "none",
+    maxWidth: "100vw"
+  },
+  link: {
+    ...linkStyle(theme)
+  }
+})
+
+const MetaculusPreview = ({classes, href, innerHTML, id}: {
+  classes: ClassesType,
+  href: string,
+  innerHTML: string,
+  id?: string,
+}) => {
+  const { AnalyticsTracker, LWPopper } = Components
+  const { anchorEl, hover, eventHandlers } = useHover();
+  const [match, www, questionNumber] = href.match(/^http(?:s?):\/\/(www\.)?metaculus\.com\/questions\/([a-zA-Z0-9]{1,6})?/)
+
+  if (!questionNumber) {
+    return <a href={href}>
+      <span dangerouslySetInnerHTML={{__html: innerHTML}}/>
+    </a>  
+  }
+
+  return <AnalyticsTracker eventType="link" eventProps={{to: href}}>
+    <span {...eventHandlers}>
+      <a className={classes.link} href={href} id={id} dangerouslySetInnerHTML={{__html: innerHTML}} />
+      
+      <LWPopper open={hover} anchorEl={anchorEl} placement="bottom-start">
+        <div className={classes.background}>
+          <iframe className={classes.iframeStyling} src={`https://d3s0w6fek99l5b.cloudfront.net/s/1/questions/embed/${questionNumber}/?plot=pdf`} />
+        </div>
+      </LWPopper>
+    </span>
+  </AnalyticsTracker>
+}
+
+const MetaculusPreviewComponent = registerComponent('MetaculusPreview', MetaculusPreview, {
+  styles: metaculusStyles
+})
+
 declare global {
   interface ComponentTypes {
     PostLinkPreview: typeof PostLinkPreviewComponent,
@@ -439,6 +486,7 @@ declare global {
     PostLinkPreviewWithPost: typeof PostLinkPreviewWithPostComponent,
     CommentLinkPreviewWithComment: typeof CommentLinkPreviewWithCommentComponent,
     MozillaHubPreview: typeof MozillaHubPreviewComponent,
+    MetaculusPreview: typeof MetaculusPreviewComponent,
     DefaultPreview: typeof DefaultPreviewComponent,
   }
 }

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -103,7 +103,7 @@ importComponent("SubscribeWidget", () => require('../components/common/Subscribe
 importComponent("SubscribeDialog", () => require('../components/common/SubscribeDialog'));
 
 importComponent("HoverPreviewLink", () => require('../components/linkPreview/HoverPreviewLink'));
-importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview"], () => require('../components/linkPreview/PostLinkPreview'));
+importComponent(["PostLinkPreview", "PostLinkCommentPreview", "PostLinkPreviewSequencePost", "PostLinkPreviewSlug", "PostLinkPreviewLegacy", "CommentLinkPreviewLegacy", "PostLinkPreviewWithPost", "PostCommentLinkPreviewGreaterWrong", "DefaultPreview", "MozillaHubPreview", "MetaculusPreview"], () => require('../components/linkPreview/PostLinkPreview'));
 
 importComponent("AccountsVerifyEmail", () => require('../components/users/AccountsVerifyEmail'));
 importComponent("AccountsEnrollAccount", () => require('../components/users/EnrollAccount'));


### PR DESCRIPTION
First (and easiest) part of adding metaculus embeds to LW, which is to simply have an iframe that displays on hover.

Biggest uncertainty I have about the PR is whether we should use the small circle in the link or not. I think it's helpful to communicate that it has a fancy preview, but it also seems a bit bad because it has so far only communicated "onsite link". 

Maybe the ideal thing would be to have a very small metaculus logo, but that seems kind of hard to style, and looked bad when I tried it for 2 minutes. 