### PR TITLE
Fix /manageSubscriptions loading bug

### DIFF
--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -71,8 +71,8 @@ const SubscribedItem = ({collectionName, fragmentName, subscription, renderDocum
     collectionName, fragmentName,
   });
   
-  if (!document || loading)
-    return <Loading/>
+  if (!document && !loading) return null
+  if (loading) return <Loading/>
   
   return <div className={classes.subscribedItem}>
     <div className={classes.subscribedItemDescription}>


### PR DESCRIPTION
If a /manageSubscriptions SubscribedItem doesn't exist for some reason, it loads indefinitely. 

This fixes that.