### PR TITLE
Tag hotfix

### DIFF
--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -72,7 +72,7 @@ const FooterTag = ({tagRel, tag, hideScore=false, hover, anchorEl, classes}: {
 
 const FooterTagComponent = registerComponent<ExternalProps>("FooterTag", FooterTag, {
   styles,
-  hocs: [withHover({pageElementContext: "tagItem"}, ({tag})=>({tagId: tag._id, tagName: tag.name, tagSlug: tag.slug}))]
+  hocs: [withHover({pageElementContext: "tagItem"}, ({tag}:{tag: TagFragment})=>({tagId: tag._id, tagName: tag.name, tagSlug: tag.slug}))]
 });
 
 declare global {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -64,8 +64,8 @@ const FooterTagList = ({post, classes}: {
     return <Loading/>;
 
   return <div className={classes.root}>
-    {results.map((result, i) =>
-      <FooterTag key={result._id} tagRel={result} tag={result.tag}/>
+    {results.filter(tagRel => !!tagRel?.tag).map(tagRel =>
+      <FooterTag key={tagRel._id} tagRel={tagRel} tag={tagRel.tag}/>
     )}
     {currentUser && <Components.AddTagButton onTagSelected={onTagSelected} />}
     { isAwaiting && <Loading/>}


### PR DESCRIPTION
If we don't do this check then users who can't see admin-only tags get an error on any pages with admin-only tags, which obviously is very bad.