### PR TITLE
Fix client-JS performance issues

### DIFF
--- a/packages/lesswrong/client/vulcan-core/start.tsx
+++ b/packages/lesswrong/client/vulcan-core/start.tsx
@@ -11,6 +11,7 @@ Meteor.startup(() => {
   // init the application components and routes, including components & routes from 3rd-party packages
   populateComponentsApp();
   const apolloClient = createApolloClient();
+  apolloClient.disableNetworkFetches = true;
 
   // Create the root element, if it doesn't already exist.
   if (!document.getElementById('react-app')) {
@@ -24,6 +25,13 @@ Meteor.startup(() => {
   );
 
   onPageLoad(() => {
-    ReactDOM.hydrate(<Main />, document.getElementById('react-app'));
+    ReactDOM.hydrate(
+      <Main />,
+      document.getElementById('react-app'),
+      () => {
+        console.log("Finished hydration");
+        apolloClient.disableNetworkFetches = false;
+      }
+    );
   });
 });

--- a/packages/lesswrong/client/vulcan-core/start.tsx
+++ b/packages/lesswrong/client/vulcan-core/start.tsx
@@ -29,7 +29,6 @@ Meteor.startup(() => {
       <Main />,
       document.getElementById('react-app'),
       () => {
-        console.log("Finished hydration");
         apolloClient.disableNetworkFetches = false;
       }
     );

--- a/packages/lesswrong/client/vulcan-lib/apollo-client/apolloClient.ts
+++ b/packages/lesswrong/client/vulcan-lib/apollo-client/apolloClient.ts
@@ -21,7 +21,6 @@ export const createApolloClient = () => {
   
   return new ApolloClient({
     link: ApolloLink.from([errorLink, meteorAccountsLink, httpLink]),
-    cache,
-    ssrForceFetchDelay: 500,
+    cache
   });
 };

--- a/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
@@ -212,7 +212,11 @@ const RecentDiscussionThread = ({
 const RecentDiscussionThreadComponent = registerComponent(
   'RecentDiscussionThread', RecentDiscussionThread, {
     styles,
-    hocs: [withErrorBoundary]
+    hocs: [withErrorBoundary],
+    areEqual: {
+      post: (before, after) => (before?._id === after?._id),
+      refetch: "ignore",
+    },
   }
 );
 

--- a/packages/lesswrong/components/comments/RecentDiscussionThreadsList.tsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThreadsList.tsx
@@ -96,7 +96,11 @@ const RecentDiscussionThreadsList = ({
   )
 }
 
-const RecentDiscussionThreadsListComponent = registerComponent('RecentDiscussionThreadsList', RecentDiscussionThreadsList);
+const RecentDiscussionThreadsListComponent = registerComponent('RecentDiscussionThreadsList', RecentDiscussionThreadsList, {
+  areEqual: {
+    terms: "deep",
+  },
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/common/AnalyticsClient.tsx
+++ b/packages/lesswrong/components/common/AnalyticsClient.tsx
@@ -16,7 +16,9 @@ export const AnalyticsClient = () => {
       analyticsEvent(events: $events, now: $now)
     }
   `;
-  const [mutate] = useMutation(query);
+  const [mutate] = useMutation(query, {
+    ignoreResults: true
+  });
   
   function flushEvents(events) {
     void mutate({

--- a/packages/lesswrong/components/common/withRecordPostView.tsx
+++ b/packages/lesswrong/components/common/withRecordPostView.tsx
@@ -22,7 +22,9 @@ export const useRecordPostView = (post: PostsBase): {recordPostView: any, isRead
     mutation increasePostViewCountMutation($postId: String) {
       increasePostViewCount(postId: $postId)
     }
-  `);
+  `, {
+    ignoreResults: true
+  });
   
   const {recordEvent} = useNewEvents()
   const currentUser = useCurrentUser();

--- a/packages/lesswrong/components/posts/PostsCommentsThread.tsx
+++ b/packages/lesswrong/components/posts/PostsCommentsThread.tsx
@@ -36,7 +36,11 @@ const PostsCommentsThread = ({ post, terms, newForm=true }: {
   }
 }
 
-const PostsCommentsThreadComponent = registerComponent('PostsCommentsThread', PostsCommentsThread);
+const PostsCommentsThreadComponent = registerComponent('PostsCommentsThread', PostsCommentsThread, {
+  areEqual: {
+    terms: "deep",
+  }
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -556,7 +556,10 @@ const PostsItem2 = ({
 
 const PostsItem2Component = registerComponent('PostsItem2', PostsItem2, {
   styles,
-  hocs: [withErrorBoundary]
+  hocs: [withErrorBoundary],
+  areEqual: {
+    terms: "deep",
+  },
 });
 
 declare global {

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -198,7 +198,12 @@ const PostsList2 = ({
   )
 }
 
-const PostsList2Component = registerComponent('PostsList2', PostsList2, {styles});
+const PostsList2Component = registerComponent('PostsList2', PostsList2, {
+  styles,
+  areEqual: {
+    terms: "deep",
+  },
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/questions/AnswerCommentsList.tsx
+++ b/packages/lesswrong/components/questions/AnswerCommentsList.tsx
@@ -141,7 +141,12 @@ const AnswerCommentsList = ({terms, lastEvent, classes, post, parentAnswer}: {
   );
 }
 
-const AnswerCommentsListComponent = registerComponent('AnswerCommentsList', AnswerCommentsList, {styles});
+const AnswerCommentsListComponent = registerComponent('AnswerCommentsList', AnswerCommentsList, {
+  styles,
+  areEqual: {
+    terms: "deep",
+  }
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/questions/AnswersList.tsx
+++ b/packages/lesswrong/components/questions/AnswersList.tsx
@@ -59,7 +59,12 @@ const AnswersList = ({terms, post, classes}: {
   }
 };
 
-const AnswersListComponent = registerComponent('AnswersList', AnswersList, {styles});
+const AnswersListComponent = registerComponent('AnswersList', AnswersList, {
+  styles,
+  areEqual: {
+    terms: "deep",
+  }
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/sequences/SequencesGridWrapper.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridWrapper.tsx
@@ -49,7 +49,12 @@ const SequencesGridWrapper = ({
   }
 };
 
-const SequencesGridWrapperComponent = registerComponent('SequencesGridWrapper', SequencesGridWrapper, {styles});
+const SequencesGridWrapperComponent = registerComponent('SequencesGridWrapper', SequencesGridWrapper, {
+  styles,
+  areEqual: {
+    terms: "deep"
+  }
+});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -75,6 +75,11 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
 }) => {
   const { AddTagButton, FilterMode, Loading, LWTooltip } = Components
   const [addedSuggestedTags, setAddedSuggestedTags] = useState(false);
+  
+  const changeFilterSettings = (newSettings: FilterSettings): void => {
+    setFilterSettings(newSettings);
+    setAddedSuggestedTags(true);
+  }
 
   const { results: suggestedTags, loading: loadingSuggestedTags } = useMulti({
     terms: {
@@ -88,17 +93,15 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
 
   const { captureEvent } = useTracking()
 
+  let filterSettingsWithSuggestedTags: FilterSettings = filterSettings;
   if (suggestedTags && !addedSuggestedTags) {
-    const filterSettingsWithSuggestedTags = addSuggestedTagsToSettings(filterSettings, suggestedTags);
-    setAddedSuggestedTags(true);
-    if (!_.isEqual(filterSettings, filterSettingsWithSuggestedTags))
-      setFilterSettings(filterSettingsWithSuggestedTags);
+    filterSettingsWithSuggestedTags = addSuggestedTagsToSettings(filterSettings, suggestedTags);
   }
 
   return <span>
-    {loadingSuggestedTags && !filterSettings.tags.length && <Loading/>}
+    {loadingSuggestedTags && !filterSettingsWithSuggestedTags.tags.length && <Loading/>}
 
-    {filterSettings.tags.map(tagSettings =>
+    {filterSettingsWithSuggestedTags.tags.map(tagSettings =>
       <FilterMode
         label={tagSettings.tagName}
         key={tagSettings.tagId}
@@ -107,23 +110,23 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
         canRemove={true}
         onChangeMode={(mode: FilterMode) => {
           const changedTagId = tagSettings.tagId;
-          const replacedIndex = _.findIndex(filterSettings.tags, t=>t.tagId===changedTagId);
-          let newTagFilters = [...filterSettings.tags];
+          const replacedIndex = _.findIndex(filterSettingsWithSuggestedTags.tags, t=>t.tagId===changedTagId);
+          let newTagFilters = [...filterSettingsWithSuggestedTags.tags];
           newTagFilters[replacedIndex] = {
-            ...filterSettings.tags[replacedIndex],
+            ...filterSettingsWithSuggestedTags.tags[replacedIndex],
             filterMode: mode
           };
           captureEvent('tagFilterModified', {tagId: tagSettings.tagId, tagName: tagSettings.tagName, mode})
 
-          setFilterSettings({
-            personalBlog: filterSettings.personalBlog,
+          changeFilterSettings({
+            personalBlog: filterSettingsWithSuggestedTags.personalBlog,
             tags: newTagFilters,
           });
         }}
         onRemove={() => {
-          setFilterSettings({
-            personalBlog: filterSettings.personalBlog,
-            tags: _.filter(filterSettings.tags, t=>t.tagId !== tagSettings.tagId),
+          changeFilterSettings({
+            personalBlog: filterSettingsWithSuggestedTags.personalBlog,
+            tags: _.filter(filterSettingsWithSuggestedTags.tags, t=>t.tagId !== tagSettings.tagId),
           });
           captureEvent("tagRemovedFromFilters", {tagId: tagSettings.tagId, tagName: tagSettings.tagName});
         }}
@@ -133,23 +136,23 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
     <FilterMode
       label={personalBlogpostName}
       description={personalBlogpostTooltip}
-      mode={filterSettings.personalBlog}
+      mode={filterSettingsWithSuggestedTags.personalBlog}
       canRemove={false}
       onChangeMode={(mode: FilterMode) => {
-        setFilterSettings({
+        changeFilterSettings({
           personalBlog: mode,
-          tags: filterSettings.tags,
+          tags: filterSettingsWithSuggestedTags.tags,
         });
       }}
     />
 
     {<LWTooltip title="Add Tag Filter">
         <AddTagButton onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {
-          if (!_.some(filterSettings.tags, t=>t.tagId===tagId)) {
+          if (!_.some(filterSettingsWithSuggestedTags.tags, t=>t.tagId===tagId)) {
             const newFilter: FilterTag = {tagId, tagName, filterMode: "Default"}
-            setFilterSettings({
-              personalBlog: filterSettings.personalBlog,
-              tags: [...filterSettings.tags, newFilter]
+            changeFilterSettings({
+              personalBlog: filterSettingsWithSuggestedTags.personalBlog,
+              tags: [...filterSettingsWithSuggestedTags.tags, newFilter]
             });
             captureEvent("tagAddedToFilters", {tagId, tagName})
           }

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -1,6 +1,6 @@
 import { addGraphQLSchema, Vulcan } from './vulcan-lib';
 import { RateLimiter } from './rateLimiter';
-import React, { useContext, useEffect, useState, useRef } from 'react'
+import React, { useContext, useEffect, useState, useRef, useCallback } from 'react'
 import { hookToHoc } from './hocUtils'
 import { Meteor } from 'meteor/meteor';
 import * as _ from 'underscore';
@@ -91,13 +91,13 @@ export function useTracking({eventType="unnamed", eventProps = {}, captureOnMoun
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skip])
 
-  const track: (type?: string|undefined, trackingData?: Record<string,any>)=>void = (type, trackingData) => {
+  const track = useCallback((type?: string|undefined, trackingData?: Record<string,any>) => (type, trackingData) => {
     captureEvent(type || eventType, {
       ...trackingContext,
       ...eventProps,
       ...trackingData
     })
-  }
+  }, [trackingContext, eventProps, eventType])
   return {captureEvent: track}
 }
 

--- a/packages/lesswrong/lib/crud/withCreate.tsx
+++ b/packages/lesswrong/lib/crud/withCreate.tsx
@@ -75,12 +75,14 @@ export default withCreate;
 
 export const useCreate = ({
   collectionName, collection,
-  fragmentName: fragmentNameArg, fragment: fragmentArg
+  fragmentName: fragmentNameArg, fragment: fragmentArg,
+  ignoreResults=false,
 }: {
   collectionName?: CollectionNameString,
   collection?: any,
   fragmentName?: string,
   fragment?: any,
+  ignoreResults?: boolean,
 }) => {
   ({ collectionName, collection } = extractCollectionInfo({collectionName, collection}));
   const { fragmentName, fragment } = extractFragmentInfo({fragmentName: fragmentNameArg, fragment: fragmentArg}, collectionName);
@@ -91,7 +93,9 @@ export const useCreate = ({
     ${createClientTemplate({ typeName, fragmentName })}
     ${fragment}
   `;
-  const [mutate, {loading, error, called, data}] = useMutation(query);
+  const [mutate, {loading, error, called, data}] = useMutation(query, {
+    ignoreResults: ignoreResults
+  });
   const wrappedCreate = ({ data }) => {
     return mutate({
       variables: { data },

--- a/packages/lesswrong/lib/events/withNewEvents.ts
+++ b/packages/lesswrong/lib/events/withNewEvents.ts
@@ -1,5 +1,5 @@
 import { useCreate } from '../crud/withCreate';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import uuid from 'uuid/v4';
 import { hookToHoc } from '../../lib/hocUtils';
 import * as _ from 'underscore';
@@ -9,9 +9,10 @@ export const useNewEvents = () => {
   const {create: createLWEvent} = useCreate({
     collectionName: "LWEvents",
     fragmentName: "newEventFragment",
+    ignoreResults: true,
   });
   
-  const recordEvent = (name: string, closeOnLeave: boolean, properties: any): string => {
+  const recordEvent = useCallback((name: string, closeOnLeave: boolean, properties: any): string => {
     const { userId, documentId, important, intercom, ...rest} = properties;
     let event = {
       userId,
@@ -32,9 +33,9 @@ export const useNewEvents = () => {
     
     void createLWEvent({data: event});
     return eventId;
-  }
+  }, [events, createLWEvent]);
   
-  const closeEvent = (eventId: string, properties:any={}): string => {
+  const closeEvent = useCallback((eventId: string, properties:any={}): string => {
     let event = events[eventId];
     let currentTime = new Date();
     
@@ -50,22 +51,22 @@ export const useNewEvents = () => {
     
     setEvents(_.omit(events, eventId));
     return eventId;
-  }
+  }, [events, createLWEvent]);
   
-  const closeAllEvents = () => {
+  const closeAllEvents = useCallback(() => {
     Object.keys(events).forEach(key => {
       closeEvent(key);
     });
     setEvents({});
-  };
+  }, [events, closeEvent]);
   
-  const onUnmount = () => {
+  const onUnmount = useCallback(() => {
     Object.keys(events).forEach(key => {
       closeEvent(key);
     });
-  }
+  }, [events, closeEvent]);
   
-  useEffect(() => onUnmount);
+  useEffect(useCallback(() => onUnmount, [onUnmount]));
   
   return {recordEvent, closeAllEvents};
 }

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -1,6 +1,47 @@
 import compose from 'lodash/flowRight';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
+import { shallowEqual, shallowEqualExcept, debugShouldComponentUpdate } from '../utils/componentUtils';
+import * as _ from 'underscore';
+
+type ComparisonFn = (prev: any, next: any)=>boolean
+type ComparePropsDict = { [propName: string]: "shallow"|"ignore"|"deep"|ComparisonFn }
+type AreEqualOption = ComparisonFn|ComparePropsDict|"auto"
+
+// Options passed to registerComponent
+interface ComponentOptions {
+  // JSS styles for this component. These will generate class names, which will
+  // be passed as an extra prop named "classes".
+  styles?: any
+  
+  // Array of higher-order components that this component should be wrapped
+  // with.
+  hocs?: Array<any>
+  
+  // Determines what changes to props are considered relevant, for rerendering.
+  // Takes either "auto" (meaning a shallow comparison of all props), a function
+  // that takes before-and-after props, or an object where keys are names of
+  // props, values are how those props are handled, and props that are not
+  // mentioned are equality-compared. The options for handling a prop are a
+  // function or one of:
+  //   * ignore: Don't rerender this component on changes to this prop
+  //   * shallow: Shallow-compare this prop (this is one level deeper than the
+  //     shallow comparison of all props)
+  //   * deep: Perform a deep comparison of before and after values of this
+  //     prop. (Don't use on prop types that are or contain React components)
+  areEqual?: AreEqualOption
+  
+  // If set, output console log messages reporting when this component is
+  // rerendered, and which props changed to trigger it.
+  debugRerenders?: boolean,
+}
+
+interface ComponentsTableEntry {
+  name: string
+  rawComponent: any
+  hocs: Array<any>
+  options?: ComponentOptions,
+}
 
 const componentsProxyHandler = {
   get: function(obj, prop) {
@@ -12,17 +53,19 @@ const componentsProxyHandler = {
   }
 }
 
-// will be populated on startup (see vulcan:routing)
+// Acts like a mapping from component-name to component, based on
+// registerComponents calls. Lazily loads those components when you dereference,
+// using a proxy.
 export const Components: ComponentTypes = new Proxy({}, componentsProxyHandler);
 
 const PreparedComponents = {};
 
 // storage for infos about components
-const ComponentsTable = {};
+const ComponentsTable: Record<string, ComponentsTableEntry> = {};
 
 const DeferredComponentsTable = {};
 
-const coreComponents = [
+const coreComponents: Array<string> = [
   'Alert',
   'Button',
   'Modal',
@@ -46,63 +89,17 @@ const coreComponents = [
 type C<T=any> = React.ComponentType<T>
 type HoC<O,T> = (component: C<O>) => C<T>
 
-/**
- * Register a Vulcan component with a name, a raw component than can be extended
- * and one or more optional higher order components.
- *
- * @param {String} name The name of the component to register.
- * @param {React Component} rawComponent Interchangeable/extendable component.
- * @param {...Function} hocs The HOCs to compose with the raw component.
- *
- * Note: when a component is registered without higher order component, `hocs` will be
- * an empty array, and it's ok!
- * See https://github.com/reactjs/redux/blob/master/src/compose.js#L13-L15
- *
- * @returns Structure of a component in the list:
- *
- * ComponentsTable.Foo = {
- *    name: 'Foo',
- *    hocs: [fn1, fn2],
- *    rawComponent: React.Component,
- *    call: () => compose(...hocs)(rawComponent),
- * }
- *
- */
-/*export function registerComponent<PropType>(name, rawComponent, ...hocs): React.ComponentType<Omit<PropType,"classes">> {
-  var styles = null;
-  
-  // support single-argument syntax
-  if (typeof arguments[0] === 'object') {
-    // note: cannot use `const` because name, components, hocs are already defined
-    // as arguments so destructuring cannot work
-    // eslint-disable-next-line no-redeclare
-    var { name, component, hocs = [], styles } = arguments[0];
-    rawComponent = component;
-  } else if (typeof arguments[2] === 'object' && (arguments[2].hocs || arguments[2].styles)) {
-    styles = arguments[2].styles;
-    hocs = arguments[2].hocs || [];
-  }
-  
-  if (styles) {
-    hocs.push(withStyles(styles, {name: name}));
-  }
-  
-  rawComponent.displayName = name;
-  
-  if (name in ComponentsTable && ComponentsTable[name].rawComponent !== rawComponent) {
-    throw new Error(`Two components with the same name: ${name}`);
-  }
-  
-  // store the component in the table
-  ComponentsTable[name] = {
-    name,
-    rawComponent,
-    hocs,
-  };
-}*/
-
+// Register a component. Takes a name, a raw component, and ComponentOptions
+// (see above). Components should be in their own file, imported with
+// `importComponent`, and registered in that file; components that are
+// registered this way can be accessed via the Components object and are lazy-
+// loaded.
+//
+// Returns a dummy value--null, but coerced to a type that you can add to the
+// ComponentTypes interface to type-check usages of the component in other
+// files.
 export function registerComponent<PropType>(name: string, rawComponent: React.ComponentType<PropType>,
-  options?: {styles?: any, hocs?: Array<any>}): React.ComponentType<Omit<PropType,"classes">>
+  options?: ComponentOptions): React.ComponentType<Omit<PropType,"classes">>
 {
   const { styles=null, hocs=[] } = options || {};
   if (styles) {
@@ -120,6 +117,7 @@ export function registerComponent<PropType>(name: string, rawComponent: React.Co
     name,
     rawComponent,
     hocs,
+    options,
   };
   
   return (null as any as React.ComponentType<Omit<PropType,"classes">>);
@@ -146,7 +144,7 @@ export function importAllComponents() {
   }
 }
 
-function prepareComponent(componentName)
+function prepareComponent(componentName: string)
 {
   if (componentName in PreparedComponents) {
     return PreparedComponents[componentName];
@@ -166,19 +164,20 @@ function prepareComponent(componentName)
   }
 }
 
-/**
- * Get a component registered with registerComponent(name, component, ...hocs).
- *
- * @param {String} name The name of the component to get.
- * @returns {Function|React Component} A (wrapped) React component
- */
-const getComponent = name => {
-  const component = ComponentsTable[name];
-  if (!component) {
+// Get a component registered with registerComponent, applying HoCs and other
+// wrappings.
+const getComponent = (name: string): any => {
+  const componentMeta = ComponentsTable[name];
+  if (!componentMeta) {
     throw new Error(`Component ${name} not registered.`);
   }
-  if (component.hocs && component.hocs.length) {
-    const hocs = component.hocs.map(hoc => {
+  
+  const componentWithMemo = componentMeta.options?.areEqual
+    ? memoizeComponent(componentMeta.options.areEqual, componentMeta.rawComponent, name, !!componentMeta.options.debugRerenders)
+    : componentMeta.rawComponent;
+  
+  if (componentMeta.hocs && componentMeta.hocs.length) {
+    const hocs = componentMeta.hocs.map(hoc => {
       if (!Array.isArray(hoc)) {
         if (typeof hoc !== 'function') {
           throw new Error(`In registered component ${name}, an hoc is of type ${typeof hoc}`);
@@ -192,17 +191,85 @@ const getComponent = name => {
       return actualHoc(...args);
     });
     // @ts-ignore
-    return compose(...hocs)(component.rawComponent);
+    return compose(...hocs)(componentWithMemo);
   } else {
-    return component.rawComponent;
+    return componentWithMemo;
   }
 };
+
+const memoizeComponent = (areEqual: AreEqualOption, component: any, name: string, debugRerenders: boolean): any => {
+  if (areEqual === "auto") {
+    if (debugRerenders) {
+      return React.memo(component, (oldProps, newProps) => {
+        // eslint-disable-next-line no-console
+        return debugShouldComponentUpdate(name, console.log, oldProps, {}, newProps, {});
+      });
+    } else {
+      return React.memo(component);
+    }
+  } else if (typeof areEqual==='function') {
+    return React.memo(component, areEqual);
+  } else {
+    return React.memo(component, (oldProps, newProps) => {
+      const speciallyHandledKeys = Object.keys(areEqual);
+      if (!shallowEqualExcept(oldProps, newProps, speciallyHandledKeys)) {
+        if (debugRerenders) {
+          // eslint-disable-next-line no-console
+          debugShouldComponentUpdate(name, console.log, oldProps, {}, newProps, {});
+        }
+        return false;
+      }
+      for (let key of speciallyHandledKeys) {
+        if (typeof areEqual[key]==="function") {
+          if (!(areEqual[key] as ComparisonFn)(oldProps[key], newProps[key])) {
+            if (debugRerenders) {
+              // eslint-disable-next-line no-console
+              console.log(`Updating ${name} because props.${key} changed`);
+            }
+            return false;
+          }
+        } else switch(areEqual[key]) {
+          case "ignore":
+            break;
+          case "default":
+            if (oldProps[key] !== newProps[key]) {
+              if (debugRerenders) {
+                // eslint-disable-next-line no-console
+                console.log(`Updating ${name} because props.${key} changed`);
+              }
+              return false;
+            }
+            break;
+          case "shallow":
+            if (!shallowEqual(oldProps[key], newProps[key])) {
+              if (debugRerenders) {
+                // eslint-disable-next-line no-console
+                console.log(`Updating ${name} because props.${key} changed`);
+              }
+              return false;
+            }
+            break;
+          case "deep":
+            if (!_.isEqual(oldProps[key], newProps[key])) {
+              if (debugRerenders) {
+                // eslint-disable-next-line no-console
+                console.log(`Updating ${name} because props.${key} changed`);
+              }
+              return false;
+            }
+            break;
+        }
+      }
+      return true;
+    });
+  }
+}
 
 /**
  * Populate the lookup table for components to be callable
  * ℹ️ Called once on app startup
  **/
-export const populateComponentsApp = () => {
+export const populateComponentsApp = (): void => {
   const missingComponents: Array<string> = [];
   for (let coreComponent of coreComponents) {
     if (!(coreComponent in ComponentsTable) && !(coreComponent in DeferredComponentsTable)) {
@@ -224,12 +291,10 @@ export const populateComponentsApp = () => {
   }
 };
 
-/**
- * Returns an instance of the given component name of function
- * @param {string|function} component  A component or registered component name
- * @param {Object} [props]  Optional properties to pass to the component
- */
-//eslint-disable-next-line react/display-name
+// Returns an instance of the given component name of function
+//
+// @param {string|function} component  A component or registered component name
+// @param {Object} [props]  Optional properties to pass to the component
 export const instantiateComponent = (component, props) => {
   if (!component) {
     return null;


### PR DESCRIPTION
Client-side Javascript execution recently regressed pretty severely (from front-page logged-out execution time ~4s, to ~10s). This fixes a bunch of things that were causing rerenders, bringing performance back to where it used to be, and adds infrastructure for memoizing components.