### PR TITLE
Tags can manually set truncation count

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -124,7 +124,7 @@ const TagPage = ({classes}: {
     captureEvent("readMoreClicked", {tagId: tag._id, tagName: tag.name, pageSectionContext: "wikiSection"})
   }
 
-  const description = truncated ? truncate(tag.description?.html, 1400, "characters", "... <a>(Read More)</a>") : tag.description?.html
+  const description = truncated ? truncate(tag.description?.html, tag.descriptionTruncationCount || 4, "paragraphs", "<a>(Read More)</a>") : tag.description?.html
 
   return <AnalyticsContext
     pageContext='tagPage'

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -11,6 +11,7 @@ registerFragment(`
     adminOnly
     defaultOrder
     suggestedAsFilter
+    descriptionTruncationCount
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -87,6 +87,15 @@ export const schema = {
     group: formGroups.advancedOptions,
     ...schemaDefaultValue(0),
   },
+  descriptionTruncationCount: {
+    // number of paragraphs to display above-the-fold
+    type: Number,
+    viewableBy: ['guests'],
+    insertableBy: ['admins', 'sunshineRegiment'],
+    editableBy: ['admins', 'sunshineRegiment'],
+    group: formGroups.advancedOptions,
+    ...schemaDefaultValue(0),
+  },
   postCount: {
     ...denormalizedCountOfReferences({
       fieldName: "postCount",

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -402,6 +402,7 @@ interface DbTag extends DbObject {
   core: boolean
   suggestedAsFilter: boolean
   defaultOrder: number
+  descriptionTruncationCount: number
   postCount: number
   userId: string
   adminOnly: boolean

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -576,6 +576,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly core: boolean,
   readonly suggestedAsFilter: boolean,
   readonly defaultOrder: number,
+  readonly descriptionTruncationCount: number,
   readonly postCount: number,
   readonly userId: string,
   readonly adminOnly: boolean,
@@ -1427,6 +1428,7 @@ interface TagBasicInfo { // fragment on Tags
   readonly adminOnly: boolean,
   readonly defaultOrder: number,
   readonly suggestedAsFilter: boolean,
+  readonly descriptionTruncationCount: number,
 }
 
 interface TagFragment extends TagBasicInfo { // fragment on Tags


### PR DESCRIPTION
This sets Tag Page truncation to be based on paragraphs instead of characters, and lets you manually specify the paragraph count.