### PR TITLE
Fix canonical url of user pages and others

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -14,7 +14,8 @@ const HeadTags = (props) => {
     const { currentRoute, pathname } = useSubscribedLocation();
     // The default url we want to use for our cannonical and og:url tags uses
     // the "base" path, site url and path without query or hash
-    const url = props.url || Utils.combineUrls(Utils.getSiteUrl(), Utils.getBasePath(pathname))
+    const url = Utils.combineUrls(Utils.getSiteUrl(), Utils.getBasePath(pathname))
+    const ogUrl = props.ogUrl || url
     const canonicalUrl = props.canonicalUrl || url
     const description = props.description || taglineSetting.get()
     const siteName = tabTitleSetting.get()
@@ -42,7 +43,7 @@ const HeadTags = (props) => {
 
           {/* facebook */}
           <meta property='og:type' content='article'/>
-          <meta property='og:url' content={url}/>
+          <meta property='og:url' content={ogUrl}/>
           {props.image && <meta property='og:image' content={props.image}/>}
           { /* <meta property='og:title' content={title}/> */ }
           <meta property='og:description' content={description}/>

--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -11,10 +11,12 @@ const tabTitleSetting = new PublicInstanceSetting<string>('forumSettings.tabTitl
 
 
 const HeadTags = (props) => {
-    const url = props.url || Utils.getSiteUrl();
+    const { currentRoute, pathname } = useSubscribedLocation();
+    // The default url we want to use for our cannonical and og:url tags uses
+    // the "base" path, site url and path without query or hash
+    const url = props.url || Utils.combineUrls(Utils.getSiteUrl(), Utils.getBasePath(pathname))
     const canonicalUrl = props.canonicalUrl || url
     const description = props.description || taglineSetting.get()
-    const { currentRoute, pathname } = useSubscribedLocation();
     const siteName = tabTitleSetting.get()
     
     const TitleComponent: any = currentRoute?.titleComponentName ? Components[currentRoute.titleComponentName] : null;

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -149,7 +149,7 @@ class AllPostsPage extends Component<AllPostsPageProps,AllPostsPageState> {
 
     return (
       <React.Fragment>
-        <HeadTags url={Utils.getSiteUrl() + "allPosts"} description={"All of LessWrong's posts, filtered and sorted however you want"}/>
+        <HeadTags description={"All of LessWrong's posts, filtered and sorted however you want"}/>
         <AnalyticsContext pageContext="allPostsPage">
           <SingleColumnSection>
             <Tooltip title={`${showSettings ? "Hide": "Show"} options for sorting and filtering`} placement="top-end">

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent, Utils } from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
 import React, { Component } from 'react';
 import { withLocation } from '../../lib/routeUtil';

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -140,13 +140,13 @@ class PostsPage extends Component<PostsPageProps> {
 
       const description = this.getDescription(post)
       const ogUrl = Posts.getPageUrl(post, true) // open graph
-      const canoncialUrl = post.canonicalSource || ogUrl
+      const canonicalUrl = post.canonicalSource || ogUrl
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>
             <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
               <HeadTags
-                ogUrl={ogUrl} canonicalUrl={canoncialUrl}
+                ogUrl={ogUrl} canonicalUrl={canonicalUrl}
                 title={post.title} description={description} noIndex={post.noIndex || !!commentId}
               />
               {/* Header/Title */}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -139,12 +139,14 @@ class PostsPage extends Component<PostsPageProps> {
       const commentId = query.commentId || params.commentId
 
       const description = this.getDescription(post)
+      const ogUrl = Posts.getPageUrl(post, true) // open graph
+      const canoncialUrl = post.canonicalSource || ogUrl
 
       return (
           <AnalyticsContext pageContext="postsPage" postId={post._id}>
             <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
               <HeadTags
-                url={Posts.getPageUrl(post, true)} canonicalUrl={post.canonicalSource}
+                ogUrl={ogUrl} canonicalUrl={canoncialUrl}
                 title={post.title} description={description} noIndex={post.noIndex || !!commentId}
               />
               {/* Header/Title */}

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerComponent, Components, Utils } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 // import { AnalyticsContext } from "../../lib/analyticsEvents";
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -494,7 +494,7 @@ const SpreadsheetPage = ({classes}:{
   const rows = currentTab?.rows || []
   return (
     <div className={classes.root}>
-      <HeadTags url={Utils.getSiteUrl() + "coronavirus-link-database"} image={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1585093292/Screen_Shot_2020-03-24_at_4.41.12_PM_qiwqwc.png"}/>
+      <HeadTags image={"https://res.cloudinary.com/lesswrong-2-0/image/upload/v1585093292/Screen_Shot_2020-03-24_at_4.41.12_PM_qiwqwc.png"}/>
       {selectedTab == "Intro" && 
         <div className={classes.introWrapper}>
           <div className={classes.intro}>

--- a/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationLog.tsx
@@ -159,4 +159,3 @@ declare global {
     ModerationLog: typeof ModerationLogComponent
   }
 }
-

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -459,12 +459,6 @@ addRoute(
     titleComponentName: 'TagPageTitle',
   },
   {
-    name:'coronavirus.link.db',
-    path:'/coronavirus-link-database',
-    componentName: 'SpreadsheetPage',
-    title: "COVID-19 Link Database"
-  },
-  {
     name: 'admin',
     path: '/admin',
     componentName: 'AdminHome',
@@ -480,7 +474,8 @@ addRoute(
     name: 'moderation',
     path: '/moderation',
     componentName: 'ModerationLog',
-    title: "Moderation Log"
+    title: "Moderation Log",
+    noIndex: true
   },
   {
     name: 'emailHistory',
@@ -618,6 +613,17 @@ switch (forumTypeSetting.get()) {
       },
     );
     break;
+}
+
+if (['AlignmentForum', 'LessWrong'].includes(forumTypeSetting.get())) {
+  addRoute(
+    {
+      name:'coronavirus.link.db',
+      path:'/coronavirus-link-database',
+      componentName: 'SpreadsheetPage',
+      title: "COVID-19 Link Database"
+    }
+  )
 }
 
 addRoute(

--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -25,6 +25,8 @@ interface UtilsType {
   slugify: (s: string) => string
   getDomain: (url: string) => string|null
   addHttp: (url: string) => string|null
+  combineUrls: (baseUrl: string, path: string) => string
+  getBasePath: (path: string) => string
   
   checkNested: any
   getNestedProperty: any
@@ -178,6 +180,19 @@ Utils.addHttp = function (url: string): string|null {
     return null;
   }
 };
+
+// Combine urls without extra /s at the join
+// https://stackoverflow.com/questions/16301503/can-i-use-requirepath-join-to-safely-concatenate-urls
+Utils.combineUrls = (baseUrl: string, path:string) => {
+  return path
+    ? baseUrl.replace(/\/+$/, '') + '/' + path.replace(/^\/+/, '')
+    : baseUrl;
+}
+
+// Remove query and anchor tags from path
+Utils.getBasePath = (path: string) => {
+  return path.split(/[?#]/)[0]
+}
 
 /////////////////////////////
 // String Helper Functions //


### PR DESCRIPTION
The default canonical url should not be the homepage, but should not just be the currently-visited url. It should use the "base" path without the query or hash. With this change we don't need the `url` prop any more, so we remove it and its usages. PostsPage does do some fancy customization, so we add the `ogUrl` prop to prevent regression.

Additionally:
* Add `noindex` to moderation log to compensate for its loss of a cannonical url to the homepage
* Add some utility functions for URL manipulation
* Move the coronavirus link database route behind a LW-AF-only conditional.