### PR TITLE
[HOTFIX] Fix crash in post page sequence nav links

### DIFF
--- a/packages/lesswrong/components/sequences/BottomNavigation.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigation.tsx
@@ -1,6 +1,7 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
+import withErrorBoundary from '../common/withErrorBoundary'
 import classnames from 'classnames';
 
 const styles = theme => ({
@@ -92,7 +93,10 @@ const BottomNavigation = ({post, classes}: {
 };
 
 
-const BottomNavigationComponent = registerComponent('BottomNavigation', BottomNavigation, {styles});
+const BottomNavigationComponent = registerComponent('BottomNavigation', BottomNavigation, {
+  styles,
+  hocs: [withErrorBoundary]
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import classnames from 'classnames';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import { Posts } from '../../lib/collections/posts/collection';
-import { useNavigation } from '../../lib/routeUtil';
 import { useUpdateContinueReading } from './useUpdateContinueReading';
 import { Link } from '../../lib/reactRouterWrapper';
 
@@ -67,7 +66,6 @@ const BottomNavigationItem = ({direction, post, sequence, classes}: {
   sequence: HasIdType,
   classes: ClassesType,
 }) => {
-  const { history } = useNavigation();
   const updateContinueReading = useUpdateContinueReading(post._id, sequence?._id);
   const { LoginPopupButton } = Components
   const commentCount = post.commentCount || "No"

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
@@ -5,6 +5,7 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import { Posts } from '../../lib/collections/posts/collection';
 import { useNavigation } from '../../lib/routeUtil';
 import { useUpdateContinueReading } from './useUpdateContinueReading';
+import { Link } from '../../lib/reactRouterWrapper';
 
 const styles = theme => ({
   root: {
@@ -67,17 +68,14 @@ const BottomNavigationItem = ({direction, post, sequence, classes}: {
   classes: ClassesType,
 }) => {
   const { history } = useNavigation();
-  const updateContinueReading = useUpdateContinueReading(post._id, sequence._id);
+  const updateContinueReading = useUpdateContinueReading(post._id, sequence?._id);
   const { LoginPopupButton } = Components
   const commentCount = post.commentCount || "No"
+  const url = Posts.getPageUrl(post, false, sequence?._id);
   
   return (
     <span>
-      <a onClick={() => {
-        const url = Posts.getPageUrl(post, false, sequence?._id)
-        updateContinueReading();
-        history.push(url);
-      }}>
+      <Link onClick={() => updateContinueReading()} to={url}>
         <div className={classnames(
           classes.root,
           { [classes.previous]: direction==="Previous" }
@@ -89,7 +87,7 @@ const BottomNavigationItem = ({direction, post, sequence, classes}: {
             <span className={classes.metaEntry}>{post.baseScore} points</span>
           </div>
         </div>
-      </a>
+      </Link>
       {direction==="Next" && <span className={classes.login}>
         <LoginPopupButton title="LessWrong keeps track of what posts logged in users have read, so you can keep reading wherever you've left off">
             Log in to save where you left off

--- a/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
@@ -5,7 +5,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import NavigateBefore from '@material-ui/icons/NavigateBefore'
 import NavigateNext from '@material-ui/icons/NavigateNext'
 import React from 'react';
-import { useNavigation } from '../../lib/routeUtil';
 import { useUpdateContinueReading } from './useUpdateContinueReading';
 import classnames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
@@ -33,9 +32,8 @@ const SequencesNavigationLink = ({ post, direction, classes }: {
   direction: "left"|"right",
   classes: ClassesType,
 }) => {
-  const { history } = useNavigation();
   const updateContinueReading = useUpdateContinueReading(post?._id, post?.sequence?._id);
-  const url = Posts.getPageUrl(post, false, post.sequence?._id);
+  const url = Posts.getPageUrl(post, false, post?.sequence?._id);
   
   const icon = (
     <IconButton classes={{root: classnames(classes.root, {

--- a/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { useNavigation } from '../../lib/routeUtil';
 import { useUpdateContinueReading } from './useUpdateContinueReading';
 import classnames from 'classnames';
+import { Link } from '../../lib/reactRouterWrapper';
 
 // Shared with SequencesNavigationLinkDisabled
 export const styles = theme => ({
@@ -34,6 +35,7 @@ const SequencesNavigationLink = ({ post, direction, classes }: {
 }) => {
   const { history } = useNavigation();
   const updateContinueReading = useUpdateContinueReading(post?._id, post?.sequence?._id);
+  const url = Posts.getPageUrl(post, false, post.sequence?._id);
   
   const icon = (
     <IconButton classes={{root: classnames(classes.root, {
@@ -46,13 +48,9 @@ const SequencesNavigationLink = ({ post, direction, classes }: {
   
   if (post) {
     const button = (
-      <a onClick={() => {
-        const url = Posts.getPageUrl(post, false, post.sequence?._id)
-        updateContinueReading();
-        history.push(url);
-      }}>
+      <Link onClick={() => updateContinueReading()} to={url}>
         {icon}
-      </a>
+      </Link>
     )
     if (post.title) {
       return <Tooltip title={post.title}>{button}</Tooltip>

--- a/packages/lesswrong/components/sequences/useUpdateContinueReading.ts
+++ b/packages/lesswrong/components/sequences/useUpdateContinueReading.ts
@@ -10,8 +10,10 @@ export const useUpdateContinueReading = (postId: string, sequenceId: string): ()
   `);
   
   return useCallback(() => {
-    updateContinueReading({
-      variables: { postId, sequenceId }
-    });
+    if (postId && sequenceId) {
+      updateContinueReading({
+        variables: { postId, sequenceId }
+      });
+    }
   }, [updateContinueReading, postId, sequenceId]);
 }


### PR DESCRIPTION
Fix a crash on sequence pages, which would happen when a post has prev/next links to posts that don't have a canonical sequence. Also add an error boundary, and use `<Link>` instead of `<a>` because open-in-new-tab was broken.