### PR TITLE
smaller code font

### DIFF
--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -190,7 +190,7 @@ const createLWTheme = (theme) => {
       },
       code: {
         fontFamily: monoStack,
-        fontSize: ".9rem",
+        fontSize: "1rem",
         fontWeight: 400,
         backgroundColor: grey[100],
         borderRadius: 2,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -190,7 +190,7 @@ const createLWTheme = (theme) => {
       },
       code: {
         fontFamily: monoStack,
-        fontSize: "1rem",
+        fontSize: ".7em",
         fontWeight: 400,
         backgroundColor: grey[100],
         borderRadius: 2,

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -190,7 +190,7 @@ const createLWTheme = (theme) => {
       },
       code: {
         fontFamily: monoStack,
-        fontSize: ".9em",
+        fontSize: ".9rem",
         fontWeight: 400,
         backgroundColor: grey[100],
         borderRadius: 2,


### PR DESCRIPTION
While reading Zack's latest post, I noticed it was hard to read because of code wrapping around lines. Then I noticed that the font for the codeblocks was just Very Large, period. This feels more natural looking to me, as well as making it easier to parse longer lines.

Compare old:

![image](https://user-images.githubusercontent.com/3246710/82509862-efbf2780-9abd-11ea-9133-cf592ad3aeed.png)

vs new:

![image](https://user-images.githubusercontent.com/3246710/82509888-fd74ad00-9abd-11ea-9898-18657c7d0ce8.png)
