### PR TITLE
Add Filter Button is more clickable

### DIFF
--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -21,7 +21,7 @@ const styles = theme => ({
 const AddTagButton = ({onTagSelected, classes, children}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
   classes: ClassesType,
-  children: any
+  children?: any
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -11,20 +11,23 @@ const styles = theme => ({
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
     display: "inline-block",
-    textAlign: "center",
-    paddingLeft: 4
+    textAlign: "center"
   },
+  defaultButton: {
+    paddingLeft: 4
+  }
 });
 
-const AddTagButton = ({onTagSelected, classes, smallVariant}: {
+const AddTagButton = ({onTagSelected, classes, children}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
   classes: ClassesType,
-  smallVariant?: boolean
+  children: any
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking()
+  const { LWPopper, AddTag } = Components
 
   if (!userCanUseTags(currentUser)) {
     return null;
@@ -36,11 +39,11 @@ const AddTagButton = ({onTagSelected, classes, smallVariant}: {
       setIsOpen(true);
       captureEvent("addTagClicked")
     }}
-    className={smallVariant ? classes.small : classes.addTagButton}
+    className={classes.addTagButton}
   >
-    {smallVariant ? "+" : "+ Add Tag"}
+    {children ? children : <span className={classes.defaultButton}>+ Add Tag</span>}
 
-    <Components.LWPopper
+    <LWPopper
       open={isOpen}
       anchorEl={anchorEl}
       placement="bottom-start"
@@ -54,7 +57,7 @@ const AddTagButton = ({onTagSelected, classes, smallVariant}: {
         onClickAway={() => setIsOpen(false)}
       >
         <Paper>
-          <Components.AddTag
+          <AddTag
             onTagSelected={({tagId, tagName}: {tagId: string, tagName: string}) => {
               setAnchorEl(null);
               setIsOpen(false);
@@ -63,7 +66,7 @@ const AddTagButton = ({onTagSelected, classes, smallVariant}: {
           />
         </Paper>
       </ClickAwayListener>
-    </Components.LWPopper>
+    </LWPopper>
   </a>;
 }
 

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -143,8 +143,8 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
       }}
     />
 
-    {<LWTooltip title="Add Tag Filter" className={classes.addButton}>
-        <AddTagButton smallVariant onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {
+    {<LWTooltip title="Add Tag Filter">
+        <AddTagButton onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {
           if (!_.some(filterSettings.tags, t=>t.tagId===tagId)) {
             const newFilter: FilterTag = {tagId, tagName, filterMode: "Default"}
             setFilterSettings({
@@ -153,7 +153,9 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
             });
             captureEvent("tagAddedToFilters", {tagId, tagName})
           }
-        }}/>
+        }}>
+          <span className={classes.addButton}>+</span>
+        </AddTagButton>
     </LWTooltip>}
   </span>
 }


### PR DESCRIPTION
Previously, if you clicked the frontpage "add tag" button in the gap between the "+" and the edge of the button, nothing would happen. This expands the click-target to match the obvious UI intuitions.