### PR TITLE
Hotfix tab navigation ui bug

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -21,7 +21,8 @@ const styles = (theme) => ({
     overflow: "hidden",
     '&:hover': {
       opacity: .6
-    }
+    },
+    boxSizing: "content-box"
   }
 })
 


### PR DESCRIPTION
Corresponds to https://github.com/LessWrong2/Lesswrong2/pull/3156

I'm guessing the deepscan errors here are spurious, and stem from the PR being based off master, which is currently quite different from devel