### PR TITLE
Additions to tagging analytics

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -83,17 +83,17 @@ const HomeLatestPosts = () => {
           </SectionTitle>
           <AnalyticsContext pageSectionContext="tagFilterSettings">
               {filterSettingsVisible && <TagFilterSettings
-              filterSettings={filterSettings} setFilterSettings={(newSettings) => {
-                setFilterSettings(newSettings)
-                if (currentUser) {
-                  updateUser({
-                    selector: { _id: currentUser._id},
-                    data: {
-                      frontpageFilterSettings: newSettings
-                    },
-                  })
-                }
-              }}
+                filterSettings={filterSettings} setFilterSettings={(newSettings) => {
+                  setFilterSettings(newSettings)
+                  if (currentUser) {
+                    updateUser({
+                      selector: { _id: currentUser._id},
+                      data: {
+                        frontpageFilterSettings: newSettings
+                      },
+                    })
+                  }
+                }}
             />}
           </AnalyticsContext>
           <AnalyticsContext listContext={"latestPosts"}>

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -80,19 +80,21 @@ const HomeLatestPosts = () => {
                 label={"Filter: "+filterSettingsToString(filterSettings)}/>
             </LWTooltip>
           </SectionTitle>
-          {filterSettingsVisible && <TagFilterSettings
-            filterSettings={filterSettings} setFilterSettings={(newSettings) => {
-              setFilterSettings(newSettings)
-              if (currentUser) {
-                updateUser({
-                  selector: { _id: currentUser._id},
-                  data: {
-                    frontpageFilterSettings: newSettings
-                  },
-                })
-              }
-            }}
-          />}
+          <AnalyticsContext pageSectionContext="tagFilterSettings">
+              {filterSettingsVisible && <TagFilterSettings
+              filterSettings={filterSettings} setFilterSettings={(newSettings) => {
+                setFilterSettings(newSettings)
+                if (currentUser) {
+                  updateUser({
+                    selector: { _id: currentUser._id},
+                    data: {
+                      frontpageFilterSettings: newSettings
+                    },
+                  })
+                }
+              }}
+            />}
+          </AnalyticsContext>
           <AnalyticsContext listContext={"latestPosts"}>
             <PostsList2 terms={recentPostsTerms}>
               <Link to={"/allPosts"}>Advanced Sorting/Filtering</Link>

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -32,6 +32,7 @@ const HomeLatestPosts = () => {
   const [filterSettings, setFilterSettings] = useFilterSettings(currentUser);
   const [filterSettingsVisible, setFilterSettingsVisible] = useState(false);
   const { timezone } = useTimezone();
+  useTracking({eventType:"frontpageFilterSettings", eventProps: {filterSettings, filterSettingsVisible}, captureOnMount: true})
 
   const { query } = location;
   const { SingleColumnSection, SectionTitle, PostsList2, LWTooltip, TagFilterSettings, SettingsIcon } = Components

--- a/packages/lesswrong/components/posts/PingbacksList.tsx
+++ b/packages/lesswrong/components/posts/PingbacksList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Posts } from '../../lib/collections/posts/collection';
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   root: {
@@ -41,8 +42,11 @@ const PingbacksList = ({classes, postId}: {
     ssr: true
   });
 
+  const pingbackIds = (results||[]).map((pingback) => pingback._id)
+  useTracking({eventType: "pingbacksList", eventProps: {pingbackIds}, captureOnMount: eventProps => eventProps.pingbackIds.length, skip: !pingbackIds.length||loading})
+
   const { Pingback, LWTooltip, LoadMore, Loading } = Components
-  
+
   if (results) {
     if (results.length > 0) {
       return <div className={classes.root}>
@@ -52,7 +56,7 @@ const PingbacksList = ({classes, postId}: {
           </LWTooltip>
         </div>
         <div className={classes.list}>
-          {results.map((post, i) => 
+          {results.map((post, i) =>
             <div key={post._id} >
               <Pingback post={post}/>
             </div>
@@ -62,7 +66,7 @@ const PingbacksList = ({classes, postId}: {
       </div>
     }
   }
-  
+
   return null;
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -408,10 +408,12 @@ class PostsPage extends Component<PostsPageProps> {
                 {!post.shortform && (wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
                   <div className={classes.footerSection}>
                     <div className={classes.voteBottom}>
-                      <PostsVote
-                        collection={Posts}
-                        post={post}
-                        />
+                      <AnalyticsContext pageSectionContext="lowerVoteButton">
+                        <PostsVote
+                          collection={Posts}
+                          post={post}
+                          />
+                      </AnalyticsContext>
                     </div>
                   </div>}
                 {sequenceId && <div className={classes.bottomNavigation}>

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -4,6 +4,7 @@ import Paper from '@material-ui/core/Paper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { useCurrentUser } from '../common/withUser';
 import { userCanUseTags } from '../../lib/betas';
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   addTagButton: {
@@ -23,17 +24,22 @@ const AddTagButton = ({onTagSelected, classes}: {
   const [isOpen, setIsOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);
   const currentUser = useCurrentUser();
-  
+  const { captureEvent } = useTracking()
+
   if (!userCanUseTags(currentUser)) {
     return null;
   }
-  
+
   return <a
-    onClick={(ev) => {setAnchorEl(ev.currentTarget); setIsOpen(true)}}
+    onClick={(ev) => {
+      setAnchorEl(ev.currentTarget);
+      setIsOpen(true);
+      captureEvent("addTagClicked")
+    }}
     className={classes.addTagButton}
   >
     {"+ Add Tag"}
-    
+
     <Components.LWPopper
       open={isOpen}
       anchorEl={anchorEl}

--- a/packages/lesswrong/components/tagging/EditTagsDialog.tsx
+++ b/packages/lesswrong/components/tagging/EditTagsDialog.tsx
@@ -3,17 +3,20 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
-const EditTagsDialog = ({post, onClose }: { 
-  post: PostsBase, 
+const EditTagsDialog = ({post, onClose }: {
+  post: PostsBase,
   onClose: ()=>void
 }) => {
   const { FooterTagList } = Components
   return <Dialog open={true} onClose={onClose} fullWidth maxWidth="sm" disableEnforceFocus>
-    <DialogTitle>{post.title}</DialogTitle>
-    <DialogContent>
-      <FooterTagList post={post}/> 
-    </DialogContent>
+    <AnalyticsContext pageSectionContext="editTagsDialog">
+      <DialogTitle>{post.title}</DialogTitle>
+      <DialogContent>
+        <FooterTagList post={post}/>
+      </DialogContent>
+    </AnalyticsContext>
   </Dialog>
 }
 

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -172,7 +172,7 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
         </div>
         <TagPreview tag={tag} showCount={false}/>
       </PopperCard>
-      </AnalyticsContext>
+    </AnalyticsContext>
   </span>
 }
 

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -10,6 +10,7 @@ import Input from '@material-ui/core/Input';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 import { isMobile } from '../../lib/utils/isMobile'
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   tag: {
@@ -85,14 +86,14 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
   description?: React.ReactNode
 }) => {
   const { LWTooltip, PopperCard, TagPreview } = Components
-  
+
   const { document: tag } = useSingle({
     documentId: tagId,
     collection: Tags,
     fragmentName: "TagPreviewFragment",
   })
 
-  const tagLabel = <span className={classNames(classes.tag, {[classes.noTag]: !tagId})}> 
+  const tagLabel = <span className={classNames(classes.tag, {[classes.noTag]: !tagId})}>
     {label}
     <span className={classes.filterScore}>
       {filterModeToStr(mode)}
@@ -101,75 +102,77 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
 
   const otherValue = ["Hidden", -30,-10,0,10,30,"Required"].includes(mode) ? "" : (mode || "")
   return <span>
-    {(tag && !isMobile()) ? <Link to={`tag/${tag.slug}`}>
-      {tagLabel}
-    </Link>
-    : tagLabel
-    }
-    <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom" 
-      modifiers={{
-        flip: {
-          behavior: ["bottom-start", "top-end", "bottom-start"],
-          boundariesElement: 'viewport'
-        }
-      }}
-    >
-      <div className={classes.filtering}>
-        <div className={classes.filterRow}>
-          <div className={classes.filterLabel}>
-            Set Filter
+    <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag?._id} tagName={tag?.name}>
+      {(tag && !isMobile()) ? <Link to={`tag/${tag.slug}`}>
+        {tagLabel}
+      </Link>
+      : tagLabel
+      }
+      <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom"
+        modifiers={{
+          flip: {
+            behavior: ["bottom-start", "top-end", "bottom-start"],
+            boundariesElement: 'viewport'
+          }
+        }}
+      >
+        <div className={classes.filtering}>
+          <div className={classes.filterRow}>
+            <div className={classes.filterLabel}>
+              Set Filter
+            </div>
+            {canRemove &&
+              <div className={classes.filterLabel} onClick={ev => {if (onRemove) onRemove()}}>
+                <LWTooltip title="This filter will no longer appear in Latest Posts. You can add it back later if you want.">
+                  <a>Remove Filter</a>
+                </LWTooltip>
+              </div>}
           </div>
-          {canRemove && 
-            <div className={classes.filterLabel} onClick={ev => {if (onRemove) onRemove()}}>
-              <LWTooltip title="This filter will no longer appear in Latest Posts. You can add it back later if you want.">
-                <a>Remove Filter</a>
-              </LWTooltip>
-            </div>}
+          <div>
+            <LWTooltip title={filterModeToTooltip("Hidden")}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Hidden"})} onClick={ev => onChangeMode("Hidden")}>
+                Hidden
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip(-25)}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode===-30})} onClick={ev => onChangeMode(-25)}>
+                -30
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip(-10)}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode===-10})} onClick={ev => onChangeMode(-10)}>
+                -10
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip("Default")}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Default" || mode===0})} onClick={ev => onChangeMode(0)}>
+                +0
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip(10)}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode===10})} onClick={ev => onChangeMode(10)}>
+                +10
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip(25)}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode===30})} onClick={ev => onChangeMode(25)}>
+                +30
+              </span>
+            </LWTooltip>
+            <LWTooltip title={filterModeToTooltip("Required")}>
+              <span className={classNames(classes.filterButton)} onClick={ev => onChangeMode("Required")}>
+                Required
+              </span>
+            </LWTooltip>
+            <Input placeholder="Other" type="number" defaultValue={otherValue} onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}/>
+          </div>
+          {description && <div className={classes.description}>
+            {description}
+          </div>}
         </div>
