### PR TITLE
Fix ToC LaTeX

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -10,6 +10,7 @@ import { Utils } from '../../vulcan-lib';
 import { localGroupTypeFormOptions } from '../localgroups/groupTypes';
 import Users from "../users/collection";
 import { Posts } from './collection';
+import Sentry from '@sentry/core';
 
 export const formGroups = {
   default: {
@@ -914,7 +915,12 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     graphQLtype: GraphQLJSON,
     resolver: async (document, args, { currentUser }) => {
-      return await Utils.getTableOfContentsData({document, version: null, currentUser});
+      try {
+        return await Utils.getTableOfContentsData({document, version: null, currentUser});
+      } catch(e) {
+        Sentry.captureException(e);
+        return null;
+      }
     },
   }),
 
@@ -924,7 +930,12 @@ addFieldsDict(Posts, {
     graphQLtype: GraphQLJSON,
     graphqlArguments: 'version: String',
     resolver: async (document, { version=null }, { currentUser }) => {
-      return await Utils.getTableOfContentsData({document, version, currentUser});
+      try {
+        return await Utils.getTableOfContentsData({document, version, currentUser});
+      } catch(e) {
+        Sentry.captureException(e);
+        return null;
+      }
     },
   }),
 

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -109,7 +109,6 @@ export function extractTableOfContents(postHTML: string)
 function elementToToCText(cheerioTag: CheerioElement) {
   const tagClone = cheerio.load(cheerioTag);
   tagClone("style").remove();
-  console.log(tagClone.root().html);
   return tagClone.root().text();
 }
 

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -46,7 +46,7 @@ const headingSelector = _.keys(headingTags).join(",");
 //       {title: "Conclusion", anchor: "conclusion", level: 1},
 //     ]
 //   }
-export function extractTableOfContents(postHTML)
+export function extractTableOfContents(postHTML: string)
 {
   if (!postHTML) return null;
   const postBody = cheerio.load(postHTML);
@@ -63,7 +63,7 @@ export function extractTableOfContents(postHTML)
       continue;
     }
 
-    let title = cheerio(tag).text();
+    let title = elementToToCText(tag);
     
     if (title && title.trim()!=="") {
       let anchor = titleToAnchor(title, usedAnchors);
@@ -104,6 +104,13 @@ export function extractTableOfContents(postHTML)
     sections: headings,
     headingsCount: headings.length
   }
+}
+
+function elementToToCText(cheerioTag: CheerioElement) {
+  const tagClone = cheerio.load(cheerioTag);
+  tagClone("style").remove();
+  console.log(tagClone.root().html);
+  return tagClone.root().text();
 }
 
 const reservedAnchorNames = ["top", "comments"];


### PR DESCRIPTION
Fixes #2962 . Currently when a (DraftJS) post has LaTeX in a section heading, the stylesheet ends up embedded in the section title, which looks ridiculous and effectively breaks the ToC; this filters <style> nodes out. Also improves the error handling of the ToC so that a crash in ToC extraction won't break the page (not that that has ever happened).