### PR TITLE
fix word wrap on all tags

### DIFF
--- a/packages/lesswrong/components/tagging/TagsListItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsListItem.tsx
@@ -10,8 +10,8 @@ const styles = theme => ({
     paddingTop: 3,
     paddingBottom: 3,
     paddingLeft: 6,
-    whiteSpace: "nowrap",
     ...theme.typography.smallText,
+
   },
   count: {
     color: theme.palette.grey[500],


### PR DESCRIPTION
Previously, long tags looked ugly on the /tags/all page. Now they look pretty natural:

![image](https://user-images.githubusercontent.com/3246710/86859055-b09d6380-c076-11ea-90b6-4fe56213b3b4.png)