-        <div>
-          <LWTooltip title={filterModeToTooltip("Hidden")}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Hidden"})} onClick={ev => onChangeMode("Hidden")}>
-              Hidden
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip(-25)}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode===-30})} onClick={ev => onChangeMode(-25)}>
-              -30
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip(-10)}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode===-10})} onClick={ev => onChangeMode(-10)}>
-              -10
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip("Default")}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Default" || mode===0})} onClick={ev => onChangeMode(0)}>
-              +0
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip(10)}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode===10})} onClick={ev => onChangeMode(10)}>
-              +10
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip(25)}>
-            <span className={classNames(classes.filterButton, {[classes.selected]: mode===30})} onClick={ev => onChangeMode(25)}>
-              +30
-            </span>
-          </LWTooltip>
-          <LWTooltip title={filterModeToTooltip("Required")}>
-            <span className={classNames(classes.filterButton)} onClick={ev => onChangeMode("Required")}>
-              Required
-            </span>
-          </LWTooltip>
-          <Input placeholder="Other" type="number" defaultValue={otherValue} onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}/>
-        </div>
-        {description && <div className={classes.description}>
-          {description}
-        </div>}
-      </div>
-      <TagPreview tag={tag} showCount={false}/>
-    </PopperCard>
+        <TagPreview tag={tag} showCount={false}/>
+      </PopperCard>
+      </AnalyticsContext>
   </span>
 }
 
