### PR TITLE
Add reinstall-ckeditor script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "meteor test-packages ./packages/lesswrong --driver-package meteortesting:mocha --exclude-archs web.browser.legacy --settings sample_settings.json --port 3200 --full-app --once",
     "test-prod": "meteor test-packages ./packages/lesswrong --driver-package meteortesting:mocha --exclude-archs web.browser.legacy --settings settings.json --port 3200 --full-app --once",
     "encrypt-credentials": "tar czf credentials.tar.gz --exclude '.git/*' -C ../ ./LessWrong-Credentials; travis encrypt-file credentials.tar.gz --add; rm credentials.tar.gz",
-    "generate": "scripts/generateTypes.sh"
+    "generate": "scripts/generateTypes.sh",
+    "reinstall-ckeditor": "yarn add ./public/lesswrong-editor"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,7 +1216,7 @@
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-"@lesswrong/lesswrong-editor@./public/lesswrong-editor/":
+"@lesswrong/lesswrong-editor@./public/lesswrong-editor":
   version "0.1.1"
   dependencies:
     ckeditor5-math "^1.0.3"


### PR DESCRIPTION
Add a reinstall-ckeditor script to more clearly communicate that you do actually have to reinstall ckeditor, as a form of documentation. 

Originally I wanted to add this as a `postinstall` script, but that gave me an infinite loop, since the `yarn add` command runs the `postInstall` hook, which runs `yarn add`, etc. So it's just a separate command for now.



┆Issue is synchronized with this [Trello card](https://trello.com/c/xL3R94VM) by [Unito](https://www.unito.io/learn-more)
