### PR TITLE
Fix sunshine new post fragment

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -119,7 +119,7 @@ const SunshineNewPostsItem = ({post, classes}: {
     }
   }
 
-  const { MetaInfo, PostBodyPrefix, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
+  const { MetaInfo, LinkPostMessage, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
   const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
   const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
 
@@ -163,7 +163,7 @@ const SunshineNewPostsItem = ({post, classes}: {
               </MetaInfo>
             </div>}
             <div className={classes.post}>
-              <PostBodyPrefix post={post} />
+              <LinkPostMessage post={post} />
               <ContentItemBody dangerouslySetInnerHTML={{__html: post.contents?.html}} description={`post ${post._id}`}/> }
             </div>
         </SidebarHoverOver>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -47,7 +47,7 @@ const SunshineNewPostsItem = ({post, classes}: {
   
   const {mutate: updatePost} = useUpdate({
     collection: Posts,
-    fragmentName: 'PostsWithNavigation',
+    fragmentName: 'PostsList',
   });
   const [addTagsMutation] = useMutation(gql`
     mutation addTagsMutation($postId: String, $tagIds: [String]) {

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -25,7 +25,7 @@ const styles = theme => ({
 const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
   onSetTagsSelected: (selectedTags: Record<string,boolean>)=>void,
   classes: ClassesType,
-  post: PostsWithNavigation
+  post: PostsList
 }) => {
   const { results, loading } = useMulti({
     terms: {

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -25,7 +25,7 @@ const styles = theme => ({
 const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
   onSetTagsSelected: (selectedTags: Record<string,boolean>)=>void,
   classes: ClassesType,
-  post: PostsList
+  post: PostsList|SunshinePostsList
 }) => {
   const { results, loading } = useMulti({
     terms: {

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -379,7 +379,7 @@ registerFragment(`
 
 registerFragment(`
   fragment SunshinePostsList on Post {
-    ...PostsWithNavigation
+    ...PostsList
     
     user {
       ...UsersMinimumInfo

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -380,6 +380,10 @@ registerFragment(`
 registerFragment(`
   fragment SunshinePostsList on Post {
     ...PostsList
+
+    contents {
+      html
+    }
     
     user {
       ...UsersMinimumInfo

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -302,7 +302,12 @@ interface UsersBannedFromPostsModerationLog { // fragment on Posts
 }
 
 interface SunshinePostsList extends PostsList { // fragment on Posts
+  readonly contents: SunshinePostsList_contents,
   readonly user: SunshinePostsList_user,
+}
+
+interface SunshinePostsList_contents { // fragment on Revisions
+  readonly html: string,
 }
 
 interface SunshinePostsList_user extends UsersMinimumInfo { // fragment on Users

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -301,7 +301,7 @@ interface UsersBannedFromPostsModerationLog { // fragment on Posts
   readonly bannedUserIds: Array<string>,
 }
 
-interface SunshinePostsList extends PostsWithNavigation { // fragment on Posts
+interface SunshinePostsList extends PostsList { // fragment on Posts
   readonly user: SunshinePostsList_user,
 }
 


### PR DESCRIPTION
In my previous Sunshine UI PR, I changed a fragment from PostsList to PostsWithNavigation because the type-checking was yelling at me. This broke the SunshineNewPostsItem.

Now I've changed it back, and... type checking _isn't_ yelling at me, and I notice I'm kinda confused about this. It appears to work fine though. 

I _do_ get an error now about "$near" when I move a SunshiNewPostsItem to frontpage, but I think I recall that happening before.