### PR TITLE
Streamline page title

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -225,7 +225,7 @@ addRoute([
     name: 'search',
     path: '/search',
     componentName: 'SearchPage',
-    title: 'LW Search'
+    title: 'Search'
   }
 ]);
 


### PR DESCRIPTION
This commit fixes

1) an incorrect 'LW' branding in an EAF page title (see https://github.com/centre-for-effective-altruism/EAForum/pull/90)

and

2) removes excessive 'LW' branding in a LW page title (2x 'LW', 1x 'LessWrong')

Screenshots of page titles in status quo. Didn't run anything locally so can't screenshot my change.

<img width="226" alt="lweaf" src="https://user-images.githubusercontent.com/44967334/84373475-87eb9080-abd4-11ea-9c12-3ebc1788f41f.png">


![lw3](https://user-images.githubusercontent.com/44967334/84373315-4c50c680-abd4-11ea-9993-800a467721af.png)






