### PR TITLE
Steamline Tag Hover Previews

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -8,7 +8,7 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { Link } from '../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-export const POST_PREVIEW_WIDTH = 435
+export const POST_PREVIEW_WIDTH = 400
 
 export const highlightStyles = theme => ({
   ...postHighlightStyles(theme),

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -39,6 +39,7 @@ const styles = theme => ({
     paddingTop: 12,
     paddingRight: 16,
     width: 500,
+    marginBottom: -4,
     ...theme.typography.commentStyle,
     [theme.breakpoints.down('xs')]: {
       width: "calc(100% - 32px)",

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { FilterMode } from '../../lib/filterSettings';
 import classNames from 'classnames';
@@ -26,8 +26,8 @@ const styles = theme => ({
   },
   description: {
     ...commentBodyStyles(theme),
-    padding: theme.spacing*2,
-    paddingtop: 20
+    margin: theme.spacing*2,
+    marginTop: 20
   },
   filterScore: {
     color: theme.palette.primary.dark,
@@ -36,9 +36,8 @@ const styles = theme => ({
   },
   filtering: {
     paddingLeft: 16,
-    paddingTop: 16,
+    paddingTop: 12,
     paddingRight: 16,
-    width: 600,
     ...theme.typography.commentStyle,
     [theme.breakpoints.down('xs')]: {
       width: "calc(100% - 32px)",
@@ -46,30 +45,48 @@ const styles = theme => ({
   },
   filterRow: {
     display: "flex",
-    justifyContent: "space-between"
+    justifyContent: "flex-start",
+    paddingBottom: 2,
+    paddingLeft: 2,
+    paddingRight: 2
   },
   filterLabel: {
-    ...theme.typography.commentStyle,
     color: theme.palette.grey[600]
   },
+  removeLabel: {
+    color: theme.palette.grey[600],
+    flexGrow: 1,
+    textAlign: "right"
+  },
   filterButton: {
-    marginTop: 8,
-    marginRight: 8,
-    padding: 4,
-    paddingLeft: 8,
-    paddingRight: 8,
+    marginRight: 16,
+    color: theme.palette.grey[500],
     ...theme.typography.smallText,
     display: "inline-block",
     cursor: "pointer",
-    borderRadius: 2,
-    border: "solid 1px rgba(0,0,0,.1)",
   },
   label: {
     marginRight: "auto"
   },
   selected: {
+    color: "black",
     backgroundColor: "rgba(0,0,0,.1)",
-    border: "none"
+    padding: 4,
+    paddingLeft: 8,
+    paddingRight: 8,
+    marginTop: -4,
+    marginBottom: -4,
+    borderRadius: 2,
+  },
+  filterInput: {
+    width: 50,
+    borderBottom: "none"
+  },
+  input: {
+    padding: 0,
+    paddingBottom: 2,
+    "-webkit-appearance": "none",
+    "-moz-appearance": "textfield"
   }
 });
 
@@ -108,7 +125,7 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
       </Link>
       : tagLabel
       }
-      <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom"
+      <PopperCard open={!!hover} anchorEl={anchorEl} placement="bottom-start"
         modifiers={{
           flip: {
             behavior: ["bottom-start", "top-end", "bottom-start"],
@@ -118,17 +135,6 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
       >
         <div className={classes.filtering}>
           <div className={classes.filterRow}>
-            <div className={classes.filterLabel}>
-              Set Filter
-            </div>
-            {canRemove &&
-              <div className={classes.filterLabel} onClick={ev => {if (onRemove) onRemove()}}>
-                <LWTooltip title={<div><div>This filter will no longer appear in Latest Posts.</div><div>You can add it back later if you want</div></div>}>
-                  <a>Remove Filter</a>
-                </LWTooltip>
-              </div>}
-          </div>
-          <div>
             <LWTooltip title={filterModeToTooltip("Hidden")}>
               <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Hidden"})} onClick={ev => onChangeMode("Hidden")}>
                 Hidden
@@ -164,7 +170,22 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
                 Required
               </span>
             </LWTooltip>
-            <Input placeholder="Other" type="number" defaultValue={otherValue} onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}/>
+            <Input 
+              className={classes.filterInput} 
+              placeholder="Other" 
+              type="number" 
+              disableUnderline
+              classes={{input:classes.input}}
+              defaultValue={otherValue} 
+
+              onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}
+            />
+            {canRemove &&
+              <div className={classes.removeLabel} onClick={ev => {if (onRemove) onRemove()}}>
+                <LWTooltip title={<div><div>This filter will no longer appear in Latest Posts.</div><div>You can add it back later if you want</div></div>}>
+                  <a>Remove</a>
+                </LWTooltip>
+              </div>}
           </div>
           {description && <div className={classes.description}>
             {description}
@@ -176,20 +197,20 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
   </span>
 }
 
-function filterModeToTooltip(mode: FilterMode): string {
+function filterModeToTooltip(mode: FilterMode): React.ReactNode {
   switch (mode) {
     case "Required":
-      return "ONLY posts with this tag will appear in Latest Posts."
+      return <div><em>Required.</em> ONLY posts with this tag will appear in Latest Posts.</div>
     case "Hidden":
-      return "Posts with this tag will be not appear in Latest Posts."
+      return <div><em>Hidden.</em> Posts with this tag will be not appear in Latest Posts.</div>
     case 0:
     case "Default":
-      return "This tag will be ignored for filtering and sorting."
+      return <div><em>+0.</em> This tag will be ignored for filtering and sorting.</div>
     default:
       if (mode<0)
-        return `These posts will be shown less often (as though their score were ${-mode} points lower).`
+        return <div><em>-{mode}.</em> These posts will be shown less often (as though their score were {-mode} points lower).</div>
       else
-        return `These posts will be shown more often (as though their score were ${mode} points higher).`
+        return <div><em>+{mode}.</em> These posts will be shown more often (as though their score were {mode} points higher).</div>
   }
 }
 

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { FilterMode } from '../../lib/filterSettings';
 import classNames from 'classnames';
@@ -38,6 +38,7 @@ const styles = theme => ({
     paddingLeft: 16,
     paddingTop: 12,
     paddingRight: 16,
+    width: 500,
     ...theme.typography.commentStyle,
     [theme.breakpoints.down('xs')]: {
       width: "calc(100% - 32px)",
@@ -49,9 +50,6 @@ const styles = theme => ({
     paddingBottom: 2,
     paddingLeft: 2,
     paddingRight: 2
-  },
-  filterLabel: {
-    color: theme.palette.grey[600]
   },
   removeLabel: {
     color: theme.palette.grey[600],
@@ -65,9 +63,6 @@ const styles = theme => ({
     display: "inline-block",
     cursor: "pointer",
   },
-  label: {
-    marginRight: "auto"
-  },
   selected: {
     color: "black",
     backgroundColor: "rgba(0,0,0,.1)",
@@ -78,13 +73,10 @@ const styles = theme => ({
     marginBottom: -4,
     borderRadius: 2,
   },
-  filterInput: {
-    width: 50,
-    borderBottom: "none"
-  },
   input: {
     padding: 0,
     paddingBottom: 2,
+    width: 50,
     "-webkit-appearance": "none",
     "-moz-appearance": "textfield"
   }

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -12,7 +12,7 @@ const styles = theme => ({
     paddingLeft: 16,
     paddingRight: 16,
     paddingBottom: 6,
-    width: 600,
+    width: 500,
     [theme.breakpoints.down('xs')]: {
       width: "100%",
     }
@@ -42,10 +42,8 @@ const styles = theme => ({
     marginBottom: 2,
     marginRight: 6
   },
-  smallPost: {
-    ...theme.typography.commentStyle,
-    ...theme.typography.smallText,
-    color: theme.palette.grey[600]
+  posts: {
+    marginTop: 20,
   }
 });
 
@@ -56,7 +54,7 @@ const TagPreview = ({tag, classes, showCount=true}: {
   classes: ClassesType,
   showCount?: boolean
 }) => {
-  const { TagPreviewDescription, PostsItem2, PostsListPlaceholder } = Components;
+  const { TagPreviewDescription, TagSmallPostLink, Loading } = Components;
   const { results } = useMulti({
     skip: !(tag?._id),
     terms: {
@@ -73,13 +71,11 @@ const TagPreview = ({tag, classes, showCount=true}: {
 
   return (<div className={classes.card}>
     <TagPreviewDescription tag={tag}/>
-    {!results && <PostsListPlaceholder count={previewPostCount} />}
-    {results && results.map((result,i) =>
-      <PostsItem2 key={result.post._id} post={result.post} index={i} showBottomBorder={showCount || i!=2}/>
-    )}
-    {/* {!showPosts && results && results.map((result, i) => {
-      return <span key={result.post._id} className={classes.smallPost}>{result.post.title}, </span>
-    })} */}
+    <div className={classes.posts}>
+      {results ? results.map((result,i) =>
+        <TagSmallPostLink key={result.post._id} post={result.post} />
+      ) : <Loading /> }
+    </div>
     {showCount && <div className={classes.footerCount}>
       <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>
     </div>}

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -7,7 +7,12 @@ import { Posts } from '../../lib/collections/posts';
 const styles = theme => ({
   root: {
     display: "flex",
-    marginBottom: 2,
+    ...theme.typography.body2,
+    ...theme.typography.postStyle,
+    color: theme.palette.grey[700], 
+    lineHeight: "1.1em",
+    marginTop: 8,
+    marginBottom: 8
   },
 });
 

--- a/packages/lesswrong/themes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/lesswrongTheme.ts
@@ -128,7 +128,6 @@ const theme = createLWTheme({
     MuiCard: {
       root: {
         borderRadius: 1,
-        border: `solid 1px rgba(0,0,0,.2)`,
         boxShadow: "0 0 10px rgba(0,0,0,.2)",
       }
     }


### PR DESCRIPTION
(this inadvertently fixes the "tag previews don't always go away when you mouseLeave" bug, by virtue of moving the post-hover off to the side instead of underneath. But it doesn't solve the underlying problem with that bug, and is mostly focused on making the tag previews simpler to look at)

![image](https://user-images.githubusercontent.com/3246710/86840543-b172cd00-c057-11ea-9fad-ab8de6f4606e.png)
