### PR TITLE
Remove sketchy localStorage usage from vulcan-accounts

### DIFF
--- a/packages/lesswrong/components/vulcan-accounts/LoginFormInner.tsx
+++ b/packages/lesswrong/components/vulcan-accounts/LoginFormInner.tsx
@@ -274,7 +274,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
         break;
     }
     this.setState({ [field]: value });
-    this.setDefaultFieldValues({ [field]: value });
   }
 
   fields() {
@@ -534,21 +533,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
   }
 
   /**
-   * Helper to store field values while using the form.
-   */
-  setDefaultFieldValues(defaults) {
-    if (typeof defaults !== 'object') {
-      throw new Error('Argument to setDefaultFieldValues is not of type object');
-    } else if (typeof localStorage !== 'undefined' && localStorage) {
-      localStorage.setItem('accounts_ui', JSON.stringify({
-        passwordSignupFields: passwordSignupFields(),
-        ...this.getDefaultFieldValues(),
-        ...defaults,
-      }));
-    }
-  }
-
-  /**
    * Helper to get field values when switching states in the form.
    */
   getDefaultFieldValues() {
@@ -560,24 +544,8 @@ export class AccountsLoginFormInner extends TrackerComponent {
         defaultFieldValues[customSignupFields[i].id] = customSignupFields[i].defaultValue;
       }
     }
-    if (typeof localStorage !== 'undefined' && localStorage) {
-      const savedDefaultFieldValues = JSON.parse(localStorage.getItem('accounts_ui') || "null");
-      if (savedDefaultFieldValues
-        && savedDefaultFieldValues.passwordSignupFields === passwordSignupFields()) {
-        defaultFieldValues = {...defaultFieldValues, ...savedDefaultFieldValues};
-      }
-    }
     
     return defaultFieldValues;
-  }
-
-  /**
-   * Helper to clear field values when signing in, up or out.
-   */
-  clearDefaultFieldValues() {
-    if (typeof localStorage !== 'undefined' && localStorage) {
-      localStorage.removeItem('accounts_ui');
-    }
   }
 
   switchToSignUp(event) {
@@ -649,7 +617,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
       // });
       this.state.onSignedOutHook();
       this.clearMessages();
-      this.clearDefaultFieldValues();
     });
   }
 
@@ -716,7 +683,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
               if (!error) {
                 loginResultCallback(() => this.state.onSignedInHook(this.props));
                 self.props.handlers.switchToProfile();
-                self.clearDefaultFieldValues();
               } else {
                 //eslint-disable-next-line no-console
                 console.error(error)
@@ -734,7 +700,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
           //   formState: STATES.PROFILE,
           //   password: null,
           // });
-          self.clearDefaultFieldValues();
         }
       });
     }
@@ -798,7 +763,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
       } else {
         self.props.handlers.switchToProfile();
         // this.setState({ formState: STATES.PROFILE });
-        self.clearDefaultFieldValues();
         loginResultCallback(() => {
           Meteor.setTimeout(() => this.state.onSignedInHook(this.props), 100);
         });
@@ -896,7 +860,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
           // self.setState({ formState: STATES.PROFILE, password: null });
           let currentUser = Accounts.user();
           loginResultCallback(self.state.onPostSignUpHook.bind(self, _options, currentUser));
-          self.clearDefaultFieldValues();
         }
 
         self.setState({ waiting: false });
@@ -942,7 +905,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
         }
         else {
           this.showMessage('accounts.info_email_sent', 'success', 5000);
-          this.clearDefaultFieldValues();
         }
         onSubmitHook(error, formState);
         this.setState({ waiting: false });
@@ -996,7 +958,6 @@ export class AccountsLoginFormInner extends TrackerComponent {
           onSubmitHook(null, formState);
           this.props.handlers.switchToProfile();
           // this.setState({ formState: STATES.PROFILE });
-          this.clearDefaultFieldValues();
         }
       });
     }


### PR DESCRIPTION
Vulcan-Accounts (inherited via Vulcan, but originally written by studiointeract) is spaghetti code. An important user is having the login form crash on open; we can't reproduce it locally, while for him it reproduces consistently even after refresh and even in incognito windows.

Vulcan-Accounts uses localStorage, but not for any good reason; it saves partially-filled-in new-account forms, which is pointless since our new-account form only has username, password and email fields. But localStorage creates the possibility of weird-broken data *in* localStorage, which is not a possibility we want. So, rip out all usages of localStorage by vulcan-accounts. This is kind of a longshot for the bug itself, but worth ruling out as a cause of the current problem and as a source of future problems.