### PR TITLE
Change Layout Grid to center non-admin-users

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -78,7 +78,7 @@ const styles = theme => ({
       minmax(0, min-content)
       minmax(0, 1fr)
       minmax(0, 765px)
-      minmax(0, 1.25fr)
+      minmax(0, 1.4fr)
       minmax(0, min-content)
     `,
     },


### PR DESCRIPTION
I think it's just necessary to have it closer to the center on smaller screens. I changed it to 1.4 (still slightly better than 1.5 like it used to be on larger screens. @Discordius if you know how to get it to work nicely at multiple screen sizes feel free to change more)