### PR TITLE
Cancel Vote button

### DIFF
--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useVote } from '../votes/withVote';
+import { hasVotedClient } from '../../lib/voting/vote';
 
 const styles = theme => ({
   relevance: {
-    marginTop: 12,
+    marginTop: 2,
     marginLeft: 16,
     ...theme.typography.commentStyle,
   },
@@ -19,6 +20,16 @@ const styles = theme => ({
   score: {
     marginLeft: 4,
     marginRight: 4,
+  },
+  removeButton: {
+    float: "right",
+    marginTop: 12
+  },
+  removed: {
+    float: "right",
+    marginTop: 12,
+    marginRight: 16,
+    color: theme.palette.grey[400]
   }
 });
 
@@ -28,14 +39,17 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
   relevance?: boolean
 }) => {
   const voteProps = useVote(tagRel, "TagRels");
-  const { VoteButton, TagPreview } = Components;
+  const newlyVoted = !!(hasVotedClient({userVotes: voteProps.document.currentUserVotes, voteType: "smallUpvote"}) && voteProps.voteCount === 1)
+
+  const { TagPreview, VoteButton, TagRelevanceButton, LWTooltip } = Components;
   
   return <div>
     <div className={classes.relevance}>
-      <span className={classes.relevanceLabel}>
-        Relevance
-      </span>
-      
+      <LWTooltip title="How relevant is this tag to this post?" placement="top">
+        <span className={classes.relevanceLabel}>
+          Relevance
+        </span>
+      </LWTooltip>
       <div className={classes.voteButton}>
         <VoteButton
           orientation="left"
@@ -55,6 +69,12 @@ const TagRelCard = ({tagRel, classes, relevance=true}: {
           {...voteProps}
         />
       </div>
+      {newlyVoted && <span className={classes.removeButton}>
+        <LWTooltip title={"Remove your relevance vote from this tag"} placement="top">
+          <TagRelevanceButton label="Remove Tag" {...voteProps} voteType="smallUpvote" cancelVote/>
+        </LWTooltip>
+      </span>}
+      {voteProps.baseScore <= 0 && <span className={classes.removed}>Removed (refresh page)</span>}
     </div>
     <TagPreview tag={tagRel.tag}/>
   </div>

--- a/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
+++ b/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
@@ -1,0 +1,67 @@
+import { registerComponent } from '../../lib/vulcan-lib';
+import React from 'react';
+import classNames from 'classnames';
+import { hasVotedClient } from '../../lib/voting/vote';
+
+import { useDialog } from '../common/withDialog';
+import { useTracking } from '../../lib/analyticsEvents';
+import { useCurrentUser } from '../common/withUser';
+import { TagRels } from '../../lib/collections/tagRels/collection';
+
+const styles = theme => ({
+  root: {
+    ...theme.typography.body2,
+    ...theme.typography.commentStyle,
+    ...theme.typography.smallText,
+    marginRight: 16,
+    color: theme.palette.grey[600]
+  },
+  voted: {
+    color: theme.palette.grey[400]
+  }
+})
+
+const TagRelevanceButton = ({document, voteType, vote, label, classes, cancelVote }: {
+  document: TagRelMinimumFragment,
+  voteType: string,
+  vote: any,
+  label: React.ReactNode,
+  classes: ClassesType,
+  cancelVote?: boolean // if this is set, the styling for the voted/non-voted status will be inverted (i.e. you click the button to cancel an existing vote)
+}) => {
+  const currentUser = useCurrentUser();
+
+  const { openDialog } = useDialog();
+  const { captureEvent } = useTracking();
+
+  const wrappedVote = (type) => {
+    if(!currentUser){
+      openDialog({
+        componentName: "LoginPopup",
+        componentProps: {}
+      });
+    } else {
+      vote({document, voteType: type, collection: TagRels, currentUser});
+      captureEvent("vote", {collectionName: "TagRels"});
+    }
+  }
+
+  const handleClick = () => {
+    wrappedVote(voteType)
+  }
+
+  const voted = hasVotedClient({userVotes: document.currentUserVotes, voteType})
+
+  return <a className={classNames(classes.root, {[classes.voted]: cancelVote ? !voted : voted})} onClick={handleClick}>
+    {label}
+  </a>
+}
+
+const TagRelevanceButtonComponent = registerComponent('TagRelevanceButton', TagRelevanceButton, {styles});
+
+declare global {
+  interface ComponentTypes {
+    TagRelevanceButton: typeof TagRelevanceButtonComponent
+  }
+}
+

--- a/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
+++ b/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
@@ -17,7 +17,11 @@ const styles = theme => ({
     color: theme.palette.grey[600]
   },
   voted: {
-    color: theme.palette.grey[400]
+    color: theme.palette.grey[900],
+    borderRadius: 2,
+    backgroundColor: "rgba(0,0,0,.1)",
+    padding: 6,
+    marginTop: -6
   }
 })
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -373,6 +373,8 @@ importComponent("EditTagPage", () => require('../components/tagging/EditTagPage'
 importComponent("EditTagsDialog", () => require('../components/tagging/EditTagsDialog'));
 importComponent("AllTagsPage", () => require('../components/tagging/AllTagsPage'));
 importComponent("AllTagsAlphabetical", () => require('../components/tagging/AllTagsAlphabetical'));
+importComponent("TagRelevanceButton", () => require('../components/tagging/TagRelevanceButton'));
+
 
 importComponent("TagsListItem", () => require('../components/tagging/TagsListItem'));
 importComponent("TagsDetailsItem", () => require('../components/tagging/TagsDetailsItem'));

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -92,7 +92,7 @@ addCallback("votes.cancel.async", cancelAlignmentUserKarmaServer);
 function updateAlignmentKarmaClientCallback (document, collection, voter, voteType) {
   const votePower = getVotePower(voter.afKarma, voteType)
 
-  if (document?.af && Users.canDo(voter, "votes.alignment")) {
+  if (document.af && Users.canDo(voter, "votes.alignment")) {
     return {
       ...document,
       afBaseScore: (document.afBaseScore || 0) + (votePower || 0),

--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -92,7 +92,7 @@ addCallback("votes.cancel.async", cancelAlignmentUserKarmaServer);
 function updateAlignmentKarmaClientCallback (document, collection, voter, voteType) {
   const votePower = getVotePower(voter.afKarma, voteType)
 
-  if (document.af && Users.canDo(voter, "votes.alignment")) {
+  if (document?.af && Users.canDo(voter, "votes.alignment")) {
     return {
       ...document,
       afBaseScore: (document.afBaseScore || 0) + (votePower || 0),


### PR DESCRIPTION
Currently, this makes a "cancel vote" button appear on the TagRelCard if there is exactly on smallUpvote cast by the currentUser. 

The TagRelevanceButton could potentially be used to generally replace the tag relevance voting widget, but currently does not.