### PR TITLE
Type-checking for routes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -77,7 +77,8 @@ module.exports = {
     "import/no-cycle": 1,
     "import/no-mutable-exports": 1,
     "no-restricted-imports": ["error", {"paths": [
-      { name: "lodash", message: "Don't import all of lodash, import a specific lodash function, eg lodash/sumBy" }
+      { name: "lodash", message: "Don't import all of lodash, import a specific lodash function, eg lodash/sumBy" },
+      { name: "react-router", message: "Don't import react-router, use lib/reactRouterWrapper" },
     ]}],
     
     // explicit-function-return-type: Disabled. Would forbid functions with

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
     "no-restricted-imports": ["error", {"paths": [
       { name: "lodash", message: "Don't import all of lodash, import a specific lodash function, eg lodash/sumBy" },
       { name: "react-router", message: "Don't import react-router, use lib/reactRouterWrapper" },
+      { name: "react-router-dom", message: "Don't import react-router-dom, use lib/reactRouterWrapper" },
     ]}],
     
     // explicit-function-return-type: Disabled. Would forbid functions with

--- a/packages/lesswrong/client/vulcan-core/AppGenerator.tsx
+++ b/packages/lesswrong/client/vulcan-core/AppGenerator.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { ApolloProvider } from 'react-apollo';
 import { runCallbacks, Components } from '../../lib/vulcan-lib';
 import { CookiesProvider } from 'react-cookie';
+// eslint-disable-next-line no-restricted-imports
 import { BrowserRouter } from 'react-router-dom';
 
 const AppGenerator = ({ apolloClient }) => {

--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+// eslint-disable-next-line no-restricted-imports
 import { Link, NavLink } from 'react-router-dom';
 
 let hashFragment = '';

--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -18,7 +18,7 @@ const HeadTags = (props) => {
     const { currentRoute, pathname } = useSubscribedLocation();
     const siteName = tabTitleSetting.get()
     
-    const TitleComponent = currentRoute?.titleComponentName ? Components[currentRoute.titleComponentName] : null;
+    const TitleComponent: any = currentRoute?.titleComponentName ? Components[currentRoute.titleComponentName] : null;
     const titleString = currentRoute?.title || props.title || currentRoute?.subtitle;
     
     return (

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -18,7 +18,7 @@ const HeaderSubtitle = ({classes}: {
 }) => {
   const { currentRoute } = useSubscribedLocation();
   if (!currentRoute) return null
-  const SubtitleComponent = currentRoute.subtitleComponentName ? Components[currentRoute.subtitleComponentName] : null;
+  const SubtitleComponent: any = currentRoute.subtitleComponentName ? Components[currentRoute.subtitleComponentName] : null;
   const subtitleString = currentRoute.subtitle;
   const subtitleLink = currentRoute.subtitleLink;
   

--- a/packages/lesswrong/components/common/PermanentRedirect.tsx
+++ b/packages/lesswrong/components/common/PermanentRedirect.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { useServerRequestStatus } from '../../lib/routeUtil'
-import { Redirect } from 'react-router'
+import { Redirect } from '../../lib/reactRouterWrapper';
 
 const PermanentRedirect = ({url, status}: {
   url: string,

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -36,4 +36,10 @@ const EASequencesHome = ({classes}) => {
   </AnalyticsContext>
 };
 
-registerComponent('EASequencesHome', EASequencesHome, {styles});
+const EASequencesHomeComponent = registerComponent('EASequencesHome', EASequencesHome, {styles});
+
+declare global {
+  interface ComponentTypes {
+    EASequencesHome: typeof EASequencesHomeComponent
+  }
+}

--- a/packages/lesswrong/components/messaging/InboxWrapper.tsx
+++ b/packages/lesswrong/components/messaging/InboxWrapper.tsx
@@ -17,4 +17,10 @@ const InboxWrapper = () => {
   </div>
 }
 
-registerComponent('InboxWrapper', InboxWrapper);
+const InboxWrapperComponent = registerComponent('InboxWrapper', InboxWrapper);
+
+declare global {
+  interface ComponentTypes {
+    InboxWrapper: typeof InboxWrapperComponent
+  }
+}

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -375,7 +375,7 @@ const styles = theme => ({
 })
 
 const SpreadsheetPage = ({classes}:{
-  classes: any
+  classes: ClassesType
 }) => {
   const { query: { tab: selectedTab = "Intro" }, hash: selectedCell } = useLocation()
   const { LWTooltip, HoverPreviewLink, Loading, HeadTags } = Components
@@ -667,6 +667,6 @@ const SpreadsheetPageComponent = registerComponent('SpreadsheetPage', Spreadshee
 
 declare global {
   interface ComponentTypes {
-    PostsSingle:typeof SpreadsheetPageComponent
+    SpreadsheetPage: typeof SpreadsheetPageComponent
   }
 }

--- a/packages/lesswrong/components/vulcan-core/App.tsx
+++ b/packages/lesswrong/components/vulcan-core/App.tsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { withApollo } from 'react-apollo';
+// eslint-disable-next-line no-restricted-imports
 import { withRouter } from 'react-router';
 import { withCurrentUser } from '../../lib/crud/withCurrentUser';
 import { withUpdate } from '../../lib/crud/withUpdate';

--- a/packages/lesswrong/components/vulcan-core/Card.tsx
+++ b/packages/lesswrong/components/vulcan-core/Card.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
-import { Link } from 'react-router-dom';
+import { Link } from '../../lib/reactRouterWrapper';
 import without from 'lodash/without';
 
 const getLabel = (fieldName, collection, intl) => {

--- a/packages/lesswrong/components/vulcan-core/ScrollToTop.tsx
+++ b/packages/lesswrong/components/vulcan-core/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {withRouter} from 'react-router';
+import {withLocation} from '../../lib/routeUtil';
 import {registerComponent} from '../../lib/vulcan-lib';
 
 // Scroll restoration based on https://reacttraining.com/react-router/web/guides/scroll-restoration.
@@ -16,7 +16,7 @@ export default class ScrollToTop extends Component<any> {
 }
 
 const ScrollToTopComponent = registerComponent('ScrollToTop', ScrollToTop, {
-  hocs: [withRouter]
+  hocs: [withLocation]
 });
 
 declare global {

--- a/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormWrapper.tsx
@@ -27,6 +27,10 @@ component is also added to wait for withSingle's loading prop to be false)
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { intlShape } from '../../lib/vulcan-i18n';
+// HACK: withRouter should be removed or turned into withLocation, but
+// FormWrapper passes props around in bulk, and Form has a bunch of prop-name
+// handling by string gluing, so it's hard to be sure this is safe.
+// eslint-disable-next-line no-restricted-imports
 import { withRouter } from 'react-router';
 import { graphql, withApollo } from 'react-apollo';
 import compose from 'lodash/flowRight';

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -6,6 +6,7 @@ export const withRouter = reactRouter3.withRouter;*/
 
 import React from 'react';
 import { useTracking } from '../lib/analyticsEvents';
+// eslint-disable-next-line no-restricted-imports
 import * as reactRouter from 'react-router';
 import * as reactRouterDom from 'react-router-dom';
 import { HashLink } from "../components/common/HashLink";
@@ -48,3 +49,5 @@ export const QueryLink = reactRouter.withRouter(({query, location, staticContext
     to={{...location, search: newSearchString}}
   />
 })
+
+export const Redirect = reactRouter.Redirect;

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { useTracking } from '../lib/analyticsEvents';
 // eslint-disable-next-line no-restricted-imports
 import * as reactRouter from 'react-router';
+// eslint-disable-next-line no-restricted-imports
 import * as reactRouterDom from 'react-router-dom';
 import { HashLink } from "../components/common/HashLink";
 import { parseQuery } from './routeUtil'

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -3,6 +3,7 @@ import qs from 'qs';
 import React, { useContext } from 'react';
 import { forumTypeSetting } from './instanceSettings';
 import { LocationContext, NavigationContext, ServerRequestStatusContext, SubscribeLocationContext } from './vulcan-core/appContext';
+import { RouterLocation } from './vulcan-lib/routes';
 
 // Given the props of a component which has withRouter, return the parsed query
 // from the URL.
@@ -17,17 +18,6 @@ export function parseQuery(location): Record<string,string> {
     query = query.substr(1);
     
   return qs.parse(query);
-}
-
-type RouterLocation = {
-  currentRoute: any,
-  RouteComponent: any,
-  location: any,
-  pathname: string,
-  url: string,
-  hash: string,
-  params: Record<string,string>,
-  query: Record<string,string>,
 }
 
 // React Hook which returns the page location (parsed URL and route).

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1,7 +1,7 @@
 import { Posts } from './collections/posts/collection';
 import { forumTypeSetting, PublicInstanceSetting } from './instanceSettings';
 import { hasEventsSetting, legacyRouteAcronymSetting } from './publicSettings';
-import { addRoute } from './vulcan-lib';
+import { addRoute, PingbackDocument, RouterLocation } from './vulcan-lib/routes';
 
 const communitySubtitle = { subtitleLink: "/community", subtitle: "Community" };
 const rationalitySubtitle = { subtitleLink: "/rationality", subtitle: "Rationality: A-Z" };
@@ -13,7 +13,10 @@ const aboutPostIdSetting = new PublicInstanceSetting<string>('aboutPostId', 'bJ2
 const contactPostIdSetting = new PublicInstanceSetting<string | null>('contactPostId', null, "optional")
 const introPostIdSetting = new PublicInstanceSetting<string | null>('introPostId', null, "optional") 
 
-function getPostPingbackById(parsedUrl, postId) {
+function getPostPingbackById(parsedUrl: RouterLocation, postId: string|null): PingbackDocument|null {
+  if (!postId)
+    return null;
+  
   if (parsedUrl.hash) {
     // If the URL contains a hash, it leads to either a comment or a landmark
     // within the post.
@@ -26,22 +29,22 @@ function getPostPingbackById(parsedUrl, postId) {
   }
 }
 
-async function getPostPingbackByLegacyId(parsedUrl, legacyId) {
+async function getPostPingbackByLegacyId(parsedUrl: RouterLocation, legacyId: string) {
   const parsedId = parseInt(legacyId, 36);
   const post = Posts.findOne({"legacyId": parsedId.toString()});
   if (!post) return null;
   return getPostPingbackById(parsedUrl, post._id);
 }
 
-async function getPostPingbackBySlug(parsedUrl, slug) {
+async function getPostPingbackBySlug(parsedUrl: RouterLocation, slug: string) {
   const post = Posts.findOne({slug: slug});
   if (!post) return null;
   return getPostPingbackById(parsedUrl, post._id);
 }
 
 
-addRoute([
-  // User-profile routes
+// User-profile routes
+addRoute(
   {
     name:'users.single',
     path:'/users/:slug',
@@ -227,13 +230,13 @@ addRoute([
     componentName: 'SearchPage',
     title: 'LW Search'
   }
-]);
+);
 
 
 
 const legacyRouteAcronym = legacyRouteAcronymSetting.get()
 
-addRoute([
+addRoute(
   // Legacy (old-LW, also old-EAF) routes
   // Note that there are also server-side-only routes in server/legacy-redirects/routes.js.
   {
@@ -251,10 +254,10 @@ addRoute([
     noIndex: true,
     // TODO: Pingback comment
   }
-]);
+);
 
 if (forumTypeSetting.get() !== 'EAForum') {
-  addRoute([
+  addRoute(
     {
       name: 'sequencesHome',
       path: '/library',
@@ -288,11 +291,11 @@ if (forumTypeSetting.get() !== 'EAForum') {
       componentName: 'PostsSingleRoute',
       _id:"DHJBEsi4XJDw2fRFq"
     },
-  ])
+  )
 }
 
 if (forumTypeSetting.get() === 'LessWrong') {
-  addRoute([
+  addRoute(
     {
       name: 'HPMOR',
       path: '/hpmor',
@@ -324,10 +327,10 @@ if (forumTypeSetting.get() === 'LessWrong') {
       ...codexSubtitle,
       getPingback: (parsedUrl) => getPostPingbackBySlug(parsedUrl, parsedUrl.params.slug),
     },
-  ]);
+  );
 }
 
-addRoute([
+addRoute(
   {
     name: 'AllComments',
     path: '/allComments',
@@ -340,10 +343,10 @@ addRoute([
     componentName: 'ShortformPage',
     title: "Shortform"
   },
-]);
+);
 
 if (hasEventsSetting.get()) {
-  addRoute([
+  addRoute(
     {
       name: 'EventsPast',
       path: '/pastEvents',
@@ -400,10 +403,10 @@ if (hasEventsSetting.get()) {
       ...communitySubtitle,
       getPingback: (parsedUrl) => getPostPingbackById(parsedUrl, parsedUrl.params._id),
     },
-  ]);
+  );
 }
 
-addRoute([
+addRoute(
   {
     name: 'searchTest',
     path: '/searchTest',
@@ -419,9 +422,9 @@ addRoute([
     path: '/imageUpload',
     componentName: 'ImageUpload'
   },
-]);
+);
 
-addRoute([
+addRoute(
   {
     name:'posts.single',
     path:'/posts/:_id/:slug?',
@@ -471,9 +474,9 @@ addRoute([
     path: '/debug/notificationEmailPreview',
     componentName: 'NotificationEmailPreviewPage'
   },
-]);
+);
 
-addRoute([
+addRoute(
   {
     path:'/posts/:_id/:slug/comment/:commentId?',
     name: 'comment.greaterwrong',
@@ -484,11 +487,11 @@ addRoute([
     noIndex: true,
     // TODO: Handle pingbacks leading to comments.
   }
-]);
+);
 
 switch (forumTypeSetting.get()) {
   case 'AlignmentForum':
-    addRoute([
+    addRoute(
       {
         name:'alignment.home',
         path:'/',
@@ -507,10 +510,10 @@ switch (forumTypeSetting.get()) {
         title: "Meta",
         ...metaSubtitle
       },
-    ]);
+    );
     break
   case 'EAForum':
-    addRoute([
+    addRoute(
       {
         name: 'home',
         path: '/',
@@ -558,11 +561,11 @@ switch (forumTypeSetting.get()) {
       //   path: '/handbook',
       //   componentName: 'EASequencesHome'
       // }
-    ]);
+    );
     break
   default:
     // Default is Vanilla LW
-    addRoute([
+    addRoute(
       {
         name: 'home',
         path: '/',
@@ -595,11 +598,11 @@ switch (forumTypeSetting.get()) {
         componentName: 'Meta',
         title: "Meta"
       },
-    ]);
+    );
     break;
 }
 
-addRoute([
+addRoute(
   {
     name: 'home2',
     path: '/home2',
@@ -647,4 +650,4 @@ addRoute([
     componentName: 'Reviews2018',
     title: "2018 Reviews",
   },
-]);
+);

--- a/packages/lesswrong/lib/vulcan-core/appContext.ts
+++ b/packages/lesswrong/lib/vulcan-core/appContext.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Components, Routes } from '../vulcan-lib';
+// eslint-disable-next-line no-restricted-imports
 import { matchPath } from 'react-router';
 import qs from 'qs'
 import Sentry from '@sentry/core';

--- a/packages/lesswrong/lib/vulcan-lib/routes.ts
+++ b/packages/lesswrong/lib/vulcan-lib/routes.ts
@@ -1,40 +1,70 @@
 import * as _ from 'underscore';
 
-type Route = any;
-export const Routes: Record<string,Route> = {}; // populated by calls to addRoute
+export type PingbackDocument = {
+  collectionName: CollectionNameString,
+  documentId: string,
+};
 
-/*
- A route is defined in the list like:
- Routes.foobar = {
- name: 'foobar',
- path: '/xyz',
- component: 'FooBar'
- componentName: 'FooBar' // optional
- }
- */
-export const addRoute = (routeOrRouteArray) => {
+export type RouterLocation = {
+  currentRoute: Route,
+  RouteComponent: any,
+  location: any,
+  pathname: string,
+  url: string,
+  hash: string,
+  params: Record<string,string>,
+  query: Record<string,string>,
+};
 
-  // be sure to have an array of routes to manipulate
-  const addedRoutes = Array.isArray(routeOrRouteArray) ? routeOrRouteArray : [routeOrRouteArray];
+export type Route = {
+  // Name of the route. Must be unique, but has no effect, except maybe
+  // appearing in debug logging occasionally.
+  name: string,
+  
+  // URL pattern for this route. Syntax comes from the path-to-regexp library
+  // (via indirect dependency via react-router).
+  path: string,
+  
+  componentName?: keyof ComponentTypes,
+  title?: string,
+  titleComponentName?: keyof ComponentTypes,
+  subtitle?: string,
+  subtitleLink?: string,
+  subtitleComponentName?: keyof ComponentTypes,
+  redirect?: (location: RouterLocation)=>string,
+  getPingback?: (parsedUrl: RouterLocation) => Promise<PingbackDocument|null> | PingbackDocument|null,
+  previewComponentName?: keyof ComponentTypes,
+  _id?: string|null,
+  noIndex?: boolean,
+};
 
-  // modify the routes table with the new routes
-  addedRoutes.forEach(({name, path, ...properties}) => {
+// populated by calls to addRoute
+export const Routes: Record<string,Route> = {};
 
+// Add a route to the routes table.
+//
+// Because routes have a bunch of optional fields and fields with constrained
+// strings (for component names), merging the types of a bunch of route
+// definitions in an array would produce an incorrect type. So instead of taking
+// an array argument, take varargs, which preserve the original type.
+export const addRoute = (...routes: Route[]): void => {
+  for (let route of routes) {
+    const {name, path, ...properties} = route;
+  
     // check if there is already a route registered to this path
     // @ts-ignore The @types/underscore signature for _.findWhere is narrower than the real function; this works fine
     const routeWithSamePath = _.findWhere(Routes, { path });
-
+  
     if (routeWithSamePath) {
       // Don't allow shadowing/replacing routes
       throw new Error(`Conflicting routes with name ${name}`);
     }
-
+  
     // register the new route
     Routes[name] = {
       name,
       path,
       ...properties
     };
-
-  });
+  }
 };

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/components/AppGenerator.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { ApolloProvider } from 'react-apollo';
+// eslint-disable-next-line no-restricted-imports
 import { StaticRouter } from 'react-router';
 
 import { Components } from '../../../../lib/vulcan-lib/components';


### PR DESCRIPTION
Adds type-checking to `addRoute`. As part of making this work, the type-signature is changed from taking a route-or-array, to taking varargs.

Also add a lint rule against bypassing reactRouterWrapper, and make things pass it.