### PR TITLE
SequencesGridItem's image height changes appropriately on mobile

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -28,7 +28,6 @@ const styles = theme => ({
     },
     [legacyBreakpoints.maxTiny]: {
       width: "100% !important",
-      padding: "14px 10px 12px 10px !important",
     },
   },
 
@@ -75,13 +74,16 @@ const styles = theme => ({
     backgroundColor: "#efefef",
     display: 'block',
     height: 95,
+    [legacyBreakpoints.maxSmall]: {
+      height: "124px !important",
+    },
     "& img": {
-      [legacyBreakpoints.maxSmall]: {
-        width: "305px !important",
-        height: "auto !important",
-      },
       width: "100%",
       height: 95,
+      [legacyBreakpoints.maxSmall]: {
+        width: "335px !important",
+        height: "124px !important",
+      },
       [legacyBreakpoints.maxTiny]: {
         width: "100% !important",
       },


### PR DESCRIPTION
In the recent SequencesGridItem UI rework I accidentally broke it's appearance on mobile.

This PR fixes it by giving it a new (fixed) height on smaller screens. I did a horizontal resize test. Currently the image starts stretching on _very_ teeny screens, but I'm not sure this even will come up on modern mobile devices.