### PR TITLE
Sunshine UI Changes

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -19,7 +19,7 @@ const styles = theme => ({
 
 const PostBodyPrefix = ({post, query, classes}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
-  query: any,
+  query?: any,
   classes: ClassesType,
 }) => {
   const { AlignmentCrosspostMessage, LinkPostMessage, PostsRevisionMessage} = Components;
@@ -36,7 +36,7 @@ const PostBodyPrefix = ({post, query, classes}: {
     <AlignmentCrosspostMessage post={post} />
     { post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>This post is awaiting moderator approval</div>}
     <LinkPostMessage post={post} />
-    {query.revision && <PostsRevisionMessage post={post} />}
+    {query?.revision && <PostsRevisionMessage post={post} />}
   </>;
 }
 

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -31,6 +31,10 @@ const styles = theme => ({
       maxWidth: MAX_COLUMN_WIDTH
     }
   },
+  footerTagList: {
+    marginTop: 16,
+    marginBottom: 66,
+  }
 });
 
 const PostsPagePostFooter = ({post, sequenceId, classes}: {
@@ -44,7 +48,9 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   
   return <>
     {!post.shortform && <AnalyticsContext pageSectionContext="tagFooter">
-      <FooterTagList post={post}/>
+      <div className={classes.footerTagList}>
+        <FooterTagList post={post}/>
+      </div>
     </AnalyticsContext>}
     {!post.shortform && (wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&
       <div className={classes.footerSection}>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -16,6 +16,7 @@ import HomeIcon from '@material-ui/icons/Home';
 import GroupIcon from '@material-ui/icons/Group';
 import ClearIcon from '@material-ui/icons/Clear';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { postHighlightStyles } from '../../themes/stylePiping'
 
 const styles = theme => ({
   icon: {
@@ -24,12 +25,20 @@ const styles = theme => ({
   },
   buttonRow: {
     ...theme.typography.commentStyle,
-    marginBottom: 12
+    marginTop: 12
+  },
+  post: {
+    ...postHighlightStyles(theme)
+  },
+  title: {
+    borderTop: "solid 1px rgba(0,0,0,.1)",
+    paddingTop: 12,
+    marginTop: 12
   }
 })
 
 const SunshineNewPostsItem = ({post, classes}: {
-  post: SunshinePostsList,
+  post: PostsWithNavigation,
   classes: ClassesType
 }) => {
   const [selectedTags, setSelectedTags] = useState<Record<string,boolean>>({});
@@ -38,7 +47,7 @@ const SunshineNewPostsItem = ({post, classes}: {
   
   const {mutate: updatePost} = useUpdate({
     collection: Posts,
-    fragmentName: 'SunshinePostsList',
+    fragmentName: 'PostsWithNavigation',
   });
   const [addTagsMutation] = useMutation(gql`
     mutation addTagsMutation($postId: String, $tagIds: [String]) {
@@ -110,7 +119,7 @@ const SunshineNewPostsItem = ({post, classes}: {
     }
   }
 
-  const { MetaInfo, FooterTagList, PostsHighlight, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
+  const { MetaInfo, PostBodyPrefix, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
   const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
   const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
 
@@ -118,31 +127,10 @@ const SunshineNewPostsItem = ({post, classes}: {
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <Typography variant="title">
-            <Link to={Posts.getPageUrl(post)}>
-              { post.title }
-            </Link>
-          </Typography>
-          {(post.moderationStyle || post.user.moderationStyle) && <div>
-            <MetaInfo>
-              <span>Mod Style: </span>
-              { post.moderationStyle || post.user.moderationStyle }
-              {!post.moderationStyle && post.user.moderationStyle && <span> (Default User Style)</span>}
-            </MetaInfo>
-          </div>}
-          {(modGuidelinesHtml || userGuidelinesHtml) && <div>
-            <MetaInfo>
-              <span>Mod Guidelines: </span>
-              <span dangerouslySetInnerHTML={{__html: modGuidelinesHtml || userGuidelinesHtml}}/>
-              {!modGuidelinesHtml && userGuidelinesHtml && <span> (Default User Guideline)</span>}
-            </MetaInfo>
-          </div>}
-          <FooterTagList post={post} />
-          <CoreTagsChecklist onSetTagsSelected={(selectedTags) => {
+          <CoreTagsChecklist post={post} onSetTagsSelected={(selectedTags) => {
             setSelectedTags(selectedTags);
           }}/>
           <div className={classes.buttonRow}>
-              Move to:
               <Button onClick={handleReview}>
                 <PersonIcon className={classes.icon} /> Personal
               </Button>
@@ -156,8 +144,28 @@ const SunshineNewPostsItem = ({post, classes}: {
                 <ClearIcon className={classes.icon} /> Draft
               </Button>
             </div>
-          <PostsHighlight post={post}/>
-
+            <Typography variant="title" className={classes.title}>
+              <Link to={Posts.getPageUrl(post)}>
+                { post.title }
+              </Link>
+            </Typography>
+            {(post.moderationStyle || post.user.moderationStyle) && <div>
+              <MetaInfo>
+                <span>Mod Style: </span>
+                { post.moderationStyle || post.user.moderationStyle }
+                {!post.moderationStyle && post.user.moderationStyle && <span> (Default User Style)</span>}
+              </MetaInfo>
+            </div>}
+            {(modGuidelinesHtml || userGuidelinesHtml) && <div>
+              <MetaInfo>
+                <span dangerouslySetInnerHTML={{__html: modGuidelinesHtml || userGuidelinesHtml}}/>
+                {!modGuidelinesHtml && userGuidelinesHtml && <span> (Default User Guideline)</span>}
+              </MetaInfo>
+            </div>}
+            <div className={classes.post}>
+              <PostBodyPrefix post={post} />
+              <ContentItemBody dangerouslySetInnerHTML={{__html: post.contents?.html}} description={`post ${post._id}`}/> }
+            </div>
         </SidebarHoverOver>
         <Link to={Posts.getPageUrl(post)}>
           {post.title}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -38,7 +38,7 @@ const styles = theme => ({
 })
 
 const SunshineNewPostsItem = ({post, classes}: {
-  post: PostsWithNavigation,
+  post: SunshinePostsList,
   classes: ClassesType
 }) => {
   const [selectedTags, setSelectedTags] = useState<Record<string,boolean>>({});

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
@@ -15,7 +15,7 @@ const SunshineNewPostsList = ({ terms, classes }) => {
   const { results, totalCount } = useMulti({
     terms,
     collection: Posts,
-    fragmentName: 'PostsWithNavigation',
+    fragmentName: 'SunshinePostsList',
     enableTotal: true,
     ssr: true
   });

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
@@ -15,7 +15,7 @@ const SunshineNewPostsList = ({ terms, classes }) => {
   const { results, totalCount } = useMulti({
     terms,
     collection: Posts,
-    fragmentName: 'SunshinePostsList',
+    fragmentName: 'PostsWithNavigation',
     enableTotal: true,
     ssr: true
   });

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -14,6 +14,7 @@ import DoneIcon from '@material-ui/icons/Done';
 import SnoozeIcon from '@material-ui/icons/Snooze';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import classNames from 'classnames';
+import DescriptionIcon from '@material-ui/icons/Description'
 
 const styles = theme => ({
   negativeKarma: {
@@ -27,6 +28,15 @@ const styles = theme => ({
   truncated: {
     maxHeight: 800,
     overflow: "hidden"
+  },
+  postIcon: {
+    height: 13,
+    color: theme.palette.grey[500],
+    position: "relative",
+    top: 3
+  },
+  reviewed: {
+    backgroundColor: theme.palette.grey[100]
   }
 })
 const SunshineNewUsersItem = ({ user, classes, updateUser, allowContentPreview=true }: {
@@ -133,9 +143,10 @@ const SunshineNewUsersItem = ({ user, classes, updateUser, allowContentPreview=t
           <MetaInfo className={classes.info}>
             <FormatDate date={user.createdAt}/>
           </MetaInfo>
-          <MetaInfo className={classes.info}>
+          {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon  className={classes.postIcon}/>}
+          {!user.reviewedByUserId && <MetaInfo className={classes.info}>
             { user.email }
-          </MetaInfo>
+          </MetaInfo>}
         </div>
         {showNewUserContent &&
           <div className={classNames({[classes.truncated]:truncated})} onClick={() => setTruncated(false)}>

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -6,15 +6,26 @@ import { Tags } from '../../lib/collections/tags/collection';
 
 const styles = theme => ({
   root: {
+    marginBottom: 8
   },
   checkbox: {
-    padding: 4,
+    padding: "0 8px 2px 0",
+    '& svg': {
+      height:14,
+      width: 14
+    }
   },
+  tag: {
+    ...theme.typography.commentStyle,
+    marginRight: 16,
+    color: theme.palette.grey[600]
+  }
 });
 
-const CoreTagsChecklist = ({onSetTagsSelected, classes}: {
+const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
   onSetTagsSelected: (selectedTags: Record<string,boolean>)=>void,
   classes: ClassesType,
+  post: PostsWithNavigation
 }) => {
   const { results, loading } = useMulti({
     terms: {
@@ -28,12 +39,12 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes}: {
   
   const { Loading } = Components;
   const [selections, setSelections] = useState<Record<string,boolean>>({});
-  
+  const { FooterTagList } = Components
   if (loading)
     return <Loading/>
   
   return <div className={classes.root}>
-    {results.map(tag => <div key={tag._id}>
+    {results.map(tag => <span key={tag._id} className={classes.tag}>
       <Checkbox
         className={classes.checkbox}
         checked={selections[tag._id]}
@@ -44,7 +55,8 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes}: {
         }}
       />
       {tag.name}
-    </div>)}
+    </span>)}
+    <FooterTagList post={post} />
   </div>
 }
 

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -9,8 +9,8 @@ import { useTracking } from "../../lib/analyticsEvents";
 
 const styles = theme => ({
   root: {
-    marginTop: 16,
-    marginBottom: 66,
+    marginTop: 8,
+    marginBottom: 8,
   },
 });
 

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -379,7 +379,7 @@ registerFragment(`
 
 registerFragment(`
   fragment SunshinePostsList on Post {
-    ...PostsList
+    ...PostsWithNavigation
     
     user {
       ...UsersMinimumInfo

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -76,6 +76,8 @@ Users.addView("sunshineNewUsers", function (terms) {
     },
     options: {
       sort: {
+        reviewedByUserId: 1,
+        postCount: -1,
         signUpReCaptchaRating: -1,
         createdAt: -1
       }

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -301,7 +301,7 @@ interface UsersBannedFromPostsModerationLog { // fragment on Posts
   readonly bannedUserIds: Array<string>,
 }
 
-interface SunshinePostsList extends PostsList { // fragment on Posts
+interface SunshinePostsList extends PostsWithNavigation { // fragment on Posts
   readonly user: SunshinePostsList_user,
 }
 


### PR DESCRIPTION
This makes several improvements to the sunshine sidebar

New Posts
– now include full body of post
– tagging section is condensed
– post information is more clearly separated from the "admin actions" section (i.e. tags and frontpage/personal/delete are clustered together at the top)

New Users
– users who have never been reviewed are sorted to the top
– unreviewed users with a postCount are sorted to the top (since they are highest priority to review)
– unreviewed users with a postCount get a little post icon to help draw your attention to them
– users who HAVE been reviewed no longer show an email address (this is because I wanted some way to distinguish them from unreviewed users, and because the email address is most useful for classifying them as spam when they are first reviewed)

![image](https://user-images.githubusercontent.com/3246710/85063179-9c90d100-b15e-11ea-8184-708dd6d8e568.png)

![image](https://user-images.githubusercontent.com/3246710/85062922-3310c280-b15e-11ea-97cd-cc5c7af4282a.png)
