### PR TITLE
Static stylesheet generation

### DIFF
--- a/packages/lesswrong/client/themeProvider.tsx
+++ b/packages/lesswrong/client/themeProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { MuiThemeProvider, createGenerateClassName } from '@material-ui/core/styles';
+import { MuiThemeProvider, createGenerateClassName, jssPreset } from '@material-ui/core/styles';
+import { create } from 'jss';
 import forumTheme from '../themes/forumTheme';
 import JssCleanup from '../components/themes/JssCleanup';
 
@@ -9,9 +10,13 @@ export function wrapWithMuiTheme (app) {
   const generateClassName = createGenerateClassName({
     dangerouslyUseGlobalCSS: true
   });
+  const jss = create({
+    ...jssPreset(),
+    insertionPoint: document.getElementById("jss-insertion-point") as HTMLElement,
+  });
   
   return (
-    <JssProvider generateClassName={generateClassName}>
+    <JssProvider jss={jss} generateClassName={generateClassName}>
       <MuiThemeProvider theme={forumTheme}>
         {app}
         <JssCleanup />

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -18,7 +18,7 @@ export const Components: ComponentTypes = new Proxy({}, componentsProxyHandler);
 const PreparedComponents = {};
 
 // storage for infos about components
-export const ComponentsTable: Record<string, ComponentsTableEntry> = {};
+export const ComponentsTable: Record<string, any> = {};
 
 const DeferredComponentsTable = {};
 
@@ -67,7 +67,7 @@ const addClassnames = (componentName: string) => {
 // ComponentTypes interface to type-check usages of the component in other
 // files.
 export function registerComponent<PropType>(name: keyof ComponentTypes, rawComponent: React.ComponentType<PropType>,
-  options?: ComponentOptions): React.ComponentType<Omit<PropType,"classes">>
+  options?: {styles?: any, hocs?: Array<any>}): React.ComponentType<Omit<PropType,"classes">>
 {
   const { styles=null, hocs=[] } = options || {};
   if (styles) {

--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -120,6 +120,7 @@ import './server/connection_logs';
 
 import './server/codegen/generateTypes';
 
+import './server/styleGeneration';
 
 // Algolia Search Integration
 import './server/search/utils';

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -8,13 +8,11 @@ import * as _ from 'underscore';
 import crypto from 'crypto'; //nodejs core library
 
 const generateMergedStylesheet = () => {
-  console.log("In generateMergedStylesheet");
   importAllComponents();
   
   const context: any = {};
   const componentsWithStyles = _.filter(Object.keys(ComponentsTable),
     componentName=>ComponentsTable[componentName].styles);
-  console.log(`${componentsWithStyles.length} components`);
   
   const DummyComponent = (props) => <div/>
   const DummyTree = <div>
@@ -27,7 +25,6 @@ const generateMergedStylesheet = () => {
   
   ReactDOM.renderToString(WrappedTree);
   const stylesheet = context.sheetsRegistry.toString()
-  console.log("generateMergedStylesheet returning length "+stylesheet.length);
   return stylesheet;
 }
 

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import ReactDOM from 'react-dom/server';
+import { getDataFromTree } from 'react-apollo';
+import { importAllComponents, ComponentsTable } from '../lib/vulcan-lib/components';
+import { Globals } from '../lib/vulcan-lib/config';
+import { createGenerateClassName, withStyles } from '@material-ui/core/styles';
+import forumTheme from '../themes/forumTheme';
+import { SheetsRegistry } from 'react-jss/lib/jss';
+import { wrapWithMuiTheme } from './material-ui/themeProvider';
+import { addStaticRoute } from './vulcan-lib';
+import * as _ from 'underscore';
+import crypto from 'crypto'; //nodejs core library
+
+const generateMergedStylesheet = () => {
+  console.log("In generateMergedStylesheet");
+  importAllComponents();
+  
+  const context: any = {};
+  const componentsWithStyles = _.filter(Object.keys(ComponentsTable),
+    componentName=>ComponentsTable[componentName].styles);
+  console.log(`${componentsWithStyles.length} components`);
+  
+  const DummyComponent = (props) => <div/>
+  const DummyTree = <div>
+    {componentsWithStyles.map(componentName => {
+      const StyledComponent = withStyles(ComponentsTable[componentName].styles, {name: componentName})(DummyComponent)
+      return <StyledComponent key={componentName}/>
+    })}
+  </div>
+  const WrappedTree = wrapWithMuiTheme(DummyTree, context);
+  
+  ReactDOM.renderToString(WrappedTree);
+  const stylesheet = context.sheetsRegistry.toString()
+  console.log("generateMergedStylesheet returning length "+stylesheet.length);
+  return stylesheet;
+}
+
+let mergedStylesheet: string|null = null;
+let stylesheetHash: string|null = null;
+
+export const getMergedStylesheet = () => {
+  if (!mergedStylesheet) {
+    mergedStylesheet = generateMergedStylesheet();
+    stylesheetHash = crypto.createHash('sha256').update(mergedStylesheet, 'utf8').digest('hex');
+  }
+  return {
+    css: mergedStylesheet,
+    url: `/allStyles?hash=${stylesheetHash}`,
+    hash: stylesheetHash,
+  };
+}
+
+addStaticRoute("/allStyles", ({query}, req, res, next) => {
+  const expectedHash = query?.hash;
+  const {hash: stylesheetHash, css} = getMergedStylesheet();
+  
+  if (!expectedHash || expectedHash === stylesheetHash) {
+    res.writeHead(200, {
+      "Cache-Control": "public, max-age=604800, immutable",
+      "Content-Type": "text/css"
+    });
+    res.end(css);
+  } else {
+    res.writeHead(404);
+    res.end("");
+  }
+});

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -7,7 +7,7 @@ import { addStaticRoute } from './vulcan-lib';
 import * as _ from 'underscore';
 import crypto from 'crypto'; //nodejs core library
 
-const generateMergedStylesheet = () => {
+const generateMergedStylesheet = (): string => {
   importAllComponents();
   
   const context: any = {};
@@ -31,11 +31,11 @@ const generateMergedStylesheet = () => {
 let mergedStylesheet: string|null = null;
 let stylesheetHash: string|null = null;
 
-export const getMergedStylesheet = () => {
-  if (!mergedStylesheet) {
+export const getMergedStylesheet = (): {css: string, url: string, hash: string} => {
+  if (!mergedStylesheet)
     mergedStylesheet = generateMergedStylesheet();
+  if (!stylesheetHash)
     stylesheetHash = crypto.createHash('sha256').update(mergedStylesheet, 'utf8').digest('hex');
-  }
   return {
     css: mergedStylesheet,
     url: `/allStyles?hash=${stylesheetHash}`,

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/server';
-import { getDataFromTree } from 'react-apollo';
 import { importAllComponents, ComponentsTable } from '../lib/vulcan-lib/components';
-import { Globals } from '../lib/vulcan-lib/config';
-import { createGenerateClassName, withStyles } from '@material-ui/core/styles';
-import forumTheme from '../themes/forumTheme';
-import { SheetsRegistry } from 'react-jss/lib/jss';
+import { withStyles } from '@material-ui/core/styles';
 import { wrapWithMuiTheme } from './material-ui/themeProvider';
 import { addStaticRoute } from './vulcan-lib';
 import * as _ from 'underscore';

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/renderPage.tsx
@@ -20,6 +20,7 @@ import AppGenerator from './components/AppGenerator';
 import Sentry from '@sentry/node';
 import { Random } from 'meteor/random';
 import { publicSettings } from '../../../lib/publicSettings'
+import { getMergedStylesheet } from '../../styleGeneration';
 
 type RenderTimings = {
   totalTime: number
@@ -177,6 +178,8 @@ const renderRequest = async ({req, user, startTime}) => {
   // context.
   const sheetsRegistry = context.sheetsRegistry;
   const jssSheets = `<style id="jss-server-side">${sheetsRegistry.toString()}</style>`
+    +'<style id="jss-insertion-point"></style>'
+    +`<link rel="stylesheet" onerror="window.missingMainStylesheet=true" href="${getMergedStylesheet().url}"></link>`
   
   const finishedTime = new Date();
   const timings: RenderTimings = {


### PR DESCRIPTION
Previously, we re-generate JSS styles with each request, and embed them into the page header, then recompute them again client-side on hydration. This is bad because it adds a lot to the SSR and client Javascript time, and because styles embedded in the page header this way can't be cached by the browser, adding to the size of the page download.

This PR makes it so that instead, we do all the JSS processing once on server startup, making a static stylesheet which is served from `/allStyles?hash=...`. The hash allows setting aggressive caching options in http headers, and there is handling for the case where a page requests static styles from a server running a different version of the app; in that case, it rejects the request, and a fallback handler generates the styles client-side like before.

Uncompressed sizes, logged out front page: Adds a 934kb cacheable stylesheet; reduces page from 885kb to 763kb (-14%).
