### PR TITLE
Add a loading indicator to comment submissions

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -12,6 +12,9 @@ import Users from '../../lib/collections/users/collection';
 const styles = theme => ({
   root: {
   },
+  loadingRoot: {
+    opacity: 0.5
+  },
   form: {
     padding: 10,
   },
@@ -62,8 +65,22 @@ const CommentsNewForm = ({prefilledProps = {}, post, parentComment, successCallb
   };
   
   const [showGuidelines, setShowGuidelines] = useState(false)
-  
-  const { ModerationGuidelinesBox, WrappedSmartForm, RecaptchaWarning } = Components
+  const [loading, setLoading] = useState(false)
+  const { ModerationGuidelinesBox, WrappedSmartForm, RecaptchaWarning, Loading } = Components
+
+  const wrappedSuccessCallback = (...args) => {
+    if (successCallback) {
+      successCallback(...args)
+    }
+    setLoading(false)
+  };
+
+  const wrappedCancelCallback = (...args) => {
+    if (cancelCallback) {
+      cancelCallback(...args)
+    }
+    setLoading(false)
+  };
   
   if (post) {
     prefilledProps = {
@@ -98,10 +115,12 @@ const CommentsNewForm = ({prefilledProps = {}, post, parentComment, successCallb
               componentProps: {}
             });
             ev.preventDefault();
+          } else {
+            setTimeout(() => setLoading(true), 0)
           }
         }}
       >
-        {submitLabel}
+        {loading ? <Loading /> : submitLabel}
       </Button>
     </div>
   };
@@ -112,7 +131,7 @@ const CommentsNewForm = ({prefilledProps = {}, post, parentComment, successCallb
 
   const commentWillBeHidden = hideUnreviewedAuthorCommentsSettings.get() && currentUser && !currentUser.isReviewed
   return (
-    <div className={classes.root} onFocus={()=>setShowGuidelines(true)}>
+    <div className={loading ? classes.loadingRoot : classes.root} onFocus={()=>setShowGuidelines(true)}>
       <RecaptchaWarning currentUser={currentUser}>
         <div className={padding ? classes.form : null}>
         {commentWillBeHidden && <div className={classes.modNote}><em>
@@ -122,8 +141,9 @@ const CommentsNewForm = ({prefilledProps = {}, post, parentComment, successCallb
         <WrappedSmartForm
           collection={Comments}
           mutationFragment={getFragment(fragment)}
-          successCallback={successCallback}
-          cancelCallback={cancelCallback}
+          successCallback={wrappedSuccessCallback}
+          cancelCallback={wrappedCancelCallback}
+          errorCallback={() => setLoading(false)}
           prefilledProps={prefilledProps}
           layout="elementOnly"
           formComponents={{


### PR DESCRIPTION
Kind of as a bit of a hotfix for long comment submissions, and also as a general quality-of-life improvements, this makes it so that when you submit a comment the form enters into a loading state that allows you to more properly track what is happening with comments that take a long time to be submitted.