### PR TITLE
Frontpage size optimizations

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { withUpdate } from '../../lib/crud/withUpdate';
 import { useCurrentUser } from '../common/withUser';
-import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -1,12 +1,12 @@
-import React, { PureComponent } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
-import withUser from '../common/withUser';
+import { useCurrentUser } from '../common/withUser';
 import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import classNames from 'classnames';
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
-import { withContinueReading } from './withContinueReading';
+import { useContinueReading } from './withContinueReading';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import Hidden from '@material-ui/core/Hidden';
 export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
@@ -64,40 +64,26 @@ const defaultFrontpageSettings = {
   curatedModifier: 50,
 }
 
+const RecommendationsAndCurated = ({
+  configName,
+  classes,
+}: {
+  configName: string,
+  classes: ClassesType,
+}) => {
+  const [showSettings, setShowSettings] = useState(false);
+  const [settingsState, setSettings] = useState<any>(null);
+  const currentUser = useCurrentUser();
+  const {continueReading} = useContinueReading();
 
-interface ExternalProps {
-  configName: string
-}
-interface RecommendationsAndCuratedProps extends ExternalProps, WithUserProps, WithStylesProps {
-  continueReading: any,
-}
-interface RecommendationsAndCuratedState {
-  showSettings: boolean,
-  settings: any,
-}
+  const toggleSettings = useCallback(() => {
+    setShowSettings(!showSettings);
+  }, [showSettings, setShowSettings]);
 
-class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedProps,RecommendationsAndCuratedState> {
-  state: RecommendationsAndCuratedState = {
-    showSettings: false,
-    settings: null,
-  }
-
-  toggleSettings = () => {
-    this.setState(prevState => ({showSettings: !prevState.showSettings}))
-  }
-
-  changeSettings = (newSettings) => {
-    this.setState({
-      settings: newSettings
-    });
-  }
-
-  render() {
-    const { continueReading, classes, currentUser, configName } = this.props;
-    const { showSettings } = this.state
+  const render = () => {
     const { SequencesGridWrapper, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList, PostsList2, RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip } = Components;
 
-    const settings = getRecommendationSettings({settings: this.state.settings, currentUser, configName})
+    const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
 
     const continueReadingTooltip = <div>
       <div>The next posts in sequences you've started reading, but not finished.</div>
@@ -134,7 +120,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
       </LWTooltip>}>
         {currentUser && 
           <LWTooltip title="Customize your recommendations">
-            <SettingsButton showIcon={false} onClick={this.toggleSettings} label="Customize"/>
+            <SettingsButton showIcon={false} onClick={toggleSettings} label="Customize"/>
           </LWTooltip>
         }
       </SectionTitle>
@@ -143,7 +129,7 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
         <RecommendationsAlgorithmPicker
           configName={configName}
           settings={frontpageRecommendationSettings}
-          onChange={(newSettings) => this.changeSettings(newSettings)}
+          onChange={(newSettings) => setSettings(newSettings)}
         /> }
 
       {!currentUser && <div>
@@ -212,18 +198,11 @@ class RecommendationsAndCurated extends PureComponent<RecommendationsAndCuratedP
       </AnalyticsContext> */}
     </SingleColumnSection>
   }
+  
+  return render();
 }
 
