### PR TITLE
Re-hide Intercom on mobile

### DIFF
--- a/packages/lesswrong/styles/main.scss
+++ b/packages/lesswrong/styles/main.scss
@@ -30,7 +30,7 @@ h3 {
 
 // Deactivate intercom on smaller devices
 
-#intercom-container {
+#intercom-container, .intercom-lightweight-app {
   @include mui-breakpoint-down-sm {
     display: none;
   }


### PR DESCRIPTION
Intercom updated the className of their component on mobile, so it avoided the CSS we had in place to hide it on mobile. This fixes that.

I think this is reasonably urgent to merge, so maybe we want to make it a hotfix, since it makes the bottom-navigation unusable on mobile and looks pretty broken.