### PR TITLE
CkEditor Beta (remove collab)

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -13,7 +13,7 @@ import EditorForm from '../async/EditorForm'
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import withErrorBoundary from '../common/withErrorBoundary';
-import { userHasCkEditor } from '../../lib/betas';
+import { userHasCkEditor, userHasCkCollaboration } from '../../lib/betas';
 import * as _ from 'underscore';
 import { Meteor } from 'meteor/meteor';
 
@@ -609,8 +609,8 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
   }
 
   isDocumentCollaborative = () => {
-    const { document, fieldName } = this.props
-    return document?._id && document?.shareWithUsers && (fieldName === "contents")
+    const { document, fieldName, currentUser } = this.props
+    return userHasCkCollaboration(currentUser) && document?._id && document?.shareWithUsers && (fieldName === "contents")
   }
 
   renderCkEditor = () => {

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -18,7 +18,8 @@ const disabled = (user: UsersCurrent|DbUser|null): boolean => false; // eslint-d
 //////////////////////////////////////////////////////////////////////////////
 
 export const userHasPingbacks = shippedFeature;
-export const userHasCkEditor = adminOnly;
+export const userHasCkEditor = optInOnly;
+export const userHasCkCollaboration = adminOnly;
 export const userCanManageTags = moderatorOnly;
 export const userCanCreateTags = moderatorOnly;
 export const userCanUseTags = shippedFeature;


### PR DESCRIPTION
I... think this might be all that needs to happen to move CkEditor into beta? (it adds a new UserHasCkCollaboration field, which is required for a doc to be ckCollaborative. I haven't yet done a dutiful search to make sure all the possible ways one could conceivably activate collaboration)