### PR TITLE
Fix retraction and banning-replies-on Answers

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Components, registerComponent } from '../../../lib/vulcan-lib';
+
+const styles = theme => ({
+  blockedReplies: {
+    padding: "5px 0",
+  },
+});
+
+const CommentBottomCaveats = ({comment, classes}: {
+  comment: CommentsList,
+  classes: ClassesType,
+}) => {
+  const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > new Date();
+  
+  return <>
+    { blockedReplies &&
+      <div className={classes.blockedReplies}>
+        A moderator has deactivated replies on this comment until <Components.CalendarDate date={comment.repliesBlockedUntil}/>
+      </div>
+    }
+    { comment.retracted && <Components.MetaInfo>[This comment is no longer endorsed by its author]</Components.MetaInfo>}
+  </>
+}
+
+const CommentBottomCaveatsComponent = registerComponent("CommentBottomCaveats", CommentBottomCaveats, {styles});
+
+declare global {
+  interface ComponentTypes {
+    CommentBottomCaveats: typeof CommentBottomCaveatsComponent
+  }
+}

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -41,9 +41,6 @@ export const styles = theme => ({
       display: 'block'
     }
   },
-  blockedReplies: {
-    padding: "5px 0",
-  },
   replyLink: {
     marginRight: 5,
     display: "inline",
@@ -333,7 +330,7 @@ export class CommentsItem extends Component<CommentsItemProps,CommentsItemState>
 
   renderCommentBottom = () => {
     const { comment, currentUser, collapsed, classes, hideReply } = this.props;
-    const { MetaInfo } = Components
+    const { CommentBottomCaveats } = Components
 
     if (!collapsed) {
       const blockedReplies = comment.repliesBlockedUntil && new Date(comment.repliesBlockedUntil) > new Date();
@@ -352,19 +349,12 @@ export class CommentsItem extends Component<CommentsItemProps,CommentsItemState>
 
       return (
         <div className={classes.bottom}>
-          { blockedReplies &&
-            <div className={classes.blockedReplies}>
-              A moderator has deactivated replies on this comment until <Components.CalendarDate date={comment.repliesBlockedUntil}/>
-            </div>
+          <CommentBottomCaveats comment={comment}/>
+          { showReplyButton &&
+            <a className={classNames("comments-item-reply-link", classes.replyLink)} onClick={this.showReply}>
+              Reply
+            </a>
           }
-          <div>
-            { comment.retracted && <MetaInfo>[This comment is no longer endorsed by its author]</MetaInfo>}
-            { showReplyButton &&
-              <a className={classNames("comments-item-reply-link", classes.replyLink)} onClick={this.showReply}>
-                Reply
-              </a>
-            }
-          </div>
         </div>
       )
     }

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -105,6 +105,9 @@ const styles = theme => ({
     marginTop: -12,
     marginBottom: 10
   },
+  retracted: {
+    textDecoration: "line-through",
+  },
 })
 
 const Answer = ({ comment, post, classes }: {
@@ -122,7 +125,7 @@ const Answer = ({ comment, post, classes }: {
     setShowEdit(false)
   }, [setShowEdit]);
 
-  const { ContentItemBody, SmallSideVote, AnswerCommentsList, CommentsMenu, CommentsItemDate, UsersName } = Components
+  const { ContentItemBody, SmallSideVote, AnswerCommentsList, CommentsMenu, CommentsItemDate, UsersName, CommentBottomCaveats } = Components
   const { html = "" } = comment.contents || {}
 
   return (
@@ -174,11 +177,15 @@ const Answer = ({ comment, post, classes }: {
                   cancelCallback={hideEdit}
                 />
                 :
-                <ContentItemBody
-                  className={classes.postContent}
-                  dangerouslySetInnerHTML={{__html:html}}
-                  description={`comment ${comment._id} on post ${post._id}`}
-                />
+                <>
+                  <ContentItemBody
+                    className={classNames(classes.postContent,
+                      {[classes.retracted]: comment.retracted})}
+                    dangerouslySetInnerHTML={{__html:html}}
+                    description={`comment ${comment._id} on post ${post._id}`}
+                  />
+                  <CommentBottomCaveats comment={comment}/>
+                </>
               }
             </div>
           </AnalyticsContext>

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -281,6 +281,7 @@ importComponent("CommentActions", () => require('../components/comments/CommentA
 importComponent("CommentsMenu", () => require('../components/comments/CommentsItem/CommentsMenu'));
 importComponent("CommentOutdatedWarning", () => require('../components/comments/CommentsItem/CommentOutdatedWarning'));
 importComponent("CommentsItemDate", () => require('../components/comments/CommentsItem/CommentsItemDate'));
+importComponent("CommentBottomCaveats", () => require('../components/comments/CommentsItem/CommentBottomCaveats'));
 importComponent("ToggleIsModeratorComment", () => require('../components/comments/CommentActions/ToggleIsModeratorComment'));
 
 importComponent("AllComments", () => require('../components/comments/AllComments'));


### PR DESCRIPTION
Due to duplication between `CommentsItem` and `Answer`, answers couldn't be retracted (even though they had the menu item and the field), and moderator-blocking replies wouldn't display the notice.