### PR TITLE
Mup-aws-beanstalk has a new deploy, our version pinnings are now unnecessary

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 # Install dependencies
 yarn;
-yarn global add mup@1.4.6 https://github.com/jimrandomh/mup-aws-beanstalk;
+yarn global add mup@1.5 mup-aws-beanstalk@0.6
 yarn global add json;
 yarn global add @sentry/cli;
 


### PR DESCRIPTION
They're most recently released version includes Jim's PR and is compatible with mup 1.5.x.