### PR TITLE
Improve JS performance of voting

### DIFF
--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { useCurrentUser } from '../common/withUser';
-import { TagRels } from '../../lib/collections/tagRels/collection';
 import { useVote } from '../votes/withVote';
 import classNames from 'classnames';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -40,7 +38,6 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
   classes: ClassesType,
 }) => {
   const { VoteButton, PostsItem2MetaInfo } = Components;
-  const currentUser = useCurrentUser();
   const voteProps = useVote(tagRel, "TagRels");
   
   const tooltip = <div>

--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -41,7 +41,7 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
 }) => {
   const { VoteButton, PostsItem2MetaInfo } = Components;
   const currentUser = useCurrentUser();
-  const vote = useVote();
+  const vote = useVote("TagRels");
   
   const tooltip = <div>
     <div>{tagRel.baseScore} Relevance</div>

--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -57,7 +57,6 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
             color="error"
             voteType="Downvote"
             document={tagRel}
-            currentUser={currentUser}
             collection={TagRels}
             vote={vote}
             solidArrow
@@ -74,7 +73,6 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
             color="secondary"
             voteType="Upvote"
             document={tagRel}
-            currentUser={currentUser}
             collection={TagRels}
             vote={vote}
             solidArrow

--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -41,7 +41,7 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
 }) => {
   const { VoteButton, PostsItem2MetaInfo } = Components;
   const currentUser = useCurrentUser();
-  const vote = useVote("TagRels");
+  const voteProps = useVote(tagRel, "TagRels");
   
   const tooltip = <div>
     <div>{tagRel.baseScore} Relevance</div>
@@ -56,15 +56,13 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
             orientation="down"
             color="error"
             voteType="Downvote"
-            document={tagRel}
-            collection={TagRels}
-            vote={vote}
             solidArrow
+            {...voteProps}
           />
         </div>
         
         <div className={classes.score}>
-          {tagRel.baseScore}
+          {voteProps.baseScore}
         </div>
       
         <div className={classNames(classes.voteButton, classes.vertLayoutVoteUp)}>
@@ -72,10 +70,8 @@ const PostsItemTagRelevance = ({tagRel, classes}: {
             orientation="up"
             color="secondary"
             voteType="Upvote"
-            document={tagRel}
-            collection={TagRels}
-            vote={vote}
             solidArrow
+            {...voteProps}
           />
         </div>
       </span>

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useVote } from '../votes/withVote';
-import { useCurrentUser } from '../common/withUser';
-import { TagRels } from '../../lib/collections/tagRels/collection';
 
 const styles = theme => ({
   relevance: {
@@ -29,7 +27,6 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
   classes: ClassesType,
   relevance?: boolean
 }) => {
-  const currentUser = useCurrentUser();
   const voteProps = useVote(tagRel, "TagRels");
   const { VoteButton, TagPreview } = Components;
   

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -30,7 +30,7 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
   relevance?: boolean
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote("TagRels");
+  const voteProps = useVote(tagRel, "TagRels");
   const { VoteButton, TagPreview } = Components;
   
   return <div>
@@ -44,22 +44,18 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           orientation="left"
           color="error"
           voteType="Downvote"
-          document={tagRel}
-          collection={TagRels}
-          vote={vote}
+          {...voteProps}
         />
       </div>
       <span className={classes.score}>
-        {tagRel.baseScore}
+        {voteProps.baseScore}
       </span>
       <div className={classes.voteButton}>
         <VoteButton
           orientation="right"
           color="secondary"
           voteType="Upvote"
-          document={tagRel}
-          collection={TagRels}
-          vote={vote}
+          {...voteProps}
         />
       </div>
     </div>

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -45,7 +45,6 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           color="error"
           voteType="Downvote"
           document={tagRel}
-          currentUser={currentUser}
           collection={TagRels}
           vote={vote}
         />
@@ -59,7 +58,6 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           color="secondary"
           voteType="Upvote"
           document={tagRel}
-          currentUser={currentUser}
           collection={TagRels}
           vote={vote}
         />

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -30,7 +30,7 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
   relevance?: boolean
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote();
+  const vote = useVote("TagRels");
   const { VoteButton, TagPreview } = Components;
   
   return <div>

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -74,7 +74,6 @@ const TagVoteActivity = ({classes}:{
                   color="error"
                   voteType="Downvote"
                   document={vote.tagRel}
-                  currentUser={currentUser}
                   collection={TagRels}
                   vote={castVote}
                 />
@@ -86,7 +85,6 @@ const TagVoteActivity = ({classes}:{
                   color="secondary"
                   voteType="Upvote"
                   document={vote.tagRel}
-                  currentUser={currentUser}
                   collection={TagRels}
                   vote={castVote}
                 />

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -3,7 +3,6 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Votes } from '../../lib/collections/votes';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useCurrentUser } from '../common/withUser';
-import { TagRels } from '../../lib/collections/tagRels/collection';
 import { Posts } from '../../lib/collections/posts';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useVote } from '../votes/withVote';
@@ -72,7 +71,7 @@ const TagVoteActivityRow = ({vote, classes}: {
 const TagVoteActivity = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, Error404, VoteButton, LoadMore } = Components
+  const { SingleColumnSection, Error404, LoadMore } = Components
   const { results: votes, loadMoreProps } = useMulti({
     terms: {view:"tagVotes"},
     collection: Votes,

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -33,10 +33,46 @@ const styles = theme => ({
   }
 })
 
-const TagVoteActivity = ({classes}:{
+const TagVoteActivityRow = ({vote, classes}: {
+  vote: TagVotingActivity,
+  classes: ClassesType
+}) => {
+  const { FormatDate, VoteButton, FooterTag } = Components;
+  const voteProps = useVote(vote.tagRel, "TagRels")
+  return (
+    <tr key={vote._id} className={classes.voteRow}>
+      <td>{vote.userId?.slice(7,10)}</td>
+      <td className={classes.tagCell}><FooterTag tag={vote.tagRel?.tag} tagRel={vote.tagRel} hideScore /></td>
+      <td> <Link to={vote.tagRel?.post && Posts.getPageUrl(vote.tagRel.post)}> {vote.tagRel?.post?.title} </Link> </td>
+      <td>{vote.power} {vote.isUnvote && <span title="Unvote">(unv.)</span>}</td>
+      <td><FormatDate date={vote.votedAt}/></td>
+      <td className={classes.votingCell}>
+        <div className={classes.voteButtons}>
+          <VoteButton
+            orientation="left"
+            color="error"
+            voteType="Downvote"
+            {...voteProps}
+          />
+          <span className={classes.score}>
+            {voteProps.baseScore}
+          </span>
+          <VoteButton
+            orientation="right"
+            color="secondary"
+            voteType="Upvote"
+            {...voteProps}
+          />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+const TagVoteActivity = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, FormatDate, Error404, VoteButton, FooterTag, LoadMore } = Components
+  const { SingleColumnSection, Error404, VoteButton, LoadMore } = Components
   const { results: votes, loadMoreProps } = useMulti({
     terms: {view:"tagVotes"},
     collection: Votes,
@@ -44,7 +80,6 @@ const TagVoteActivity = ({classes}:{
     limit: 200,
     ssr: true
   })
-  const castVote = useVote("TagRels")
 
   const currentUser = useCurrentUser();
 
@@ -61,36 +96,7 @@ const TagVoteActivity = ({classes}:{
           <td className={classes.headerCell}> When </td>
           <td className={classes.headerCell}> Vote </td>
         </tr>
-        {votes?.map(vote=><tr key={vote._id} className={classes.voteRow}>
-            <td>{vote.userId?.slice(7,10)}</td>
-            <td className={classes.tagCell}><FooterTag tag={vote.tagRel?.tag} tagRel={vote.tagRel} hideScore /></td>
-            <td> <Link to={vote.tagRel?.post && Posts.getPageUrl(vote.tagRel.post)}> {vote.tagRel?.post?.title} </Link> </td>
-            <td>{vote.power} {vote.isUnvote && <span title="Unvote">(unv.)</span>}</td>
-            <td><FormatDate date={vote.votedAt}/></td>
-            <td className={classes.votingCell}>
-              <div className={classes.voteButtons}>
-                <VoteButton
-                  orientation="left"
-                  color="error"
-                  voteType="Downvote"
-                  document={vote.tagRel}
-                  collection={TagRels}
-                  vote={castVote}
-                />
-                <span className={classes.score}>
-                  {vote.tagRel?.baseScore}
-                </span>
-                <VoteButton
-                  orientation="right"
-                  color="secondary"
-                  voteType="Upvote"
-                  document={vote.tagRel}
-                  collection={TagRels}
-                  vote={castVote}
-                />
-              </div>
-            </td>
-          </tr>)}
+        {votes?.map(vote => <TagVoteActivityRow key={vote._id} vote={vote} classes={classes}/>)}
       </tbody>
     </table>
     <LoadMore {...loadMoreProps} />

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -44,7 +44,7 @@ const TagVoteActivity = ({classes}:{
     limit: 200,
     ssr: true
   })
-  const castVote = useVote()
+  const castVote = useVote("TagRels")
 
   const currentUser = useCurrentUser();
 

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -42,14 +42,14 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote("Comments");
+  const voteProps = useVote(comment, "Comments");
   const {eventHandlers, hover} = useHover();
   
   if (!comment) return null;
 
   const { VoteButton } = Components
-  const voteCount = comment.voteCount;
-  const karma = Comments.getKarma(comment)
+  const voteCount = voteProps.voteCount;
+  const karma = voteProps.baseScore;
 
   const moveToAfInfo = Users.isAdmin(currentUser) && !!comment.moveToAlignmentUserId && (
     <div className={classes.tooltipHelp}>
@@ -70,9 +70,7 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 orientation="left"
                 color="error"
                 voteType="Downvote"
-                document={comment}
-                collection={Comments}
-                vote={vote}
+                {...voteProps}
               />
             </span>
           </Tooltip>
@@ -94,9 +92,7 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 orientation="right"
                 color="secondary"
                 voteType="Upvote"
-                document={comment}
-                collection={Comments}
-                vote={vote}
+                {...voteProps}
               />
             </span>
           </Tooltip>

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -42,7 +42,7 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote();
+  const vote = useVote("Comments");
   const {eventHandlers, hover} = useHover();
   
   if (!comment) return null;

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -71,7 +71,6 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 color="error"
                 voteType="Downvote"
                 document={comment}
-                currentUser={currentUser}
                 collection={Comments}
                 vote={vote}
               />
@@ -96,7 +95,6 @@ const CommentsVote = ({ comment, hideKarma=false, classes }: {
                 color="secondary"
                 voteType="Upvote"
                 document={comment}
-                currentUser={currentUser}
                 collection={Comments}
                 vote={vote}
               />

--- a/packages/lesswrong/components/votes/CommentsVote.tsx
+++ b/packages/lesswrong/components/votes/CommentsVote.tsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
-import { Comments } from "../../lib/collections/comments";
 import Users from '../../lib/collections/users/collection';
 import moment from '../../lib/moment-timezone';
 import { useHover } from '../common/withHover';

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -62,7 +62,6 @@ const PostsVote = ({ post, classes, collection }: {
               color="secondary"
               voteType="Upvote"
               document={post}
-              currentUser={currentUser}
               collection={collection}
               vote={vote}
             />
@@ -102,7 +101,6 @@ const PostsVote = ({ post, classes, collection }: {
               color="error"
               voteType="Downvote"
               document={post}
-              currentUser={currentUser}
               collection={collection}
               vote={vote}
             />

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 import classNames from 'classnames';
-import { useCurrentUser } from '../common/withUser';
 import { useVote } from './withVote';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
@@ -45,7 +44,6 @@ const PostsVote = ({ post, classes, collection }: {
   classes: ClassesType,
   collection: any,
 }) => {
-  const currentUser = useCurrentUser();
   const voteProps = useVote(post, "Posts");
 
   return (

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -46,8 +46,7 @@ const PostsVote = ({ post, classes, collection }: {
   collection: any,
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote("Posts");
-  const baseScore = forumTypeSetting.get() === 'AlignmentForum' ? post.afBaseScore : post.baseScore
+  const voteProps = useVote(post, "Posts");
 
   return (
       <div className={classes.voteBlock}>
@@ -61,19 +60,17 @@ const PostsVote = ({ post, classes, collection }: {
               orientation="up"
               color="secondary"
               voteType="Upvote"
-              document={post}
-              collection={collection}
-              vote={vote}
+              {...voteProps}
             />
           </div>
         </Tooltip>
         <div className={classes.voteScores}>
           <Tooltip
-            title={`${post.voteCount} ${post.voteCount == 1 ? "Vote" : "Votes"}`}
+            title={`${voteProps.voteCount} ${voteProps.voteCount == 1 ? "Vote" : "Votes"}`}
             placement="right"
             classes={{tooltip: classes.tooltip}}
           >
-            <Typography variant="headline" className={classes.voteScore}>{baseScore || 0}</Typography>
+            <Typography variant="headline" className={classes.voteScore}>{voteProps.baseScore}</Typography>
           </Tooltip>
 
           {!!post.af && !!post.afBaseScore && forumTypeSetting.get() !== 'AlignmentForum' &&
@@ -100,9 +97,7 @@ const PostsVote = ({ post, classes, collection }: {
               orientation="down"
               color="error"
               voteType="Downvote"
-              document={post}
-              collection={collection}
-              vote={vote}
+              {...voteProps}
             />
           </div>
         </Tooltip>

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -46,7 +46,7 @@ const PostsVote = ({ post, classes, collection }: {
   collection: any,
 }) => {
   const currentUser = useCurrentUser();
-  const vote = useVote();
+  const vote = useVote("Posts");
   const baseScore = forumTypeSetting.get() === 'AlignmentForum' ? post.afBaseScore : post.baseScore
 
   return (

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -75,6 +75,7 @@ const VoteButton = ({
   vote: any,
   collection: any,
   document: any,
+  
   voteType: string,
   color: any,
   orientation: string,
@@ -129,7 +130,7 @@ const VoteButton = ({
   }
 
   const hasVoted = (type) => {
-    return hasVotedClient({document, voteType: type})
+    return hasVotedClient({userVotes: document.currentUserVotes, voteType: type})
   }
 
   const voted = hasVoted(`small${voteType}`) || hasVoted(`big${voteType}`)

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -1,5 +1,5 @@
 import { registerComponent } from '../../lib/vulcan-lib';
-import React, { PureComponent } from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { hasVotedClient } from '../../lib/voting/vote';
 import { isMobile } from '../../lib/utils/isMobile'
@@ -8,8 +8,8 @@ import UpArrowIcon from '@material-ui/icons/KeyboardArrowUp';
 import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
 import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
-import withDialog from '../common/withDialog';
-import { withTracking } from "../../lib/analyticsEvents";
+import { useDialog } from '../common/withDialog';
+import { useTracking } from '../../lib/analyticsEvents';
 
 const styles = theme => ({
   root: {
@@ -63,7 +63,14 @@ const styles = theme => ({
   }
 })
 
-interface ExternalProps {
+const VoteButton = ({
+  vote, collection, document, voteType,
+  color = "secondary",
+  orientation = "up",
+  currentUser, solidArrow,
+  theme,
+  classes,
+}: {
   vote: any,
   collection: any,
   document: any,
@@ -72,128 +79,105 @@ interface ExternalProps {
   orientation: string,
   currentUser: UsersCurrent|null,
   solidArrow?: boolean
-}
-interface VoteButtonProps extends ExternalProps, WithStylesProps, WithDialogProps, WithTrackingProps {
-  theme: any,
-}
-interface VoteButtonState {
-  voted: boolean,
-  bigVoted: boolean,
-  bigVotingTransition: boolean,
-  bigVoteCompleted: boolean,
-}
+  // From withTheme. TODO: Hookify this.
+  theme?: any
+  classes: ClassesType
+}) => {
+  const { openDialog } = useDialog();
+  const { captureEvent } = useTracking();
+  const [votingTransition, setVotingTransition] = useState<any>(null);
+  const [bigVotingTransition, setBigVotingTransition] = useState(false);
+  const [bigVoteCompleted, setBigVoteCompleted] = useState(false);
 
-class VoteButton extends PureComponent<VoteButtonProps,VoteButtonState> {
-  votingTransition: any
-
-  constructor(props: VoteButtonProps) {
-    super(props);
-    this.votingTransition = null
-    this.state = {
-      voted: false,
-      bigVoted: false,
-      bigVotingTransition: false,
-      bigVoteCompleted: false,
-    };
-  }
-
-  handleMouseDown = () => { // This handler is only used on desktop
-    const { theme } = this.props
+  const handleMouseDown = () => { // This handler is only used on desktop
     if(!isMobile()) {
-      this.setState({bigVotingTransition: true})
-      this.votingTransition = setTimeout(() => {this.setState({bigVoteCompleted: true})}, theme.voting.strongVoteDelay)
+      setBigVotingTransition(true);
+      setVotingTransition(setTimeout(() => {
+        setBigVoteCompleted(true);
+      }, theme.voting.strongVoteDelay))
     }
   }
 
-  clearState = () => {
-    clearTimeout(this.votingTransition)
-    this.setState({bigVotingTransition: false, bigVoteCompleted: false})
+  const clearState = () => {
+    clearTimeout(votingTransition);
+    setBigVotingTransition(false);
+    setBigVoteCompleted(false);
   }
 
-  vote = (type) => {
-    const document = this.props.document;
-    const collection = this.props.collection;
-    const user = this.props.currentUser;
-    if(!user){
-      this.props.openDialog({
+  const wrappedVote = (type) => {
+    if(!currentUser){
+      openDialog({
         componentName: "LoginPopup",
         componentProps: {}
       });
     } else {
-      this.props.vote({document, voteType: type, collection, currentUser: this.props.currentUser});
-      this.props.captureEvent("vote", {collectionName: collection.collectionName});
+      vote({document, voteType: type, collection, currentUser});
+      captureEvent("vote", {collectionName: collection.collectionName});
     }
   }
 
-  handleMouseUp = () => { // This handler is only used on desktop
+  const handleMouseUp = () => { // This handler is only used on desktop
     if(!isMobile()) {
-      const { voteType } = this.props
-      const { bigVoteCompleted } = this.state
       if (bigVoteCompleted) {
-        this.vote(`big${voteType}`)
+        wrappedVote(`big${voteType}`)
       } else {
-        this.vote(`small${voteType}`)
+        wrappedVote(`small${voteType}`)
       }
-      this.clearState()
+      clearState()
     }
   }
 
-  handleClick = () => { // This handler is only used for mobile
+  const hasVoted = (type) => {
+    return hasVotedClient({document, voteType: type})
+  }
+
+  const voted = hasVoted(`small${voteType}`) || hasVoted(`big${voteType}`)
+  const bigVoted = hasVoted(`big${voteType}`)
+  
+  const handleClick = () => { // This handler is only used for mobile
     if(isMobile()) {
-      const { voteType } = this.props
       // This causes the following behavior (repeating after 3rd click):
       // 1st Click: small upvote; 2nd Click: big upvote; 3rd Click: cancel big upvote (i.e. going back to no vote)
-      const voted = this.hasVoted(`big${voteType}`) || this.hasVoted(`small${voteType}`)
       if (voted) {
-        this.vote(`big${voteType}`)
+        wrappedVote(`big${voteType}`)
       } else {
-        this.vote(`small${voteType}`)
+        wrappedVote(`small${voteType}`)
       }
-      this.clearState()
+      clearState()
     }
   }
 
-  hasVoted = (type) => {
-    return hasVotedClient({document: this.props.document, voteType: type})
-  }
-
-  render() {
-    const { classes, orientation = 'up', theme, color = "secondary", voteType, solidArrow } = this.props
-    const voted = this.hasVoted(`small${voteType}`) || this.hasVoted(`big${voteType}`)
-    const bigVoted = this.hasVoted(`big${voteType}`)
-    const { bigVotingTransition, bigVoteCompleted } = this.state
-
-    const Icon = solidArrow ? ArrowDropUpIcon :UpArrowIcon
-    return (
-        <IconButton
-          className={classNames(classes.root, classes[orientation])}
-          onMouseDown={this.handleMouseDown}
-          onMouseUp={this.handleMouseUp}
-          onMouseOut={this.clearState}
-          onClick={this.handleClick}
-          disableRipple
-        >
-          <Icon
-            className={classes.smallArrow}
-            color={voted ? color : 'inherit'}
+  const Icon = solidArrow ? ArrowDropUpIcon :UpArrowIcon
+  return (
+    <IconButton
+      className={classNames(classes.root, classes[orientation])}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onMouseOut={clearState}
+      onClick={handleClick}
+      disableRipple
+    >
+      <Icon
+        className={classes.smallArrow}
+        color={voted ? color : 'inherit'}
+        viewBox='6 6 12 12'
+      />
+      <Transition in={!!(bigVotingTransition || bigVoted)} timeout={theme.voting.strongVoteDelay}>
+        {(state) => (
+          <UpArrowIcon
+            style={{color: bigVoteCompleted && theme.palette[color].light}}
+            className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
+            color={(bigVoted || bigVoteCompleted) ? color : 'inherit'}
             viewBox='6 6 12 12'
-          />
-          <Transition in={!!(bigVotingTransition || bigVoted)} timeout={theme.voting.strongVoteDelay}>
-            {(state) => (
-              <UpArrowIcon
-                style={{color: bigVoteCompleted && theme.palette[color].light}}
-                className={classNames(classes.bigArrow, {[classes.bigArrowCompleted]: bigVoteCompleted, [classes.bigArrowSolid]: solidArrow}, classes[state])}
-                color={(bigVoted || bigVoteCompleted) ? color : 'inherit'}
-                viewBox='6 6 12 12'
-              />)}
-          </Transition>
-        </IconButton>
-  )}
+          />)}
+      </Transition>
+    </IconButton>
+  )
 }
 
-const VoteButtonComponent = registerComponent<ExternalProps>('VoteButton', VoteButton, {
+const VoteButtonComponent = registerComponent('VoteButton', VoteButton, {
   styles,
-  hocs: [withDialog, withTheme(), withTracking]
+  hocs: [withTheme()]
 });
 
 declare global {

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -10,6 +10,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Transition from 'react-transition-group/Transition';
 import { useDialog } from '../common/withDialog';
 import { useTracking } from '../../lib/analyticsEvents';
+import { useCurrentUser } from '../common/withUser';
 
 const styles = theme => ({
   root: {
@@ -67,7 +68,7 @@ const VoteButton = ({
   vote, collection, document, voteType,
   color = "secondary",
   orientation = "up",
-  currentUser, solidArrow,
+  solidArrow,
   theme,
   classes,
 }: {
@@ -77,12 +78,12 @@ const VoteButton = ({
   voteType: string,
   color: any,
   orientation: string,
-  currentUser: UsersCurrent|null,
   solidArrow?: boolean
   // From withTheme. TODO: Hookify this.
   theme?: any
   classes: ClassesType
 }) => {
+  const currentUser = useCurrentUser();
   const { openDialog } = useDialog();
   const { captureEvent } = useTracking();
   const [votingTransition, setVotingTransition] = useState<any>(null);

--- a/packages/lesswrong/components/votes/withVote.ts
+++ b/packages/lesswrong/components/votes/withVote.ts
@@ -1,9 +1,8 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useMessages } from '../common/withMessages';
 import { useMutation } from 'react-apollo';
 import gql from 'graphql-tag';
 import { performVoteClient } from '../../lib/voting/vote';
-import { VoteableCollections } from '../../lib/make_voteable';
 import { getCollection, getFragmentText } from '../../lib/vulcan-lib';
 import * as _ from 'underscore';
 import { Random } from 'meteor/random';
@@ -36,7 +35,7 @@ export const useVote = (document: any, collectionName: CollectionNameString): {
   const [mutate] = useMutation(query, {
     onCompleted: useCallback(() => {
       setOptimisticResponseDocument(null)
-    }),
+    }, []),
   });
   
   const vote = useCallback(({document, voteType, collection, currentUser, voteId = Random.id()}) => {

--- a/packages/lesswrong/components/votes/withVote.ts
+++ b/packages/lesswrong/components/votes/withVote.ts
@@ -7,6 +7,7 @@ import { VoteableCollections } from '../../lib/make_voteable';
 import { getCollection, getFragmentText } from '../../lib/vulcan-lib';
 import * as _ from 'underscore';
 import { Random } from 'meteor/random';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const getVoteMutationQuery = (collection) => {
   return gql`
@@ -21,7 +22,13 @@ const getVoteMutationQuery = (collection) => {
   `
 }
 
-export const useVote = (collectionName: CollectionNameString) => {
+export const useVote = (document: any, collectionName: CollectionNameString): {
+  vote: any,
+  collection: any,
+  document: any,
+  baseScore: number,
+  voteCount: number,
+}=> {
   const messages = useMessages();
   const collection = getCollection(collectionName);
   const query = getVoteMutationQuery(collection);
@@ -49,5 +56,10 @@ export const useVote = (collectionName: CollectionNameString) => {
     }
   }, [messages, mutate]);
   
-  return vote;
+  const af = forumTypeSetting.get() === 'AlignmentForum'
+  return {
+    vote, collection, document,
+    baseScore: (af ? document.afBaseScore : document.baseScore) || 0,
+    voteCount: (af ? document.afVoteCount : document.voteCount) || 0,
+  };
 }

--- a/packages/lesswrong/components/votes/withVote.ts
+++ b/packages/lesswrong/components/votes/withVote.ts
@@ -48,5 +48,6 @@ export const useVote = (collectionName: CollectionNameString) => {
       messages.flash({ messageString: errorMessage });
     }
   }, [messages, mutate]);
+  
   return vote;
 }

--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -15,8 +15,7 @@ addVoteType('upvote', {power: 1, exclusive: true});
 addVoteType('downvote', {power: -1, exclusive: true});
 
 // Test if a user has voted on the client
-export const hasVotedClient = ({ document, voteType }) => {
-  const userVotes = document.currentUserVotes;
+export const hasVotedClient = ({ userVotes, voteType }) => {
   if (voteType) {
     return _.where(userVotes, { voteType }).length
   } else {
@@ -127,7 +126,7 @@ export const performVoteClient = ({ document, collection, voteType = 'upvote', u
 
   let voteOptions = {document, collection, voteType, user, voteId};
 
-  if (hasVotedClient({document, voteType})) {
+  if (hasVotedClient({userVotes: document.currentUserVotes, voteType})) {
     returnedDocument = cancelVoteClient(voteOptions);
     returnedDocument = runCallbacks(`votes.cancel.client`, returnedDocument, collection, user, voteType);
   } else {

--- a/packages/lesswrong/lib/voting/vote.ts
+++ b/packages/lesswrong/lib/voting/vote.ts
@@ -120,11 +120,6 @@ export const performVoteClient = ({ document, collection, voteType = 'upvote', u
   const collectionName = collection.options.collectionName;
   let returnedDocument;
 
-  // console.log('// voteOptimisticResponse')
-  // console.log('collectionName: ', collectionName)
-  // console.log('document:', document)
-  // console.log('voteType:', voteType)
-
   // make sure item and user are defined
   if (!document || !user || !Users.canDo(user, `${collectionName.toLowerCase()}.${voteType}`)) {
     throw new Error(`Cannot perform operation '${collectionName.toLowerCase()}.${voteType}'`);
@@ -133,15 +128,9 @@ export const performVoteClient = ({ document, collection, voteType = 'upvote', u
   let voteOptions = {document, collection, voteType, user, voteId};
 
   if (hasVotedClient({document, voteType})) {
-
-    // console.log('action: cancel')
     returnedDocument = cancelVoteClient(voteOptions);
     returnedDocument = runCallbacks(`votes.cancel.client`, returnedDocument, collection, user, voteType);
-
   } else {
-
-    // console.log('action: vote')
-
     if (voteTypes[voteType].exclusive) {
       const tempDocument = runCallbacks(`votes.clear.client`, voteOptions.document, collection, user);
       voteOptions.document = clearVotesClient({document:tempDocument})
@@ -150,8 +139,6 @@ export const performVoteClient = ({ document, collection, voteType = 'upvote', u
     returnedDocument = addVoteClient(voteOptions);
     returnedDocument = runCallbacks(`votes.${voteType}.client`, returnedDocument, collection, user, voteType);
   }
-
-  // console.log('returnedDocument:', returnedDocument)
 
   return returnedDocument;
 }

--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -294,7 +294,7 @@ addCallback("comments.new.sync", CommentsNewUserApprovedStatus);
  // LESSWRONG – bigUpvote
 async function LWCommentsNewUpvoteOwnComment(comment) {
   var commentAuthor = Users.findOne(comment.userId);
-  const votedComment = await performVoteServer({ document: comment, voteType: 'smallUpvote', collection: Comments, user: commentAuthor })
+  const votedComment = commentAuthor && await performVoteServer({ document: comment, voteType: 'smallUpvote', collection: Comments, user: commentAuthor })
   return {...comment, ...votedComment};
 }
 addCallback('comments.new.after', LWCommentsNewUpvoteOwnComment);

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -86,7 +86,7 @@ addCallback("posts.new.sync", PostsNewDefaultTypes);
 // LESSWRONG – bigUpvote
 async function LWPostsNewUpvoteOwnPost(post) {
  var postAuthor = Users.findOne(post.userId);
- const votedPost = await performVoteServer({ document: post, voteType: 'bigUpvote', collection: Posts, user: postAuthor })
+ const votedPost = postAuthor && await performVoteServer({ document: post, voteType: 'bigUpvote', collection: Posts, user: postAuthor })
  return {...post, ...votedPost};
 }
 

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -83,7 +83,7 @@ addCallback("tag.update.after", async (newDoc, {oldDocument}) => {
 addCallback("tagRels.new.after", async (tagRel) => {
   // When you add a tag, vote for it as relevant
   var tagCreator = Users.findOne(tagRel.userId);
-  const votedTagRel = await performVoteServer({ document: tagRel, voteType: 'smallUpvote', collection: TagRels, user: tagCreator })
+  const votedTagRel = tagCreator && await performVoteServer({ document: tagRel, voteType: 'smallUpvote', collection: TagRels, user: tagCreator })
   updatePostDenormalizedTags(tagRel.postId);
   return {...tagRel, ...votedTagRel};
 });

--- a/packages/lesswrong/server/voteServer.ts
+++ b/packages/lesswrong/server/voteServer.ts
@@ -10,7 +10,11 @@ import * as _ from 'underscore';
 
 
 // Test if a user has voted on the server
-const hasVotedServer = async ({ document, voteType, user }) => {
+const hasVotedServer = async ({ document, voteType, user }: {
+  document: any,
+  voteType: string,
+  user: DbUser,
+}) => {
   const vote = await Connectors.get(Votes, {
     documentId: document._id,
     userId: user._id, voteType,
@@ -20,8 +24,14 @@ const hasVotedServer = async ({ document, voteType, user }) => {
 }
 
 // Add a vote of a specific type on the server
-const addVoteServer = async (voteOptions) => {
-  const { document, collection, voteType, user, voteId, updateDocument } = voteOptions;
+const addVoteServer = async ({ document, collection, voteType, user, voteId, updateDocument }: {
+  document: any,
+  collection: any,
+  voteType: string,
+  user: DbUser|null,
+  voteId: string,
+  updateDocument: boolean
+}) => {
   const newDocument = _.clone(document);
 
   // create vote and insert it
@@ -57,7 +67,12 @@ const addVoteServer = async (voteOptions) => {
 }
 
 // Clear all votes for a given document and user (server)
-const clearVotesServer = async ({ document, user, collection, updateDocument }) => {
+const clearVotesServer = async ({ document, user, collection, updateDocument }: {
+  document: any,
+  user: DbUser,
+  collection: any,
+  updateDocument: boolean,
+}) => {
   const newDocument = _.clone(document);
   const votes = await Connectors.find(Votes, {
     documentId: document._id,
@@ -112,8 +127,13 @@ const clearVotesServer = async ({ document, user, collection, updateDocument }) 
 }
 
 // Cancel votes of a specific type on a given document (server)
-export const cancelVoteServer = async ({ document, voteType, collection, user, updateDocument }) => {
-
+export const cancelVoteServer = async ({ document, voteType, collection, user, updateDocument }: {
+  document: any,
+  voteType: string,
+  collection: any,
+  user: DbUser,
+  updateDocument: boolean
+}) => {
   const newDocument = _.clone(document);
   const vote = Votes.findOne({
     documentId: document._id,
@@ -182,7 +202,7 @@ export const performVoteServer = async ({ documentId, document, voteType = 'bigU
   voteType: string,
   collection: any,
   voteId?: string,
-  user: any,
+  user: DbUser,
   updateDocument?: boolean,
   toggleIfAlreadyVoted?: boolean,
 }) => {
@@ -225,7 +245,7 @@ export const performVoteServer = async ({ documentId, document, voteType = 'bigU
   return document;
 }
 
-const getVotingRateLimits = async (user) => {
+const getVotingRateLimits = async (user: DbUser|null) => {
   if (user?.isAdmin) {
     // Very lax rate limiting for admins
     return {
@@ -243,7 +263,12 @@ const getVotingRateLimits = async (user) => {
 
 // Check whether a given vote would exceed voting rate limits, and if so, throw
 // an error. Otherwise do nothing.
-const checkRateLimit = async ({ document, collection, voteType, user }):Promise<void> => {
+const checkRateLimit = async ({ document, collection, voteType, user }: {
+  document: any,
+  collection: any,
+  voteType: string,
+  user: DbUser
+}): Promise<void> => {
   // No rate limit on self-votes
   if(document.userId === user._id)
     return;

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -23,13 +23,22 @@ addGraphQLMutation('vote(documentId: String, voteType: String, collectionName: S
 
 const voteResolver = {
   Mutation: {
+    // Voting mutation. Voting toggles, like the vote button UI: if the given
+    // vote type is different from the user's previous vote, change to the new
+    // vote type, but if it's the same as the user's previous vote, cancel that
+    // vote.
+    //
+    // The voteId argument is ignored (we don't actually want to give clients
+    // control over database IDs), but still exists as an option for legacy
+    // compatibility.
     async vote(root, {documentId, voteType, collectionName, voteId}, context: ResolverContext) {
       const { currentUser } = context;
       const collection = context[collectionName];
       
+      if (!collection) throw new Error("Error casting vote: Invalid collectionName");
       if (!currentUser) throw new Error("Error casting vote: Not logged in.");
 
-      const document = await performVoteServer({documentId, voteType, collection, voteId, user: currentUser});
+      const document = await performVoteServer({documentId, voteType, collection, user: currentUser});
       return document;
     },
   },

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -24,13 +24,13 @@ addGraphQLMutation('vote(documentId: String, voteType: String, collectionName: S
 const voteResolver = {
   Mutation: {
     async vote(root, {documentId, voteType, collectionName, voteId}, context: ResolverContext) {
-      
       const { currentUser } = context;
       const collection = context[collectionName];
+      
+      if (!currentUser) throw new Error("Error casting vote: Not logged in.");
 
       const document = await performVoteServer({documentId, voteType, collection, voteId, user: currentUser});
       return document;
-
     },
   },
 };

--- a/packages/lesswrong/server/votingGraphQL.ts
+++ b/packages/lesswrong/server/votingGraphQL.ts
@@ -23,14 +23,16 @@ addGraphQLMutation('vote(documentId: String, voteType: String, collectionName: S
 
 const voteResolver = {
   Mutation: {
-    // Voting mutation. Voting toggles, like the vote button UI: if the given
-    // vote type is different from the user's previous vote, change to the new
-    // vote type, but if it's the same as the user's previous vote, cancel that
-    // vote.
+    // vote: Voting mutation. Voting toggles, like the vote button UI: if the
+    // given vote type is different from the user's previous vote, change to the
+    // new vote type, but if it's the same as the user's previous vote, cancel
+    // that vote.
     //
     // The voteId argument is ignored (we don't actually want to give clients
     // control over database IDs), but still exists as an option for legacy
     // compatibility.
+    //
+    // Returns the document that was voted upon, with its score updated.
     async vote(root, {documentId, voteType, collectionName, voteId}, context: ResolverContext) {
       const { currentUser } = context;
       const collection = context[collectionName];


### PR DESCRIPTION
Voting on comments on a post-page with a lot of comments was very slow. On a 500-comment post, clicking a vote button could cause 4+ seconds of script execution time, giving noticeably bad responsiveness and also kind of breaking the strong-vote interaction. The reason for this was that voting triggered two rerenders of every comment. When you clicked the vote button, it would first do an optimistic-response, and rerender every comment with one of the comments having a different `currentUserVotes`; then the response to the query would come back, and it would rerender every comment *again*. There were some hacky attempts to fix this in the past, based around using `shouldComponentUpdate` to ignore prop changes that might be spurious, but they broke at some point and are pretty doomed in-general.

I observed that dropping the Apollo `optimisticResponse` eliminated both rerenders, and decided the best way to fix it was to not use Apollo's optimistic response at all, but instead make something out of React state which has the same effect. This completely eliminated both rerenders, making comment-voting fast again.

A very trivial downside of this is that, on posts which have two sets of vote buttons, when you vote with the top buttons the state of the bottom ones doesn't update until the server response comes back, and vise versa, where before it was updated client side.

Best reviewed commit-by-commit. All commits except the last one are refactoring commits, to make the change easier; the last one makes the change that actually speeds things up.