### PR TITLE
Fix padding on small post blockquote paragraphs

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -270,9 +270,6 @@ const smallPostStyles = theme => ({
   '& blockquote': {
     ...theme.typography.body2,
     ...theme.typography.postStyle,
-    '& > p': {
-      margin:0
-    },
   },
   '& ul': {
     paddingInlineStart: 30


### PR DESCRIPTION
I'm not entirely sure why I originally made blockquote > p blocks have no margins, but it results in this:

![image](https://user-images.githubusercontent.com/3246710/85627772-ed536e80-b623-11ea-8c4a-04d25cf54ce3.png)

It looks like removing the special styling fixes the problem. I'm not sure if it causes some other problem somewhere else, but for now am happy to re-roll on styles.