### PR TITLE
fix nav event padding

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -14,10 +14,10 @@ const styles = (theme) => ({
     color: theme.palette.grey[600],
     width: 
       TAB_NAVIGATION_MENU_WIDTH - // base width
-      ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))), // paddingLeft,
+      ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft,
+      (theme.spacing.unit*2), // paddingRight,
     fontSize: "1rem",
     whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
     overflow: "hidden",
     '&:hover': {
       opacity: .6

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -15,7 +15,7 @@ const styles = (theme) => ({
     width: 
       TAB_NAVIGATION_MENU_WIDTH - // base width
       ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft,
-      (theme.spacing.unit*2), // paddingRight,
+      (theme.spacing.unit*2), // leave some space on the right,
     fontSize: "1rem",
     whiteSpace: "nowrap",
     overflow: "hidden",

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -71,6 +71,9 @@ const styles = createStyles(theme => ({
     width: 25,
     marginTop: theme.spacing.unit*2,
     marginBottom: theme.spacing.unit*2
+  },
+  event: {
+    textOverflow: "ellipsis",
   }
 }))
 
@@ -137,12 +140,12 @@ const TabNavigationEventsList = ({ terms, onClick, classes }) => {
               component={Link} to={Posts.getPageUrl(event)}
               classes={{root: classes.subItemOverride}}
             >
-              <TabNavigationSubItem>
+              <TabNavigationSubItem className={classes.event}>
                 {(displayTime && displayTime !== " ") && <span className={classNames(
                     classes.displayTime, {[classes.yesterday]: displayTime === YESTERDAY_STRING})
                   }>
                     {displayTime}
-                </span>}
+                </span>} 
                 <span className={classes.title}>{event.title}</span>
               </TabNavigationSubItem>
             </MenuItemUntyped>


### PR DESCRIPTION
I haven't figured out exactly what's going on with the padding for the TabNavigationSubItems (it looks like there's a bit of a spaghetti tower that I started and that JP layered on top of). But, this fix  adds right-padding back to the Event items, without disrupting the Subscribe menu item

![image](https://user-images.githubusercontent.com/3246710/82087366-cdd03a00-96a4-11ea-8f25-77b8c1eacb9e.png)