-const RecommendationsAndCuratedComponent = registerComponent<ExternalProps>("RecommendationsAndCurated", RecommendationsAndCurated, {
-  styles,
-  hocs: [
-    withUpdate({
-      collection: Users,
-      fragmentName: "UsersCurrent",
-    }),
-    withContinueReading, withUser,
-  ]
-});
+const RecommendationsAndCuratedComponent = registerComponent("RecommendationsAndCurated", RecommendationsAndCurated, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/recommendations/withContinueReading.ts
+++ b/packages/lesswrong/components/recommendations/withContinueReading.ts
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
-import { graphql } from 'react-apollo';
+import { useQuery } from 'react-apollo';
 import { getFragment } from '../../lib/vulcan-lib';
 
-export const withContinueReading = component => {
+export const useContinueReading = () => {
   // FIXME: For some unclear reason, using a ...fragment in the 'sequence' part
   // of this query doesn't work (leads to a 400 Bad Request), so this is expanded
   // out to a short list of individual fields.
@@ -34,19 +34,13 @@ export const withContinueReading = component => {
     }
     ${getFragment("PostsList")}
   `;
-
-  return graphql(continueReadingQuery,
-    {
-      alias: "withContinueReading",
-      options: (props) => ({
-        variables: {}
-      }),
-      props(props: any) {
-        return {
-          continueReadingLoading: props.data.loading,
-          continueReading: props.data.ContinueReading,
-        }
-      }
-    }
-  )(component);
+  
+  const { data, loading, error } = useQuery(continueReadingQuery, {
+    ssr: true,
+  });
+  
+  return {
+    continueReading: data.ContinueReading,
+    loading, error
+  };
 }

--- a/packages/lesswrong/components/recommendations/withContinueReading.ts
+++ b/packages/lesswrong/components/recommendations/withContinueReading.ts
@@ -21,9 +21,6 @@ export const useContinueReading = () => {
           slug
           gridImageId
         }
-        lastReadPost {
-          ...PostsList
-        }
         nextPost {
           ...PostsList
         }

--- a/packages/lesswrong/components/recommendations/withDismissRecommendation.ts
+++ b/packages/lesswrong/components/recommendations/withDismissRecommendation.ts
@@ -1,20 +1,17 @@
+import { useCallback } from 'react';
 import gql from 'graphql-tag';
-import { graphql } from 'react-apollo';
+import { useMutation } from 'react-apollo';
 
-export const withDismissRecommendation = component => {
-  return graphql(gql`
+export const useDismissRecommendation = () => {
+  const [mutate] = useMutation(gql`
     mutation dismissRecommendation($postId: String) {
       dismissRecommendation(postId: $postId)
     }
-  `, {
-    props: ({ownProps, mutate}: any): any => ({
-      dismissRecommendation: async ({postId}) => {
-        await mutate({
-          variables: {
-            postId: postId
-          },
-        });
-      }
-    })
-  })(component);
+  `);
+  
+  return useCallback(async (postId: string) => {
+    await mutate({
+      variables: { postId }
+    });
+  }, [mutate]);
 }

--- a/packages/lesswrong/lib/collections/comments/fragments.ts
+++ b/packages/lesswrong/lib/collections/comments/fragments.ts
@@ -2,18 +2,16 @@ import { registerFragment } from '../../vulcan-lib';
 
 registerFragment(`
   fragment CommentsList on Comment {
-    # example-forum
     _id
     postId
     parentCommentId
     topLevelCommentId
     contents {
-      ...RevisionDisplay
+      html
       plaintextMainText
     }
     postedAt
     repliesBlockedUntil
-    # vulcan:users
     userId
     deleted
     deletedPublic
@@ -22,7 +20,6 @@ registerFragment(`
     user {
       ...UsersMinimumInfo
     }
-    # vulcan:voting
     currentUserVotes {
       ...VoteFragment
     }

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -52,7 +52,6 @@ registerFragment(`
     hiddenRelatedQuestion
     originalPostRelationSourceId
 
-    # vulcan:users
     userId
     
     # Local Event data
@@ -146,10 +145,9 @@ registerFragment(`
       version
     }
     moderationGuidelines {
-      ...RevisionDisplay
+      html
     }
     customHighlight {
-      version
       html
     }
 

--- a/packages/lesswrong/lib/collections/votes/fragments.ts
+++ b/packages/lesswrong/lib/collections/votes/fragments.ts
@@ -43,7 +43,6 @@ registerFragment(`
 // note: fragment used by default on the UsersProfile fragment
 registerFragment(/* GraphQL */`
   fragment VotedItem on Vote {
-    # vulcan:voting
     documentId
     power
     votedAt

--- a/packages/lesswrong/lib/fragments.ts
+++ b/packages/lesswrong/lib/fragments.ts
@@ -11,7 +11,6 @@ registerFragment(`
     slug
     groups
     services
-    
     karma
   }
 `);
@@ -339,7 +338,6 @@ registerFragment(`
 
 registerFragment(`
   fragment commentWithContextFragment on Comment {
-    # example-forum
     _id
     parentCommentId
     topLevelCommentId
@@ -347,13 +345,11 @@ registerFragment(`
       ...RevisionDisplay
     }
     postedAt
-    # vulcan:users
+    
     userId
     user {
       ...UsersMinimumInfo
     }
-    # example-forum
-    # vulcan:voting
     currentUserVotes{
       ...VoteFragment
     }
@@ -364,12 +360,11 @@ registerFragment(`
 
 registerFragment(`
   fragment commentInlineFragment on Comment {
-    # example-forum
     _id
     contents {
       ...RevisionDisplay
     }
-    # vulcan:users
+
     userId
     user {
       ...UsersMinimumInfo
@@ -379,7 +374,6 @@ registerFragment(`
 
 registerFragment(`
   fragment UsersMinimumInfo on User {
-    # vulcan:users
     _id
     slug
     oldSlugs
@@ -405,7 +399,6 @@ registerFragment(`
 
 registerFragment(`
   fragment UsersProfile on User {
-    # vulcan:users
     ...UsersMinimumInfo
     createdAt
     isAdmin
@@ -413,11 +406,9 @@ registerFragment(`
     htmlBio
     website
     groups
-    # example-forum
     postCount
     afPostCount
     frontpagePostCount
-    # example-forum
     commentCount
     sequenceCount
     afCommentCount
@@ -448,12 +439,10 @@ registerFragment(`
 
 registerFragment(`
   fragment UsersMapEntry on User {
-    # vulcan:users
     ...UsersMinimumInfo
     createdAt
     isAdmin
     groups
-    # example-forum
     location
     googleLocation
     mapLocation
@@ -630,10 +619,6 @@ registerFragment(`
     voteCount
   }
 `);
-
-//
-// example-forum migrated fragments
-//
 
 registerFragment(`
   fragment RevisionDisplay on Revision {

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -135,7 +135,7 @@ interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
 
 interface PostsList extends PostsBase, PostsAuthors { // fragment on Posts
   readonly contents: PostsList_contents,
-  readonly moderationGuidelines: RevisionDisplay,
+  readonly moderationGuidelines: PostsList_moderationGuidelines,
   readonly customHighlight: PostsList_customHighlight,
   readonly tags: Array<TagPreviewFragment>,
 }
@@ -146,8 +146,11 @@ interface PostsList_contents { // fragment on Revisions
   readonly version: string,
 }
 
+interface PostsList_moderationGuidelines { // fragment on Revisions
+  readonly html: string,
+}
+
 interface PostsList_customHighlight { // fragment on Revisions
-  readonly version: string,
   readonly html: string,
 }
 
@@ -367,7 +370,8 @@ interface CommentsList { // fragment on Comments
   readonly directChildrenCount: number,
 }
 
-interface CommentsList_contents extends RevisionDisplay { // fragment on Revisions
+interface CommentsList_contents { // fragment on Revisions
+  readonly html: string,
   readonly plaintextMainText: string,
 }
 

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -259,7 +259,6 @@ const getResumeSequences = async (currentUser, context: ResolverContext) => {
         collection: collectionId
           ? await context["Collections"].loader.load(collectionId)
           : null,
-        lastReadPost: lastReadPostId && await context["Posts"].loader.load(lastReadPostId),
         nextPost: await context["Posts"].loader.load(nextPostId),
         numRead: numRead,
         numTotal: numTotal,
@@ -314,7 +313,6 @@ addGraphQLSchema(`
   type RecommendResumeSequence {
     sequence: Sequence
     collection: Collection
-    lastReadPost: Post
     nextPost: Post!
     numRead: Int
     numTotal: Int

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -251,7 +251,7 @@ const getResumeSequences = async (currentUser, context: ResolverContext) => {
 
   const results = await Promise.all(_.map(sequences,
     async (partiallyReadSequence: any) => {
-      const { sequenceId, collectionId, lastReadPostId, nextPostId, numRead, numTotal, lastReadTime } = partiallyReadSequence;
+      const { sequenceId, collectionId, nextPostId, numRead, numTotal, lastReadTime } = partiallyReadSequence;
       return {
         sequence: sequenceId
           ? await context["Sequences"].loader.load(sequenceId)


### PR DESCRIPTION
Shrinks the size of the front page. The largest-effect-size thing here is trimming down fragments, which saves ~75kb of duplicate comment text. Also load the only the next post (which is displayed) for continue reading entries, don't also load the last-read post (which is not displayed); for me this was ~40kb.

Hookifies RecommendationsAndCurated/ContinueReadingList, because I thought I might also make it not do the query if the continue-reading section is hidden and/or apply the limit-3 in a way that saves downloading, but I didn't get to that yet.