### PR TITLE
fix parens for Subscribe menu item

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -15,7 +15,7 @@ const styles = (theme) => ({
     width: 
       TAB_NAVIGATION_MENU_WIDTH - // base width
       ((theme.spacing.unit*2) + (iconWidth + (theme.spacing.unit*2))) - // paddingLeft,
-      (theme.spacing.unit*2), // leave some space on the right,
+      (theme.spacing.unit*1.5), // leave some space on the right,
     fontSize: "1rem",
     whiteSpace: "nowrap",
     overflow: "hidden",


### PR DESCRIPTION
Changes the max-width so that the closing parens of the "Subscribe (RSS/Email)" is visible.