### PR TITLE
Partial Recommendations Rework

### DIFF
--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -2,10 +2,7 @@ import React, { Component } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { withTracking } from "../../lib/analyticsEvents";
 
-interface ExternalProps {
-  view: string,
-}
-interface SubscribeWidgetProps extends ExternalProps, WithTrackingProps {
+interface SubscribeWidgetProps extends WithTrackingProps {
 }
 interface SubscribeWidgetState {
   dialogOpen: boolean,
@@ -14,7 +11,7 @@ interface SubscribeWidgetState {
 class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetState> {
   state: SubscribeWidgetState = {
     dialogOpen: false,
-    method: "curated",
+    method: "",
   }
 
   openDialog(method: string) {
@@ -24,7 +21,6 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
 
   render() {
     const { TabNavigationSubItem, SubscribeDialog } = Components;
-    const { view } = this.props;
     const { dialogOpen, method } = this.state;
 
     return (
@@ -35,7 +31,7 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
         { dialogOpen && <SubscribeDialog
           open={true}
           onClose={ () => this.setState({ dialogOpen: false })}
-          view={view}
+          view={"curated"}
           method={method} /> }
       </div>
     )

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import Hidden from '@material-ui/core/Hidden';
 import { withTracking } from "../../lib/analyticsEvents";
 
 interface ExternalProps {

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -38,7 +38,7 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
   }
 }
 
-const SubscribeWidgetComponent = registerComponent<ExternalProps>("SubscribeWidget", SubscribeWidget, {
+const SubscribeWidgetComponent = registerComponent("SubscribeWidget", SubscribeWidget, {
   hocs: [withTracking]
 });
 

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -30,10 +30,7 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
     return (
       <React.Fragment>
         <div onClick={() => this.openDialog("rss")}>
-          <TabNavigationSubItem>Subscribe (RSS)</TabNavigationSubItem>
-        </div>
-        <div onClick={ () => this.openDialog("email")}>
-          <TabNavigationSubItem>Subscribe (Email)</TabNavigationSubItem>
+          <TabNavigationSubItem>Subscribe (RSS/Email)</TabNavigationSubItem>
         </div>
         { dialogOpen && <SubscribeDialog
           open={true}

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -14,7 +14,7 @@ interface SubscribeWidgetState {
 class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetState> {
   state: SubscribeWidgetState = {
     dialogOpen: false,
-    method: "",
+    method: "curated",
   }
 
   openDialog(method: string) {
@@ -28,16 +28,16 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
     const { dialogOpen, method } = this.state;
 
     return (
-      <React.Fragment>
-        <div onClick={() => this.openDialog("rss")}>
+      <div>
+        <a onClick={() => this.openDialog("rss")}>
           <TabNavigationSubItem>Subscribe (RSS/Email)</TabNavigationSubItem>
-        </div>
+        </a>
         { dialogOpen && <SubscribeDialog
           open={true}
           onClose={ () => this.setState({ dialogOpen: false })}
           view={view}
           method={method} /> }
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/packages/lesswrong/components/common/SubscribeWidget.tsx
+++ b/packages/lesswrong/components/common/SubscribeWidget.tsx
@@ -24,26 +24,19 @@ class SubscribeWidget extends Component<SubscribeWidgetProps,SubscribeWidgetStat
   }
 
   render() {
-    const { SeparatorBullet } = Components;
+    const { TabNavigationSubItem, SubscribeDialog } = Components;
     const { view } = this.props;
     const { dialogOpen, method } = this.state;
 
     return (
       <React.Fragment>
-        <a onClick={ () => this.openDialog("rss") }>
-          { /* On very small screens, use shorter link text ("Subscribe (RSS)"
-               instead of "Subscribe via RSS") to avoid wrapping */ }
-          <Hidden smUp implementation="css">Subscribe (RSS)</Hidden>
-          <Hidden xsDown implementation="css">Subscribe via RSS</Hidden>
-          {/* todo: change back to "via RSS" */}
-        </a>
-        <SeparatorBullet />
-        <a onClick={ () => this.openDialog("email") }>
-          <Hidden smUp implementation="css">Subscribe (Email)</Hidden> 
-          <Hidden xsDown implementation="css">Subscribe via Email</Hidden> 
-          {/* todo: change back to "via Email" */}
-        </a>
-        { dialogOpen && <Components.SubscribeDialog
+        <div onClick={() => this.openDialog("rss")}>
+          <TabNavigationSubItem>Subscribe (RSS)</TabNavigationSubItem>
+        </div>
+        <div onClick={ () => this.openDialog("email")}>
+          <TabNavigationSubItem>Subscribe (Email)</TabNavigationSubItem>
+        </div>
+        { dialogOpen && <SubscribeDialog
           open={true}
           onClose={ () => this.setState({ dialogOpen: false })}
           view={view}

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -11,12 +11,10 @@ const styles = (theme) => ({
     paddingBottom: theme.spacing.unit,
     // padding reflects how large an icon+padding is
     paddingLeft: (theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2)),
-    paddingRight: theme.spacing.unit*2,
     color: theme.palette.grey[600],
     width: 
       TAB_NAVIGATION_MENU_WIDTH - // base width
-      ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft
-      ( theme.spacing.unit*2), //paddingRight
+      ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))), // paddingLeft,
     fontSize: "1rem",
     whiteSpace: "nowrap",
     textOverflow: "ellipsis",

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -136,6 +136,9 @@ export default {
       divider: true,
       showOnCompressed: true,
     }, {
+      id: 'subscribeWidget',
+      customComponent: Components.SubscribeWidget,
+    }, {
       id: 'about',
       title: 'About',
       link: '/about',
@@ -157,9 +160,6 @@ export default {
       title: 'Tags',
       link: '/tags',
       subItem: true,
-    }, {
-      id: 'eventsList',
-      customComponent: Components.SubscribeWidget,
     }
   ],
   AlignmentForum: [

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -78,6 +78,19 @@ export default {
       showOnMobileStandalone: true,
       showOnCompressed: true,
     }, {
+      id: 'questions',
+      title: 'Open Questions',
+      mobileTitle: 'Questions',
+      link: '/questions',
+      icon: questionsGlobeIcon,
+      tooltip: <div>
+        <div>• Ask simple newbie questions.</div>
+        <div>• Collaborate on open research questions.</div>
+        <div>• Pose and resolve confusions.</div>
+      </div>,
+      showOnMobileStandalone: true,
+      showOnCompressed: true,
+    }, {
       id: 'library',
       title: 'Library',
       link: '/library',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -78,19 +78,6 @@ export default {
       showOnMobileStandalone: true,
       showOnCompressed: true,
     }, {
-      id: 'questions',
-      title: 'Open Questions',
-      mobileTitle: 'Questions',
-      link: '/questions',
-      icon: questionsGlobeIcon,
-      tooltip: <div>
-        <div>• Ask simple newbie questions.</div>
-        <div>• Collaborate on open research questions.</div>
-        <div>• Pose and resolve confusions.</div>
-      </div>,
-      showOnMobileStandalone: true,
-      showOnCompressed: true,
-    }, {
       id: 'library',
       title: 'Library',
       link: '/library',
@@ -170,6 +157,9 @@ export default {
       title: 'Tags',
       link: '/tags',
       subItem: true,
+    }, {
+      id: 'eventsList',
+      customComponent: Components.SubscribeWidget,
     }
   ],
   AlignmentForum: [

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { registerComponent, Components, getSetting } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
+import Posts from '../../lib/collections/posts/collection';
 import StarIcon from '@material-ui/icons/Star';
 import PersonIcon from '@material-ui/icons/Person';
 import DetailsIcon from '@material-ui/icons/Details';
 import GroupIcon from '@material-ui/icons/Group';
 import LinkIcon from '@material-ui/icons/Link';
+import { curatedUrl } from '../recommendations/RecommendationsAndCurated';
+import { Link } from '../../lib/reactRouterWrapper';
 
-const MetaTitle = getSetting('forumType') === 'EAForum' ? 'Community Post' : 'Meta Post'
+// ea-forum-look-here (JP I think you really just gotta move away from your re-use of meta now)
 const MetaIcon = getSetting('forumType') === 'EAForum' ? GroupIcon : DetailsIcon
 
 const styles = theme => ({
@@ -60,20 +63,20 @@ const PostsItemIcons = ({post, classes}: {
 
   return <span className={classes.iconSet}>
     {post.curatedDate && <span className={classes.postIcon}>
-      <LWTooltip title="Curated Post" placement="right">
-        <StarIcon className={classes.icon}/>
+      <LWTooltip title={<div>Curated <div><em>(click to view all curated posts)</em></div></div>} placement="right">
+        <Link to={curatedUrl}><StarIcon className={classes.icon}/></Link>
       </LWTooltip>
     </span>}
     
     {post.question && <span className={classes.postIcon}>
-      <LWTooltip title="Question Post" placement="right">
-        <span className={classes.question}>Q</span>
+      <LWTooltip title={<div>Question <div><em>(click to view all questions)</em></div></div>} placement="right">
+        <Link to={"/questions"}><span className={classes.question}>Q</span></Link>
       </LWTooltip>
     </span>}
 
     {post.url && <span className={classes.postIcon}>
-      <LWTooltip title="Link Post" placement="right">
-        <LinkIcon className={classes.linkIcon}/>
+      <LWTooltip title={<div>Link Post <div><em>(Click to see linked content)</em></div></div>} placement="right">
+        <a href={post.url}><LinkIcon className={classes.linkIcon}/></a>
       </LWTooltip>
     </span>}
 
@@ -84,15 +87,15 @@ const PostsItemIcons = ({post, classes}: {
     </span>}
 
     {post.meta && <span className={classes.postIcon}>
-      <LWTooltip title={MetaTitle} placement="right">
-        <MetaIcon className={classes.icon}/>
+      <LWTooltip title={<div>Meta <div><em>(Click to view all meta content)</em></div></div>} placement="right">
+        <Link to={"/tag/site-meta"}><MetaIcon className={classes.icon}/></Link>
       </LWTooltip>
     </span>}
 
     {getSetting('forumType') !== 'AlignmentForum' && post.af &&
       <span className={classes.postIcon}>
-        <LWTooltip title="Crossposted from AlignmentForum.org" placement="right">
-          <span><OmegaIcon className={classNames(classes.icon, classes.alignmentIcon)}/></span>
+        <LWTooltip title={<div>Crossposted from AlignmentForum.org<div><em>(Click to visit AF version)</em></div></div>} placement="right">
+          <a href={`https://alignmentforum.org/${Posts.getPageUrl(post)}`}><OmegaIcon className={classNames(classes.icon, classes.alignmentIcon)}/></a>
         </LWTooltip>
       </span>
     }

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -95,7 +95,7 @@ const PostsItemIcons = ({post, classes}: {
     {getSetting('forumType') !== 'AlignmentForum' && post.af &&
       <span className={classes.postIcon}>
         <LWTooltip title={<div>Crossposted from AlignmentForum.org<div><em>(Click to visit AF version)</em></div></div>} placement="right">
-          <a href={`https://alignmentforum.org/${Posts.getPageUrl(post)}`}><OmegaIcon className={classNames(classes.icon, classes.alignmentIcon)}/></a>
+            <a href={`https://alignmentforum.org${Posts.getPageUrl(post)}`}><OmegaIcon className={classNames(classes.icon, classes.alignmentIcon)}/></a>
         </LWTooltip>
       </span>
     }

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -93,15 +93,7 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
 
   const url = postLink || Posts.getPageUrl(post)
 
-  const title = <span className={classNames(
-      classes.root,
-      {
-        [classes.read]: read,
-        [classes.wrap]: wrap,
-        [classes.adminUnread]: !read && userHasBoldPostItems(currentUser),
-        [classes.adminRead]: read && userHasBoldPostItems(currentUser),
-      }
-    )}>
+  const title = <span>
     {post.unlisted && <span className={classes.tag}>[Unlisted]</span>}
 
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}
@@ -113,23 +105,20 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
     <span>{post.title}</span>
   </span>
 
-  if (isLink) {
-    return <span>
-          <Link to={url}>
-            {title}
-          </Link>
-          {showIcons && <span className={classes.hideSmDown}>
-            <PostsItemIcons post={post}/>
-          </span>}
-      </span>
-  } else {
-    return <span>
-      {title}
+  return (
+    <span className={classNames(classes.root, {
+      [classes.read]: read,
+      [classes.wrap]: wrap,
+      [classes.adminUnread]: !read && userHasBoldPostItems(currentUser),
+      [classes.adminRead]: read && userHasBoldPostItems(currentUser),
+    })}>
+      {isLink ? <Link to={url}>{title}</Link> : title }
       {showIcons && <span className={classes.hideSmDown}>
         <PostsItemIcons post={post}/>
       </span>}
     </span>
-  }
+  )
+
 }
 
 const PostsTitleComponent = registerComponent('PostsTitle', PostsTitle, {styles});

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -115,18 +115,24 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
     {post.isEvent && shouldRenderEventsTag && <span className={classes.tag}>[Event]</span>}
 
     <span>{post.title}</span>
-
-    {showIcons && <span className={classes.hideSmDown}>
-      <PostsItemIcons post={post}/>
-    </span>}
   </span>
 
   if (isLink) {
-    return <Link to={url}>
-      {title}
-    </Link>
+    return <span>
+          <Link to={url}>
+            {title}
+          </Link>
+          {showIcons && <span className={classes.hideSmDown}>
+            <PostsItemIcons post={post}/>
+          </span>}
+      </span>
   } else {
-    return <span>{title}</span>
+    return <span>
+      {title}
+      {showIcons && <span className={classes.hideSmDown}>
+        <PostsItemIcons post={post}/>
+      </span>}
+    </span>
   }
 }
 

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -108,10 +108,6 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
 
     {shared && <span className={classes.tag}>[Shared]</span>}
 
-    {/* {post.question && shouldRenderQuestionTag && <span className={classes.question}>Q</span>} */}
-
-    {/* {post.url && showLinkTag && <span className={classes.tag}>[Link]</span>} */}
-
     {post.isEvent && shouldRenderEventsTag && <span className={classes.tag}>[Event]</span>}
 
     <span>{post.title}</span>

--- a/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
+++ b/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
@@ -73,9 +73,6 @@ class ContinueReadingList extends Component<ContinueReadingListProps,ContinueRea
       return <PostsLoading/>
     
     const { entries, showAllLink } = this.limitResumeReading(continueReading);
-    const saveLeftOffTooltip = <div>
-      Logging in helps you keep track of which sequences you've started reading, so that you can continue reading them when you return to LessWrong.
-    </div>
 
     return <div>
       <AnalyticsContext listContext={"continueReading"} capturePostItemOnMount>
@@ -91,15 +88,11 @@ class ContinueReadingList extends Component<ContinueReadingListProps,ContinueRea
         })}
       </AnalyticsContext>
       
-      
-      <SectionFooter>
-        {showAllLink && <a onClick={this.showAll}>
+      {showAllLink && <SectionFooter>
+        <a onClick={this.showAll}>
           Show All
-        </a>}
-        <LoginPopupButton title={saveLeftOffTooltip}>
-          Log in to save where you left off
-        </LoginPopupButton>
-      </SectionFooter>
+        </a>
+      </SectionFooter>}
     </div>
   }
 }

--- a/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
+++ b/packages/lesswrong/components/recommendations/ContinueReadingList.tsx
@@ -68,7 +68,7 @@ class ContinueReadingList extends Component<ContinueReadingListProps,ContinueRea
   
   render() {
     const { continueReading, continueReadingLoading } = this.props;
-    const { PostsItem2, PostsLoading, SectionFooter, LoginPopupButton } = Components;
+    const { PostsItem2, PostsLoading, SectionFooter } = Components;
     if (continueReadingLoading || !continueReading)
       return <PostsLoading/>
     

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -11,6 +11,8 @@ import Typography from '@material-ui/core/Typography';
 import Hidden from '@material-ui/core/Hidden';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 
+export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
+
 const styles = theme => ({
   section: {
     marginTop: -12,
@@ -84,7 +86,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
   render() {
     const { continueReading, classes, currentUser, configName } = this.props;
     const { showSettings } = this.state
-    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, RecommendationsList, SubscribeWidget, SectionTitle, SectionSubtitle, SeparatorBullet, BookmarksList, LWTooltip } = Components;
+    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, RecommendationsList, SubscribeWidget, SectionTitle, SectionSubtitle, SectionFooter, BookmarksList, LWTooltip } = Components;
 
     const settings = getRecommendationSettings({settings: this.state.settings, currentUser, configName})
 
@@ -124,8 +126,6 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
 
     const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
     const renderContinueReading = (continueReading?.length > 0) && !settings.hideContinueReading
-    const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
-
 
     return <SingleColumnSection className={classes.section}>
       <SectionTitle title="Recommendations">
@@ -202,18 +202,6 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
           <AnalyticsContext listContext={"curatedPosts"}>
             <PostsList2 terms={{view:"curated", limit:3}} showLoadMore={false} hideLastUnread={true}/>
           </AnalyticsContext>
-          <div className={classes.footerWrapper}>
-            <Typography component="div" variant="body2" className={classNames(classes.footer, {[classes.loggedOutFooter]:!currentUser})}>
-              <Link to={curatedUrl}>
-                { /* On very small screens, use shorter link text ("More Curated"
-                    instead of "View All Curated Posts") to avoid wrapping */ }
-                <Hidden smUp implementation="css">More Curated</Hidden>
-                <Hidden xsDown implementation="css">View All Curated Posts</Hidden>
-              </Link>
-              <SeparatorBullet />
-              <SubscribeWidget view={"curated"} />
-            </Typography>
-          </div>
         </div>
       </AnalyticsContext>
     </SingleColumnSection>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -7,8 +7,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 import { withContinueReading } from './withContinueReading';
-import Typography from '@material-ui/core/Typography';
-import Hidden from '@material-ui/core/Hidden';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 
 export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
@@ -86,7 +84,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
   render() {
     const { continueReading, classes, currentUser, configName } = this.props;
     const { showSettings } = this.state
-    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, RecommendationsList, SubscribeWidget, SectionTitle, SectionSubtitle, SectionFooter, BookmarksList, LWTooltip } = Components;
+    const { RecommendationsAlgorithmPicker, SingleColumnSection, SettingsIcon, ContinueReadingList, PostsList2, RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip } = Components;
 
     const settings = getRecommendationSettings({settings: this.state.settings, currentUser, configName})
 

--- a/packages/lesswrong/server/migrations/2019-04-10-confirmLegacyEmails.ts
+++ b/packages/lesswrong/server/migrations/2019-04-10-confirmLegacyEmails.ts
@@ -34,7 +34,7 @@ registerMigration({
           // If the email address matches legacyData.emailAddress, set its verified flag to legacyData.email_validated.
           const legacyData = user.legacyData;
           for (let i=0; i<user.emails.length; i++) {
-            if (legacyData && legacyData.email
+            if (legacyData.email
               && user.emails && user.emails[i].address === legacyData.email)
             {
               const shouldBeVerified = legacyData.email_validated;


### PR DESCRIPTION
This removes some buttons from the Recommendations section:

1. The "Login" button under Core Reading is just gone
2. The "View All Curated" button is replaced by the "Curated Icon" on posts being a link (as well as most such post-item-icons being links)
3. The Subscribe buttons are moved over to the Nav Bar

This also removes the Open Questions Nav Item, which wasn't really pulling it's weight (currently you can get to the /questions page via clicking on the Question icon on PostItems)

![image](https://user-images.githubusercontent.com/3246710/81236875-0be9a180-8fb3-11ea-8bf1-280631e22d86.png)

