### PR TITLE
reverse Suggest Curated order

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -51,7 +51,7 @@ const SunshineSidebar = ({classes}) => {
         <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
         <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 10}}/>
         <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
-        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 10}}/>
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         
         {/* alignmentForumAdmins see AF content above the fold */}
         { currentUser?.groups && currentUser.groups.includes('alignmentForumAdmins') && <div>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -913,7 +913,7 @@ Posts.addView("sunshineCuratedSuggestions", function () {
     },
     options: {
       sort: {
-        createdAt: 1,
+        createdAt: -1,
       },
       hint: "posts.sunshineCuratedSuggestions",
     }


### PR DESCRIPTION
Reverses the Suggest Curated order so that the above-the-folder suggestions are actually fresh and hopefully exciting.

Cuts down the limit from 10 to 7 because it seemed like "about the number of posts I want to actually consider most of the time."