### PR TITLE
shortform submit styling

### DIFF
--- a/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
+++ b/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
@@ -4,8 +4,11 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = theme => ({
   root: {
-    marginLeft: 12,
-    marginRight: 12
+    paddingLeft: 12,
+    paddingRight: 12,
+    background: "white",
+    border: `solid 1px ${theme.palette.commentBorderGrey}`,
+    borderRadius: 3
   }
 }) 
 


### PR DESCRIPTION
Changes shortform form style to match comments (instead of weirdly grey)

![image](https://user-images.githubusercontent.com/3246710/86990624-d5b2d480-c151-11ea-81ad-1e5ecfad26ed.png)
