### PR TITLE
Replace covid-checkbox with archives-checkbox

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -98,19 +98,19 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
     </div>} */}
 
     {/* disabled during 2018 Review [and coronavirus]*/}
-    {/* {(configName === "frontpage") && <div> 
+    {(configName === "frontpage") && <div> 
       <Checkbox
         checked={!settings.hideFrontpage}
         onChange={(ev, checked) => applyChange({ ...settings, hideFrontpage: !checked })}
       /> Show 'From the Archives' recommendations
-    </div>} */}
+    </div>}
 
-    <div> 
+    {/* <div> 
       <Checkbox
         checked={!settings.hideCoronavirus}
         onChange={(ev, checked) => applyChange({ ...settings, hideCoronavirus: !checked })}
       /> Show 'Coronavirus' recommendations
-    </div>
+    </div> */}
 
     <div>
       <Checkbox

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -129,9 +129,9 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
 
     return <SingleColumnSection className={classes.section}>
       <SectionTitle title="Recommendations">
-        <LWTooltip title="Customize your recommendations">
+        {currentUser && <LWTooltip title="Customize your recommendations">
           <SettingsIcon onClick={this.toggleSettings} label="Settings"/>
-        </LWTooltip>
+        </LWTooltip>}
       </SectionTitle>
       {showSettings &&
         <RecommendationsAlgorithmPicker


### PR DESCRIPTION
This...

a) replaces the "Coronavirus Frontpage checkbox" with a "From the archives" checkbox. 
b) removes the "settings" option for logged out users, because some settings only applies after you were logged in, and generally it was more confusing than helpful.