### PR TITLE
Show number of tagged posts on tag hover-preview

### DIFF
--- a/packages/lesswrong/components/posts/PostsListPlaceholder.tsx
+++ b/packages/lesswrong/components/posts/PostsListPlaceholder.tsx
@@ -12,8 +12,7 @@ const PostsListPlaceholder = ({count, classes}: {
     placeholders.push(
       <div key={i} className={classNames(
         classes.root,
-        classes.background,
-        {[classes.bottomBorder]: i !== count-1}
+        classes.background
       )}>
         <div className={classes.postsItem}>
           <span className={classes.title}>

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -168,7 +168,7 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
           {description}
         </div>}
       </div>
-      <TagPreview tag={tag}/>
+      <TagPreview tag={tag} showCount={false}/>
     </PopperCard>
   </span>
 }

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -8,7 +8,7 @@ import * as _ from 'underscore';
 const styles = theme => ({
   root: {
     marginLeft: "auto",
-    marginBottom: 16,
+    marginBottom: 6,
     ...theme.typography.commentStyle,
     display: "flex",
     flexWrap: "wrap"

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -39,8 +39,9 @@ const styles = theme => ({
     ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
     color: theme.palette.primary.main,
-    marginTop: 8,
-    marginBottom: 6
+    marginTop: 6,
+    marginBottom: 2,
+    marginRight: 6
   }
 });
 

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -47,9 +47,10 @@ const styles = theme => ({
 
 const previewPostCount = 3;
 
-const TagPreview = ({tag, classes}: {
+const TagPreview = ({tag, classes, showCount=true}: {
   tag: TagPreviewFragment,
   classes: ClassesType,
+  showCount?: boolean
 }) => {
   const { ContentItemBody, PostsItem2, PostsListPlaceholder } = Components;
   const { results } = useMulti({
@@ -76,11 +77,11 @@ const TagPreview = ({tag, classes}: {
     }
     {!results && <PostsListPlaceholder count={previewPostCount} />}
     {results && results.map((result,i) =>
-      <PostsItem2 key={result.post._id} post={result.post} index={i}/>
+      <PostsItem2 key={result.post._id} post={result.post} index={i} showBottomBorder={showCount && i!=2}/>
     )}
-    <div className={classes.footerCount}>
+    {showCount && <div className={classes.footerCount}>
       <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>
-    </div>
+    </div>}
   </div>)
 }
 

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
+import { Tags } from '../../lib/collections/tags/collection';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { truncate } from '../../lib/editor/ellipsize';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = theme => ({
   card: {
@@ -31,6 +33,14 @@ const styles = theme => ({
   score: {
     marginLeft: 4,
     marginRight: 4,
+  },
+  footerCount: {
+    textAlign: "right",
+    ...theme.typography.smallFont,
+    ...theme.typography.commentStyle,
+    color: theme.palette.primary.main,
+    marginTop: 8,
+    marginBottom: 6
   }
 });
 
@@ -65,8 +75,11 @@ const TagPreview = ({tag, classes}: {
     }
     {!results && <PostsListPlaceholder count={previewPostCount} />}
     {results && results.map((result,i) =>
-      <PostsItem2 key={result.post._id} post={result.post} index={i} showBottomBorder={i!=2}/>
+      <PostsItem2 key={result.post._id} post={result.post} index={i}/>
     )}
+    <div className={classes.footerCount}>
+      <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>
+    </div>
   </div>)
 }
 

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -93,7 +93,7 @@ const schema = {
 interface ExtendedTagsCollection extends TagsCollection {
   // From search/utils.ts
   toAlgolia: (tag: DbTag) => Array<Record<string,any>>|null
-  getUrl: (tag: DbTag) => string
+  getUrl: (tag: TagPreviewFragment) => string
 }
 
 export const Tags: ExtendedTagsCollection = createCollection({

--- a/packages/lesswrong/lib/collections/tags/helpers.ts
+++ b/packages/lesswrong/lib/collections/tags/helpers.ts
@@ -1,5 +1,5 @@
 import Tag from './collection';
 
-Tag.getUrl = (tag) => {
+Tag.getUrl = (tag: TagPreviewFragment) => {
   return `/tag/${tag.slug}`
 }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -802,7 +802,6 @@ interface UsersCurrent extends UsersMinimumInfo { // fragment on Users
   readonly bookmarkedPostsMetadata: Array<any /*{"definitions":[{}]}*/>,
   readonly noExpandUnreadCommentsReview: boolean,
   readonly reviewVotesQuadratic: boolean,
-  readonly signUpReCaptchaRating: number,
 }
 
 interface UserBookmarks { // fragment on Users


### PR DESCRIPTION
note: this is having some kind of fragment/type issue that I didn't quite grok, could use help with.

```

packages/lesswrong/components/tagging/TagPreview.tsx:82:29 - error TS2345: Argument of type 'TagPreviewFragment' is not assignable to parameter of type 'DbTag'.
  Property 'schemaVersion' is missing in type 'TagPreviewFragment' but required in type 'DbTag'.

82       <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>
```

![image](https://user-images.githubusercontent.com/3246710/81627961-3329df80-93b4-11ea-8961-1aadc784ec92.png)
