### PR TITLE
Add post/comment karma to sunshine sidebar

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -38,7 +38,7 @@ const SunshineNewUserCommentsList = ({terms, classes, truncated=false}: {
       {results.map(comment=><div className={classes.comment} key={comment._id}>
         <MetaInfo>
           <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
-            {comment.baseScore} {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>)
+            {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>, {comment.baseScore} karma)
           </Link>
         </MetaInfo>
         {!truncated && <div><MetaInfo>{comment.deleted && `[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -38,7 +38,7 @@ const SunshineNewUserCommentsList = ({terms, classes, truncated=false}: {
       {results.map(comment=><div className={classes.comment} key={comment._id}>
         <MetaInfo>
           <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
-            {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>)
+            [{comment.baseScore}] {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>)
           </Link>
         </MetaInfo>
         {!truncated && <div><MetaInfo>{comment.deleted && `[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -38,7 +38,7 @@ const SunshineNewUserCommentsList = ({terms, classes, truncated=false}: {
       {results.map(comment=><div className={classes.comment} key={comment._id}>
         <MetaInfo>
           <Link to={Posts.getPageUrl(comment.post) + "#" + comment._id}>
-            [{comment.baseScore}] {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>)
+            {comment.baseScore} {comment.deleted && "[Deleted] "}Comment on '{comment.post.title}' (<FormatDate date={comment.postedAt}/>)
           </Link>
         </MetaInfo>
         {!truncated && <div><MetaInfo>{comment.deleted && `[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -43,7 +43,7 @@ const SunshineNewUserPostsList = ({terms, classes, truncated=false}: {
         <MetaInfo>
           <Link to={`/posts/${post._id}`}>
             {(post.status !==2) && `[Spam] ${post.status}`}
-            {post.baseScore} Post: {post.title}
+            Post: {post.title} ({post.baseScore} karma)
           </Link>
         </MetaInfo>
         <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -43,7 +43,7 @@ const SunshineNewUserPostsList = ({terms, classes, truncated=false}: {
         <MetaInfo>
           <Link to={`/posts/${post._id}`}>
             {(post.status !==2) && `[Spam] ${post.status}`}
-            Post: {post.title}
+            [{post.baseScore}] Post: {post.title}
           </Link>
         </MetaInfo>
         <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -43,7 +43,7 @@ const SunshineNewUserPostsList = ({terms, classes, truncated=false}: {
         <MetaInfo>
           <Link to={`/posts/${post._id}`}>
             {(post.status !==2) && `[Spam] ${post.status}`}
-            [{post.baseScore}] Post: {post.title}
+            {post.baseScore} Post: {post.title}
           </Link>
         </MetaInfo>
         <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents && post.contents.htmlHighlight)}} />


### PR DESCRIPTION
When evaluating snoozed sunshine users, it'd be helpful to easily see the karma of their individual comments.



┆Issue is synchronized with this [Trello card](https://trello.com/c/QDDKcJ0D) by [Unito](https://www.unito.io/learn-more)
