### PR TITLE
Fix missing revision denormalizations

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -24,8 +24,7 @@ const styles = theme => ({
     marginRight: 4
   },
   buttonRow: {
-    ...theme.typography.commentStyle,
-    marginTop: 12
+    ...theme.typography.commentStyle
   },
   post: {
     ...postHighlightStyles(theme)
@@ -34,6 +33,9 @@ const styles = theme => ({
     borderTop: "solid 1px rgba(0,0,0,.1)",
     paddingTop: 12,
     marginTop: 12
+  },
+  moderation: {
+    marginBottom: 12
   }
 })
 
@@ -119,9 +121,11 @@ const SunshineNewPostsItem = ({post, classes}: {
     }
   }
 
-  const { MetaInfo, LinkPostMessage, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist } = Components
+  const { MetaInfo, LinkPostMessage, ContentItemBody, SunshineListItem, SidebarHoverOver, SidebarInfo, CoreTagsChecklist, FooterTagList } = Components
   const { html: modGuidelinesHtml = "" } = post.moderationGuidelines || {}
   const { html: userGuidelinesHtml = "" } = post.user.moderationGuidelines || {}
+
+  const moderationSection = post.moderationStyle || post.user.moderationStyle || modGuidelinesHtml || userGuidelinesHtml
 
   return (
     <span {...eventHandlers}>
@@ -130,6 +134,7 @@ const SunshineNewPostsItem = ({post, classes}: {
           <CoreTagsChecklist post={post} onSetTagsSelected={(selectedTags) => {
             setSelectedTags(selectedTags);
           }}/>
+          <FooterTagList post={post} />
           <div className={classes.buttonRow}>
               <Button onClick={handleReview}>
                 <PersonIcon className={classes.icon} /> Personal
@@ -149,18 +154,20 @@ const SunshineNewPostsItem = ({post, classes}: {
                 { post.title }
               </Link>
             </Typography>
-            {(post.moderationStyle || post.user.moderationStyle) && <div>
-              <MetaInfo>
-                <span>Mod Style: </span>
-                { post.moderationStyle || post.user.moderationStyle }
-                {!post.moderationStyle && post.user.moderationStyle && <span> (Default User Style)</span>}
-              </MetaInfo>
-            </div>}
-            {(modGuidelinesHtml || userGuidelinesHtml) && <div>
-              <MetaInfo>
-                <span dangerouslySetInnerHTML={{__html: modGuidelinesHtml || userGuidelinesHtml}}/>
-                {!modGuidelinesHtml && userGuidelinesHtml && <span> (Default User Guideline)</span>}
-              </MetaInfo>
+            {moderationSection && <div className={classes.moderation}>
+              {(post.moderationStyle || post.user.moderationStyle) && <div>
+                <MetaInfo>
+                  <span>Mod Style: </span>
+                  { post.moderationStyle || post.user.moderationStyle }
+                  {!post.moderationStyle && post.user.moderationStyle && <span> (Default User Style)</span>}
+                </MetaInfo>
+              </div>}
+              {(modGuidelinesHtml || userGuidelinesHtml) && <div>
+                <MetaInfo>
+                  <span dangerouslySetInnerHTML={{__html: modGuidelinesHtml || userGuidelinesHtml}}/>
+                  {!modGuidelinesHtml && userGuidelinesHtml && <span> (Default User Guideline)</span>}
+                </MetaInfo>
+              </div>}
             </div>}
             <div className={classes.post}>
               <LinkPostMessage post={post} />

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -6,7 +6,9 @@ import { Tags } from '../../lib/collections/tags/collection';
 
 const styles = theme => ({
   root: {
-    marginBottom: 8
+    marginBottom: 8,
+    display: "flex",
+    flexWrap: "wrap"
   },
   checkbox: {
     padding: "0 8px 2px 0",
@@ -16,9 +18,12 @@ const styles = theme => ({
     }
   },
   tag: {
+    minWidth: "25%",
+    display: "inline-block",
     ...theme.typography.commentStyle,
     marginRight: 16,
-    color: theme.palette.grey[600]
+    color: theme.palette.grey[600],
+    marginTop: 4
   }
 });
 
@@ -39,7 +44,6 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
   
   const { Loading } = Components;
   const [selections, setSelections] = useState<Record<string,boolean>>({});
-  const { FooterTagList } = Components
   if (loading)
     return <Loading/>
   
@@ -56,7 +60,6 @@ const CoreTagsChecklist = ({onSetTagsSelected, classes, post}: {
       />
       {tag.name}
     </span>)}
-    <FooterTagList post={post} />
   </div>
 }
 

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -395,12 +395,11 @@ export function addEditableCallbacks({collection, options = {}}: {
       const userId = currentUser._id
       const editedAt = new Date()
       
-      // FIXME: See comment on the other Connectors.create call in this file.
-      // Missing _id and schemaVersion.
-      // @ts-ignore
-      
       let newRevisionId;
       if (await revisionIsChange(newDocument, fieldName)) {
+        // FIXME: See comment on the other Connectors.create call in this file.
+        // Missing _id and schemaVersion.
+        // @ts-ignore
         const newRevision = await Connectors.create(Revisions, {
           documentId: document._id,
           ...await buildRevision({
@@ -415,7 +414,7 @@ export function addEditableCallbacks({collection, options = {}}: {
         });
         newRevisionId = newRevision._id;
       } else {
-        newRevisionId = (await getLatestRev(newDocument._id, fieldName))._id;
+        newRevisionId = (await getLatestRev(newDocument._id, fieldName))!._id;
       }
       
       return {

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -379,8 +379,9 @@ export function addEditableCallbacks({collection, options = {}}: {
   }
 
   async function editorSerializationEdit (docData, { oldDocument: document, newDocument, currentUser }) {
-    if (docData[fieldName]?.originalContents && await revisionIsChange(newDocument, fieldName)) {
+    if (docData[fieldName]?.originalContents) {
       if (!currentUser) { throw Error("Can't create document without current user") }
+      
       const { data, type } = docData[fieldName].originalContents
       const commitMessage = docData[fieldName].commitMessage;
       const html = await dataToHTML(data, type, !currentUser.isAdmin)
@@ -397,18 +398,25 @@ export function addEditableCallbacks({collection, options = {}}: {
       // FIXME: See comment on the other Connectors.create call in this file.
       // Missing _id and schemaVersion.
       // @ts-ignore
-      const newRevision = await Connectors.create(Revisions, {
-        documentId: document._id,
-        ...await buildRevision({
-          originalContents: newDocument[fieldName].originalContents,
-          currentUser,
-        }),
-        fieldName,
-        collectionName,
-        version,
-        updateType,
-        commitMessage,
-      });
+      
+      let newRevisionId;
+      if (await revisionIsChange(newDocument, fieldName)) {
+        const newRevision = await Connectors.create(Revisions, {
+          documentId: document._id,
+          ...await buildRevision({
+            originalContents: newDocument[fieldName].originalContents,
+            currentUser,
+          }),
+          fieldName,
+          collectionName,
+          version,
+          updateType,
+          commitMessage,
+        });
+        newRevisionId = newRevision._id;
+      } else {
+        newRevisionId = (await getLatestRev(newDocument._id, fieldName))._id;
+      }
       
       return {
         ...docData,
@@ -416,7 +424,7 @@ export function addEditableCallbacks({collection, options = {}}: {
           ...docData[fieldName],
           html, version, userId, editedAt, wordCount
         },
-        [`${fieldName}_latest`]: newRevision,
+        [`${fieldName}_latest`]: newRevisionId,
         ...(pingbacks ? {
           pingbacks: await htmlToPingbacks(html, [{
               collectionName: collection.collectionName,


### PR DESCRIPTION
Fix a bug (introduced by me in the revision history viewer PR) which made it so that, if you edited a post without changing its body, such as undrafting or re-drafting it, then denormalized revision fields wouldn't be filled in correctly. This would cause the post to appear blank (though the contents would still be there on the editor form). Currently lessestwrong/staging is affected, but production is not.
