### PR TITLE
defensive programming for timezone components

### DIFF
--- a/packages/lesswrong/components/common/BatchTimePicker.tsx
+++ b/packages/lesswrong/components/common/BatchTimePicker.tsx
@@ -5,6 +5,7 @@ import { useTimezone } from './withTimezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
+import withErrorBoundary from './withErrorBoundary';
 import * as _ from 'underscore';
 
 // value: {timeOfDayGMT:int, dayOfWeekGMT:string}
@@ -59,7 +60,7 @@ const BatchTimePicker = ({ mode, value, onChange}: {
   </React.Fragment>;
 }
 
-const BatchTimePickerComponent = registerComponent("BatchTimePicker", BatchTimePicker);
+const BatchTimePickerComponent = registerComponent("BatchTimePicker", BatchTimePicker, {hocs:[withErrorBoundary]});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -81,7 +81,6 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
       timeOfDay: timeOfDay,
       dayOfWeek: oldTimeLocalTZ.dayOfWeek
     };
-    console.log("DDD", timeOfDay, oldTimeLocalTZ)
     const newTimeGMT = convertTimeOfWeekTimezone(newTimeLocalTZ.timeOfDay, newTimeLocalTZ.dayOfWeek, tz, "GMT");
     
     this.modifyValue({
@@ -92,7 +91,6 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
   
   setBatchingDayOfWeek = (dayOfWeek, tz) => {
     const oldTimeLocalTZ = this.getBatchingTimeLocalTZ();
-    console.log("ZZZZ", dayOfWeek, oldTimeLocalTZ)
     const newTimeLocalTZ = {
       timeOfDay: oldTimeLocalTZ.timeOfDay,
       dayOfWeek: dayOfWeek

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -9,6 +9,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 import withTimezone from '../common/withTimezone';
+import withErrorBoundary from '../common/withErrorBoundary';
 import moment from '../../lib/moment-timezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
 import * as _ from 'underscore';
@@ -80,6 +81,7 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
       timeOfDay: timeOfDay,
       dayOfWeek: oldTimeLocalTZ.dayOfWeek
     };
+    console.log("DDD", timeOfDay, oldTimeLocalTZ)
     const newTimeGMT = convertTimeOfWeekTimezone(newTimeLocalTZ.timeOfDay, newTimeLocalTZ.dayOfWeek, tz, "GMT");
     
     this.modifyValue({
@@ -90,6 +92,7 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
   
   setBatchingDayOfWeek = (dayOfWeek, tz) => {
     const oldTimeLocalTZ = this.getBatchingTimeLocalTZ();
+    console.log("ZZZZ", dayOfWeek, oldTimeLocalTZ)
     const newTimeLocalTZ = {
       timeOfDay: oldTimeLocalTZ.timeOfDay,
       dayOfWeek: dayOfWeek
@@ -112,6 +115,10 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
   render() {
     const { timezone, classes } = this.props;
     const settings = this.props.value || {}
+
+    if (!settings.timeOfDayGMT || !settings.dayOfWeekGMT) {
+      return null
+    }
     
     const {timeOfDay, dayOfWeek} = this.getBatchingTimeLocalTZ();
     
@@ -208,7 +215,7 @@ class KarmaChangeNotifierSettings extends PureComponent<KarmaChangeNotifierSetti
 
 const KarmaChangeNotifierSettingsComponent = registerComponent("KarmaChangeNotifierSettings", KarmaChangeNotifierSettings, {
   styles,
-  hocs: [withTimezone]
+  hocs: [withTimezone, withErrorBoundary]
 });
 
 declare global {


### PR DESCRIPTION
Fixes https://github.com/LessWrong2/Lesswrong2/issues/3167

I'm not 100% sure what the preferred way of handling users who are missing timezone information is. Defer to Jim on whether the PR should early-escape from the render function, or just get wrapped in a withErrorBoundary so it doesn't destroy the entire UsersEdit component (or some third thing)