@@ -203,7 +206,9 @@ function filterModeToStr(mode: FilterMode): string {
   }
 }
 
-const FilterModeComponent = registerComponent("FilterMode", FilterModeRawComponent, {styles, hocs: [withHover()]});
+const FilterModeComponent = registerComponent("FilterMode", FilterModeRawComponent,
+  {styles, hocs: [withHover({pageElementContext: "tagFilterMode"}, ({tagId, label, mode})=>({tagId, label, mode}))]
+  });
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import withHover from '../common/withHover';
+import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 export const tagStyle = theme => ({
   marginRight: 4,
@@ -44,7 +45,7 @@ const FooterTag = ({tagRel, tag, hideScore=false, hover, anchorEl, classes}: {
   tagRel: TagRelMinimumFragment,
   tag: TagFragment,
   hideScore?: boolean,
-  
+
   hover: boolean,
   anchorEl: any,
   classes: ClassesType,
@@ -54,22 +55,24 @@ const FooterTag = ({tagRel, tag, hideScore=false, hover, anchorEl, classes}: {
 
   if (tag.adminOnly) { return null }
 
-  return (<span className={classes.root}>
-    <Link to={`/tag/${tag.slug}`}>
-      <span className={classes.name}>{tag.name}</span>
-      {!hideScore && <span className={classes.score}>{tagRel.baseScore}</span>}
-    </Link>
-    <PopperCard open={hover} anchorEl={anchorEl}>
-      <div className={classes.hovercard}>
-        <TagRelCard tagRel={tagRel} />
-      </div>
-    </PopperCard>
-  </span>);
+  return (<AnalyticsContext tagName={tag.name} tagId={tag._id} tagSlug={tag.slug} pageElementContext="tagItem">
+    <span className={classes.root}>
+      <Link to={`/tag/${tag.slug}`}>
+        <span className={classes.name}>{tag.name}</span>
+        {!hideScore && <span className={classes.score}>{tagRel.baseScore}</span>}
+      </Link>
+      <PopperCard open={hover} anchorEl={anchorEl}>
+        <div className={classes.hovercard}>
+          <TagRelCard tagRel={tagRel} />
+        </div>
+      </PopperCard>
+    </span>
+  </AnalyticsContext>);
 }
 
 const FooterTagComponent = registerComponent<ExternalProps>("FooterTag", FooterTag, {
   styles,
-  hocs: [withHover()]
+  hocs: [withHover({pageElementContext: "tagItem"}, ({tag})=>({tagId: tag._id, tagName: tag.name, tagSlug: tag.slug}))]
 });
 
 declare global {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -20,6 +20,7 @@ const FooterTagList = ({post, classes}: {
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
   const currentUser = useCurrentUser();
+  const { captureEvent } = useTracking()
 
   const { results, loading, refetch } = useMulti({
     terms: {
@@ -55,6 +56,7 @@ const FooterTagList = ({post, classes}: {
     });
     setIsAwaiting(false)
     refetch()
+    captureEvent("tagAddedToItem", {tagId, tagName})
   }, [setIsAwaiting, mutate, refetch, post._id]);
 
   const { Loading, FooterTag } = Components

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -57,7 +57,7 @@ const FooterTagList = ({post, classes}: {
     setIsAwaiting(false)
     refetch()
     captureEvent("tagAddedToItem", {tagId, tagName})
-  }, [setIsAwaiting, mutate, refetch, post._id]);
+  }, [setIsAwaiting, mutate, refetch, post._id, captureEvent]);
 
   const { Loading, FooterTag } = Components
   if (loading || !results)

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -5,6 +5,7 @@ import { useMutation } from 'react-apollo';
 import gql from 'graphql-tag';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 import { useCurrentUser } from '../common/withUser';
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   root: {
@@ -19,7 +20,7 @@ const FooterTagList = ({post, classes}: {
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
   const currentUser = useCurrentUser();
-  
+
   const { results, loading, refetch } = useMulti({
     terms: {
       view: "tagsOnPost",
@@ -30,7 +31,11 @@ const FooterTagList = ({post, classes}: {
     limit: 100,
     ssr: true,
   });
-  
+
+  const tagIds = (results||[]).map((tag) => tag._id)
+  useTracking({eventType: "tagList", eventProps: {tagIds}, captureOnMount: eventProps => eventProps.tagIds.length, skip: !tagIds.length||loading})
+
+
   const [mutate] = useMutation(gql`
     mutation addOrUpvoteTag($tagId: String, $postId: String) {
       addOrUpvoteTag(tagId: $tagId, postId: $postId) {
@@ -51,11 +56,11 @@ const FooterTagList = ({post, classes}: {
     setIsAwaiting(false)
     refetch()
   }, [setIsAwaiting, mutate, refetch, post._id]);
-  
+
   const { Loading, FooterTag } = Components
   if (loading || !results)
     return <Loading/>;
-  
+
   return <div className={classes.root}>
     {results.map((result, i) =>
       <FooterTag key={result._id} tagRel={result} tag={result.tag}/>

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -4,6 +4,7 @@ import { FilterSettings, FilterTag, FilterMode } from '../../lib/filterSettings'
 import { useMulti } from '../../lib/crud/withMulti';
 import { Tags } from '../../lib/collections/tags/collection';
 import * as _ from 'underscore';
+import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   root: {
@@ -61,7 +62,7 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
 }) => {
   const { AddTagButton, FilterMode, Loading } = Components
   const [addedSuggestedTags, setAddedSuggestedTags] = useState(false);
-  
+
   const { results: suggestedTags, loading: loadingSuggestedTags } = useMulti({
     terms: {
       view: "suggestedFilterTags",
@@ -70,14 +71,16 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
     fragmentName: "TagFragment",
     limit: 100,
   });
-  
+
+  const { captureEvent } = useTracking()
+
   if (suggestedTags && !addedSuggestedTags) {
     const filterSettingsWithSuggestedTags = addSuggestedTagsToSettings(filterSettings, suggestedTags);
     setAddedSuggestedTags(true);
     if (!_.isEqual(filterSettings, filterSettingsWithSuggestedTags))
       setFilterSettings(filterSettingsWithSuggestedTags);
   }
-  
+
   return <div className={classes.root}>
     {filterSettings.tags.map(tagSettings =>
       <FilterMode
@@ -94,7 +97,7 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             ...filterSettings.tags[replacedIndex],
             filterMode: mode
           };
-          
+
           setFilterSettings({
             personalBlog: filterSettings.personalBlog,
             tags: newTagFilters,
@@ -105,10 +108,11 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             personalBlog: filterSettings.personalBlog,
             tags: _.filter(filterSettings.tags, t=>t.tagId !== tagSettings.tagId),
           });
+          captureEvent("tagRemovedFromFilters", {tagId: tagSettings.tagId, tagName: tagSettings.tagName});
         }}
       />
     )}
-    
+
     <FilterMode
       label={personalBlogpostName}
       description={personalBlogpostTooltip}
@@ -129,6 +133,7 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             personalBlog: filterSettings.personalBlog,
             tags: [...filterSettings.tags, newFilter]
           });
+          captureEvent("tagAddedToFilters", {tagId, tagName})
         }
       }}/>}
     {loadingSuggestedTags && <Loading/>}
@@ -140,7 +145,7 @@ const addSuggestedTagsToSettings = (oldFilterSettings: FilterSettings, suggested
   for (let tag of oldFilterSettings.tags)
     tagsIncluded[tag.tagId] = true;
   const tagsNotIncluded = _.filter(suggestedTags, tag=>!(tag._id in tagsIncluded));
-  
+
   return {
     ...oldFilterSettings,
     tags: [

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -97,6 +97,7 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             ...filterSettings.tags[replacedIndex],
             filterMode: mode
           };
+          captureEvent('tagFilterModified', {tagId: tagSettings._id, tagName: tagSettings.tagName, mode})
 
           setFilterSettings({
             personalBlog: filterSettings.personalBlog,

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -98,7 +98,7 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             ...filterSettings.tags[replacedIndex],
             filterMode: mode
           };
-          captureEvent('tagFilterModified', {tagId: tagSettings._id, tagName: tagSettings.tagName, mode})
+          captureEvent('tagFilterModified', {tagId: tagSettings.tagId, tagName: tagSettings.tagName, mode})
 
           setFilterSettings({
             personalBlog: filterSettings.personalBlog,

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -9,6 +9,7 @@ import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
 import withDialog from '../common/withDialog';
+import { withTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   root: {
@@ -84,7 +85,7 @@ interface VoteButtonState {
 
 class VoteButton extends PureComponent<VoteButtonProps,VoteButtonState> {
   votingTransition: any
-  
+
   constructor(props: VoteButtonProps) {
     super(props);
     this.votingTransition = null
@@ -120,6 +121,7 @@ class VoteButton extends PureComponent<VoteButtonProps,VoteButtonState> {
       });
     } else {
       this.props.vote({document, voteType: type, collection, currentUser: this.props.currentUser});
+      this.props.captureEvent("vote", {collectionName: collection.collectionName});
     }
   }
 
@@ -139,7 +141,7 @@ class VoteButton extends PureComponent<VoteButtonProps,VoteButtonState> {
   handleClick = () => { // This handler is only used for mobile
     if(isMobile()) {
       const { voteType } = this.props
-      // This causes the following behavior (repeating after 3rd click): 
+      // This causes the following behavior (repeating after 3rd click):
       // 1st Click: small upvote; 2nd Click: big upvote; 3rd Click: cancel big upvote (i.e. going back to no vote)
       const voted = this.hasVoted(`big${voteType}`) || this.hasVoted(`small${voteType}`)
       if (voted) {
@@ -191,7 +193,7 @@ class VoteButton extends PureComponent<VoteButtonProps,VoteButtonState> {
 
 const VoteButtonComponent = registerComponent<ExternalProps>('VoteButton', VoteButton, {
   styles,
-  hocs: [withDialog, withTheme()]
+  hocs: [withDialog, withTheme(), withTracking]
 });
 
 declare global {

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -73,7 +73,7 @@ interface ExternalProps {
   currentUser: UsersCurrent|null,
   solidArrow?: boolean
 }
-interface VoteButtonProps extends ExternalProps, WithStylesProps, WithDialogProps {
+interface VoteButtonProps extends ExternalProps, WithStylesProps, WithDialogProps, WithTrackingProps {
   theme: any,
 }
 interface VoteButtonState {


### PR DESCRIPTION
- capture better context of events in tagFooter
- capture display of tags (and pingbacks) whether or not they're clicked
- track votes from within app so we know where people took action (only that they voted)
- track adding, removing, and modifying frontpage tag filters
- tracking what filterSettings are when frontpage loads + whether they're visible
- track addTag button + when tags added to posts