### PR TITLE
Fix sequences tooltip

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -104,11 +104,10 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   const getSequenceUrl = () => {
     return '/s/' + sequence._id
   }
-  const { hover, anchorEl } = useHover()
-  const { PopperCard, SequenceTooltip, LinkCard } = Components;
+  const { LinkCard } = Components;
   const url = getSequenceUrl()
 
-  return <LinkCard className={classes.root} to={url} tooltip={sequence.contents.plaintextDescription}>
+  return <LinkCard className={classes.root} to={url} tooltip={sequence.contents.plaintextDescription.slice(0, 750)}>
     <div className={classes.image}>
       <NoSSR>
         <Components.CloudinaryImage
@@ -128,9 +127,6 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
           by <Components.UsersName user={sequence.user} />
         </div>}
     </div>
-    <PopperCard open={hover} anchorEl={anchorEl}>
-      <SequenceTooltip sequence={sequence}/>
-    </PopperCard>
   </LinkCard>
 }
 

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -3,7 +3,6 @@ import NoSSR from 'react-no-ssr';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import { legacyBreakpoints } from '../../lib/utils/theme';
-import { useHover } from '../common/withHover';
 import classNames from 'classnames';
 
 const styles = theme => ({

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -106,7 +106,7 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
   const { LinkCard } = Components;
   const url = getSequenceUrl()
 
-  return <LinkCard className={classes.root} to={url} tooltip={sequence.contents.plaintextDescription.slice(0, 750)}>
+  return <LinkCard className={classes.root} to={url} tooltip={sequence.contents.plaintextDescription?.slice(0, 750)}>
     <div className={classes.image}>
       <NoSSR>
         <Components.CloudinaryImage


### PR DESCRIPTION
There were a bunch of sketchy things going on with the sequences tooltip, with two tooltip components, one of them being completely inaccessible. This removes one of them and adds a length limit to the current tooltip.