### PR TITLE
RecentDiscussion Link Post Message

### DIFF
--- a/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
@@ -136,7 +136,7 @@ const RecentDiscussionThread = ({
     [setHighlightVisible, highlightVisible, markAsRead]
   );
   
-  const { ContentItemBody, PostsItemMeta, ShowOrHideHighlightButton, CommentsNode, PostsHighlight } = Components
+  const { ContentItemBody, PostsItemMeta, ShowOrHideHighlightButton, CommentsNode, PostsHighlight, LinkPostMessage } = Components
 
   const lastCommentId = comments && comments[0]?._id
   const nestedComments = unflattenComments(comments);
@@ -149,9 +149,10 @@ const RecentDiscussionThread = ({
     return null
   }
 
-  const highlightClasses = classNames(classes.highlight, {
+  const highlightClasses = classNames(classes.highlight, classes.postHighlight, {
     [classes.noComments]: post.commentCount === null
   })
+
   return (
     <div className={classes.root}>
       <div className={classes.post}>
@@ -171,12 +172,12 @@ const RecentDiscussionThread = ({
             <PostsHighlight post={post} />
           </div>
           : <div className={highlightClasses} onClick={showHighlight}>
-              { showSnippet &&
+              { showSnippet && <>
+                <LinkPostMessage post={post} noMargin />
                 <ContentItemBody
-                  className={classes.postHighlight}
                   dangerouslySetInnerHTML={{__html: postExcerptFromHTML(post.contents.htmlHighlight)}}
                   description={`post ${post._id}`}
-                />
+                /></>
               }
             </div>
         }

--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -1,23 +1,28 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import { Posts } from '../../lib/collections/posts';
 import React from 'react';
+import classNames from 'classnames';
 
 const styles = theme => ({
   root: {
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle
   },
+  noMargin: {
+    marginBottom: 0
+  }
 })
 
-const LinkPostMessage = ({post, classes}: {
+const LinkPostMessage = ({post, classes, noMargin}: {
   post: PostsBase,
-  classes: ClassesType
+  classes: ClassesType,
+  noMargin?: boolean
 }) => {
   if (!post.url)
     return null;
 
   return (
-    <div className={classes.root}>
+    <div className={classNames(classes.root, {[classes.noMargin]:noMargin})}>
       This is a linkpost for <a href={Posts.getLink(post)} target={Posts.getLinkTarget(post)}>{post.url}</a>
     </div>
   );


### PR DESCRIPTION
On unread linkposts, previously, it had just had an awkward space where the "Link Post" message was supposed to be. Now it appears:

![image](https://user-images.githubusercontent.com/3246710/86507325-4b065a00-bd8c-11ea-824c-f0bcf380850b.png)
