### PR TITLE
Fix crash when deleting comments

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/commentCallbacks.ts
@@ -185,9 +185,9 @@ addCallback('comments.new.validate', CommentsNewRateLimit);
 // LessWrong callbacks                              //
 //////////////////////////////////////////////////////
 
-function CommentsEditSoftDeleteCallback (comment, oldComment) {
+function CommentsEditSoftDeleteCallback (comment, oldComment, currentUser) {
   if (comment.deleted && !oldComment.deleted) {
-    runCallbacksAsync('comments.moderate.async', comment);
+    runCallbacksAsync('comments.moderate.async', comment, oldComment, {currentUser});
   }
 }
 addCallback("comments.edit.async", CommentsEditSoftDeleteCallback);


### PR DESCRIPTION
Fixes a crash introduced in https://github.com/LessWrong2/Lesswrong2/pull/3261 , which changed the type signature of `comments.moderate.async` without changing the call in `CommentsEditSoftDeleteCallback`. This crash shows up in unit tests, but the exception gets printed and swallowed without actually making the test fail. 