### PR TITLE
SequencesGridItem has new styling (removing padding)

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -42,8 +42,7 @@ const styles = theme => ({
     marginLeft: "auto"
   },
   sequenceGrid: {
-    marginTop: 8,
-    marginBottom: 8
+    marginTop: 8
   },
   loggedOutCustomizeLabel: {
     fontSize: "1rem",
@@ -152,7 +151,6 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
                 terms={{'view':'curatedSequences', limit:3}}
                 showAuthor={true}
                 showLoadMore={false}
-                smallerHeight
               />
             </div>
           </Hidden>

--- a/packages/lesswrong/components/sequences/SequencesGrid.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.tsx
@@ -12,17 +12,11 @@ export const styles = theme => ({
   },
 
   gridContent: {
-    marginLeft: -15,
-    marginRight: -24,
-    [theme.breakpoints.down('sm')]: {
-      marginLeft: 0,
-      marginRight: 0
-    },
-
     display: "flex",
     flexDirection: "row",
     flexWrap: "wrap",
     flexFlow: "row wrap",
+    justifyContent: "space-between",
     [legacyBreakpoints.maxSmall]: {
       alignItems: "center",
       justifyContent: "center",
@@ -35,11 +29,10 @@ export const styles = theme => ({
   },
 });
 
-const SequencesGrid = ({sequences, showAuthor, classes, smallerHeight}: {
+const SequencesGrid = ({sequences, showAuthor, classes }: {
   sequences: Array<SequencesPageFragment>,
   showAuthor?: boolean,
-  classes: ClassesType,
-  smallerHeight?: boolean,
+  classes: ClassesType
 }) =>
   <div className={classes.grid}>
     <div className={classes.gridContent}>
@@ -49,7 +42,7 @@ const SequencesGrid = ({sequences, showAuthor, classes, smallerHeight}: {
             sequence={sequence}
             key={sequence._id}
             showAuthor={showAuthor}
-            smallerHeight={smallerHeight}/>
+          />
         );
       })}
     </div>

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -5,15 +5,18 @@ import { Link } from '../../lib/reactRouterWrapper';
 import Typography from '@material-ui/core/Typography';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import { useHover } from '../common/withHover';
+import classNames from 'classnames';
 
 const styles = theme => ({
   root: {
     ...theme.typography.postStyle,
 
-    width: "33%",
-    padding: 15,
+    width: "calc(33% - 5px)",
+    boxShadow: "0 0 3px rgba(0,0,0,.2)",
     paddingBottom: 0,
     marginBottom: 10,
+    display: "flex",
+    flexDirection: "column",
 
     "&:hover": {
       boxShadow: "0 1px 6px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.12)",
@@ -56,12 +59,20 @@ const styles = theme => ({
   },
 
   meta: {
-    marginTop: 10,
-    marginBottom: 8,
+    paddingLeft: 12,
+    paddingTop: 12,
+    paddingRight: 8,
+    paddingBottom: 5,
+    flexGrow: 1,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center"
   },
-
+  hiddenAuthor: {
+    paddingBottom: 8
+  },
   image: {
-    backgroundColor: "#b4a78f",
+    backgroundColor: "#bbbbbb",
     display: 'block',
     height: 95,
     "& img": {
@@ -79,11 +90,10 @@ const styles = theme => ({
   }
 })
 
-const SequencesGridItem = ({ sequence, showAuthor=false, classes, smallerHeight }: {
+const SequencesGridItem = ({ sequence, showAuthor=false, classes }: {
   sequence: SequencesPageFragment,
   showAuthor?: boolean,
-  classes: ClassesType,
-  smallerHeight?: boolean
+  classes: ClassesType
 
 }) => {
   const getSequenceUrl = () => {
@@ -103,7 +113,7 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, smallerHeight 
         />
       </NoSSR>
     </div>
-    <div className={classes.meta}>
+    <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor})}>
       <Link key={sequence._id} to={url}>
         <Typography variant='title' className={classes.title}>
           {sequence.draft && <span className={classes.draft}>[Draft] </span>}

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -72,7 +72,7 @@ const styles = theme => ({
     paddingBottom: 8
   },
   image: {
-    backgroundColor: "#bbbbbb",
+    backgroundColor: "#efefef",
     display: 'block',
     height: 95,
     "& img": {
@@ -80,7 +80,6 @@ const styles = theme => ({
         width: "305px !important",
         height: "auto !important",
       },
-      opacity: .93,
       width: "100%",
       height: 95,
       [legacyBreakpoints.maxTiny]: {

--- a/packages/lesswrong/components/sequences/SequencesGridWrapper.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridWrapper.tsx
@@ -13,14 +13,12 @@ const SequencesGridWrapper = ({
   classes,
   showLoadMore = false,
   showAuthor = false,
-  smallerHeight = false,
 }: {
   terms: any,
   className?: string,
   classes: ClassesType,
   showLoadMore?: boolean,
   showAuthor?: boolean,
-  smallerHeight?: boolean
 }) => {
   const { results, loading, count, totalCount, loadMore, loadingMore } = useMulti({
     terms,
@@ -32,7 +30,7 @@ const SequencesGridWrapper = ({
   
   if (results && results.length) {
     return (<div className={classNames(className, classes.gridWrapper)}>
-      <Components.SequencesGrid sequences={results} showAuthor={showAuthor} smallerHeight={smallerHeight} />
+      <Components.SequencesGrid sequences={results} showAuthor={showAuthor} />
       { showLoadMore && totalCount! > count! &&
           <div className={classes.loadMore}>
             <Components.LoadMore loading={loadingMore} loadMore={loadMore} count={count} totalCount={totalCount} />


### PR DESCRIPTION
This is partly in preparation for an overall frontpage redesign

![image](https://user-images.githubusercontent.com/3246710/83316850-496dd300-a1dd-11ea-845a-8f35a28b4110.png)

![image](https://user-images.githubusercontent.com/3246710/83316863-5d193980-a1dd-11ea-8782-a70d3f05af42.png)

![image](https://user-images.githubusercontent.com/3246710/83316874-6904fb80-a1dd-11ea-84d9-e3f4e3bd896b.png)



┆Issue is synchronized with this [Trello card](https://trello.com/c/C3hoocEj) by [Unito](https://www.unito.io/learn-more)
