### PR TITLE
Fix ToC generation removing headers [approved with caveats]

### DIFF
--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -107,7 +107,8 @@ export function extractTableOfContents(postHTML: string)
 }
 
 function elementToToCText(cheerioTag: CheerioElement) {
-  const tagClone = cheerio.load(cheerioTag);
+  const tagHtml = cheerio(cheerioTag).html();
+  const tagClone = cheerio.load(tagHtml);
   tagClone("style").remove();
   return tagClone.root().text();
 }


### PR DESCRIPTION
Fix #3187: ToC generation removes headers from the source document. The Cheerio API is subtle, and is mutate-by-default. Apparently `cheerio.load`, which I thought would clone an element, transfers ownership of it instead (removing it from the source document).