### PR TITLE
Remove recommendationSettings from fragments

### DIFF
--- a/packages/lesswrong/lib/fragments.ts
+++ b/packages/lesswrong/lib/fragments.ts
@@ -525,8 +525,6 @@ registerFragment(`
     # Karma Settings
     karmaChangeLastOpened
     karmaChangeNotifierSettings
-
-    recommendationSettings
     
     notificationShortformContent
     notificationCommentsOnSubscribedPost


### PR DESCRIPTION
This being included in a fragment prevented me from editing myself on devel. Not sure why, but I don't think it should be part of the UsersEdit fragment, since it's hidden in the edit form.



┆Issue is synchronized with this [Trello card](https://trello.com/c/Rin1Ar59) by [Unito](https://www.unito.io/learn-more)
