### PR TITLE
Sunshine Curated appears after 3 days

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCuratedSuggestionsList.tsx
@@ -21,9 +21,9 @@ const SunshineCuratedSuggestionsList = ({ terms, belowFold }:{
     fragmentName: 'PostsList',
   });
   const curatedDate = new Date(curatedResults && curatedResults[0]?.curatedDate)
-  const twoDaysAgo = new Date(new Date().getTime()-(2*24*60*60*1000));
+  const threeDaysAgo = new Date(new Date().getTime()-(3*24*60*60*1000));
 
-  if (!belowFold && (curatedDate > twoDaysAgo)) return null
+  if (!belowFold && (curatedDate > threeDaysAgo)) return null
 
   if (loading) return <Components.Loading/>;
   


### PR DESCRIPTION
I felt like 2 days was a bit too short. I basically want to curate something within a day after the list appears in the Sidebar (so that the Sidebar can mostly remain an "inbox zero" experience). 

If we're aiming to curate mostly twice a week, 2 days is too often.



┆Issue is synchronized with this [Trello card](https://trello.com/c/16wy7vsJ) by [Unito](https://www.unito.io/learn-more)
