### PR TITLE
Work around an Apollo bug that broke SSR on sequence pages

### DIFF
--- a/packages/lesswrong/components/titles/SequencesPageTitle.tsx
+++ b/packages/lesswrong/components/titles/SequencesPageTitle.tsx
@@ -13,7 +13,7 @@ const SequencesPageTitle = ({isSubtitle, siteName, classes}) => {
   const { document: sequence, loading } = useSingle({
     documentId: _id,
     collection: Sequences,
-    fragmentName: "SequencesPageFragment",
+    fragmentName: "SequencesPageTitleFragment",
     fetchPolicy: 'cache-only',
   });
   

--- a/packages/lesswrong/lib/collections/sequences/fragments.ts
+++ b/packages/lesswrong/lib/collections/sequences/fragments.ts
@@ -1,15 +1,21 @@
 import { registerFragment } from '../../vulcan-lib';
 
 registerFragment(`
-  fragment SequencesPageFragment on Sequence {
+  fragment SequencesPageTitleFragment on Sequence {
     _id
+    title
+  }
+`);
+
+registerFragment(`
+  fragment SequencesPageFragment on Sequence {
+    ...SequencesPageTitleFragment
     createdAt
     userId
     user {
       ...UsersMinimumInfo
     }
-    title
-    contents { 
+    contents {
       ...RevisionDisplay
     }
     gridImageId

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1221,12 +1221,15 @@ interface ChaptersEdit extends ChaptersFragment { // fragment on Chapters
   readonly contents: RevisionEdit,
 }
 
-interface SequencesPageFragment { // fragment on Sequences
+interface SequencesPageTitleFragment { // fragment on Sequences
   readonly _id: string,
+  readonly title: string,
+}
+
+interface SequencesPageFragment extends SequencesPageTitleFragment { // fragment on Sequences
   readonly createdAt: Date,
   readonly userId: string,
   readonly user: UsersMinimumInfo,
-  readonly title: string,
   readonly contents: RevisionDisplay,
   readonly gridImageId: string,
   readonly bannerImageId: string,
@@ -1615,6 +1618,7 @@ interface FragmentTypes {
   RevisionEdit: RevisionEdit
   ChaptersFragment: ChaptersFragment
   ChaptersEdit: ChaptersEdit
+  SequencesPageTitleFragment: SequencesPageTitleFragment
   SequencesPageFragment: SequencesPageFragment
   SequencesEdit: SequencesEdit
   SequencesNavigationFragment: SequencesNavigationFragment


### PR DESCRIPTION
Work around an Apollo bug that breaks SSR on sequences pages, by making the fragment in the `cache-only` request in `SequencesPageTitle` different from the fragment in `SequencesPage`. This should also fix #3188 (sequence pages don't have a working Facebook preview).

The Apollo bug, as I currently understand it: If the page contains a `useSingle` with `fetchPolicy: 'cache-only'` and another `useSingle` with the same fragment and a different fetch policy somewhere else, then in the SSR (but not in the client render), the second `useSingle` will fail to load. This suggests that the second query is inheriting the fetch policy of the first, rather than the fetch policies being reconciles by taking the one that gets the data. Upgrading to newer versions of various Apollo libs did not seem to help.



┆Issue is synchronized with this [Trello card](https://trello.com/c/gneJmEFu) by [Unito](https://www.unito.io/learn-more)
