### PR TITLE
Fix RSS Imports by adding better catch statements

### DIFF
--- a/packages/lesswrong/server/rss-integration/cron.ts
+++ b/packages/lesswrong/server/rss-integration/cron.ts
@@ -6,77 +6,75 @@ import Users from '../../lib/collections/users/collection';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 
 const runRSSImport = async () => {
-  try {
-    const feedparser = require('feedparser-promised');
-    const feeds = RSSFeeds.find({status: {$ne: 'inactive'}}).fetch()
-    await asyncForeachSequential(feeds, async feed => {
-      try {
-        // create array of all posts in current rawFeed object
-        let previousPosts = feed.rawFeed || [];
+  const feedparser = require('feedparser-promised');
+  const feeds = RSSFeeds.find({status: {$ne: 'inactive'}}).fetch()
+  await asyncForeachSequential(feeds, async feed => {
+    try {
+      // create array of all posts in current rawFeed object
+      let previousPosts = feed.rawFeed || [];
 
-        // check the feed for new posts
-        const url = feed.url;
-        const currentPosts = await feedparser.parse(url);
-        
-        let newPosts: Array<any> = currentPosts.filter(function (post) {
-          return !previousPosts.some(prevPost => {
-            return post.guid === prevPost.guid
-          })
+      // check the feed for new posts
+      const url = feed.url;
+      const currentPosts = await feedparser.parse(url);
+      
+      let newPosts: Array<any> = currentPosts.filter(function (post) {
+        return !previousPosts.some(prevPost => {
+          return post.guid === prevPost.guid
         })
+      })
 
-        // update feed object with new feed data (mutation)
-        var set: any = {};
-        set.rawFeed = currentPosts;
+      // update feed object with new feed data (mutation)
+      var set: any = {};
+      set.rawFeed = currentPosts;
 
-        await editMutation({
-          collection: RSSFeeds,
-          documentId: feed._id,
-          set: set,
+      await editMutation({
+        collection: RSSFeeds,
+        documentId: feed._id,
+        set: set,
+        validate: false,
+      })
+
+      await asyncForeachSequential(newPosts, async newPost => {
+        var body;
+
+        if (newPost['content:encoded'] && newPost.displayFullContent) {
+          body = newPost['content:encoded'];
+        } else if (newPost.description) {
+          body = newPost.description;
+        } else if (newPost.summary) {
+          body = newPost.summary;
+        } else {
+          body = "";
+        }
+
+        var post = {
+          title: newPost.title,
+          userId: feed.userId,
+          canonicalSource: feed.setCanonicalUrl ? newPost.link : undefined,
+          contents: {
+            originalContents: {
+              type: "html",
+              data: body
+            }
+          },
+          feedId: feed._id,
+          feedLink: newPost.link
+        };
+
+        let lwUser = Users.findOne({_id: feed.userId});
+
+        await newMutation({
+          collection: Posts,
+          document: post,
+          currentUser: lwUser,
           validate: false,
         })
-
-        await asyncForeachSequential(newPosts, async newPost => {
-          var body;
-
-          if (newPost['content:encoded'] && newPost.displayFullContent) {
-            body = newPost['content:encoded'];
-          } else if (newPost.description) {
-            body = newPost.description;
-          } else if (newPost.summary) {
-            body = newPost.summary;
-          } else {
-            body = "";
-          }
-
-          var post = {
-            title: newPost.title,
-            userId: feed.userId,
-            canonicalSource: feed.setCanonicalUrl ? newPost.link : undefined,
-            contents: {
-              originalContents: {
-                type: "html",
-                data: body
-              }
-            },
-            feedId: feed._id,
-            feedLink: newPost.link
-          };
-
-          let lwUser = Users.findOne({_id: feed.userId});
-
-          await newMutation({
-            collection: Posts,
-            document: post,
-            currentUser: lwUser,
-            validate: false,
-          })
-        })
-      } catch(error) {
-        //eslint-disable-next-line no-console
-        console.error('RSS error: ', error, feed);
-      }
-    })
-  } 
+      })
+    } catch(error) {
+      //eslint-disable-next-line no-console
+      console.error('RSS error: ', error, feed);
+    }
+  })
 }
 
 

--- a/packages/lesswrong/server/rss-integration/cron.ts
+++ b/packages/lesswrong/server/rss-integration/cron.ts
@@ -88,4 +88,4 @@ addCronJob({
   job: runRSSImport
 });
 
-Vulcan.runRSSImpoort = runRSSImport
+Vulcan.runRSSImport = runRSSImport

--- a/packages/lesswrong/server/rss-integration/cron.ts
+++ b/packages/lesswrong/server/rss-integration/cron.ts
@@ -1,84 +1,91 @@
 import { addCronJob } from '../cronUtil';
 import RSSFeeds from '../../lib/collections/rssfeeds/collection';
-import { newMutation, editMutation } from '../vulcan-lib';
+import { newMutation, editMutation, Vulcan } from '../vulcan-lib';
 import { Posts } from '../../lib/collections/posts';
 import Users from '../../lib/collections/users/collection';
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
+
+const runRSSImport = async () => {
+  try {
+    const feedparser = require('feedparser-promised');
+    const feeds = RSSFeeds.find({status: {$ne: 'inactive'}}).fetch()
+    await asyncForeachSequential(feeds, async feed => {
+      try {
+        // create array of all posts in current rawFeed object
+        let previousPosts = feed.rawFeed || [];
+
+        // check the feed for new posts
+        const url = feed.url;
+        const currentPosts = await feedparser.parse(url);
+        
+        let newPosts: Array<any> = currentPosts.filter(function (post) {
+          return !previousPosts.some(prevPost => {
+            return post.guid === prevPost.guid
+          })
+        })
+
+        // update feed object with new feed data (mutation)
+        var set: any = {};
+        set.rawFeed = currentPosts;
+
+        await editMutation({
+          collection: RSSFeeds,
+          documentId: feed._id,
+          set: set,
+          validate: false,
+        })
+
+        await asyncForeachSequential(newPosts, async newPost => {
+          var body;
+
+          if (newPost['content:encoded'] && newPost.displayFullContent) {
+            body = newPost['content:encoded'];
+          } else if (newPost.description) {
+            body = newPost.description;
+          } else if (newPost.summary) {
+            body = newPost.summary;
+          } else {
+            body = "";
+          }
+
+          var post = {
+            title: newPost.title,
+            userId: feed.userId,
+            canonicalSource: feed.setCanonicalUrl ? newPost.link : undefined,
+            contents: {
+              originalContents: {
+                type: "html",
+                data: body
+              }
+            },
+            feedId: feed._id,
+            feedLink: newPost.link
+          };
+
+          let lwUser = Users.findOne({_id: feed.userId});
+
+          await newMutation({
+            collection: Posts,
+            document: post,
+            currentUser: lwUser,
+            validate: false,
+          })
+        })
+      } catch(error) {
+        //eslint-disable-next-line no-console
+        console.error('RSS error: ', error, feed);
+      }
+    })
+  } 
+}
+
 
 addCronJob({
   name: 'addNewRSSPosts',
   schedule(parser) {
     return parser.text('every 10 minutes');
   },
-  async job() {
-    const feedparser = require('feedparser-promised');
-
-    const feeds = RSSFeeds.find({status: {$ne: 'inactive'}}).fetch()
-    await asyncForeachSequential(feeds, async feed => {
-      // create array of all posts in current rawFeed object
-      let previousPosts = feed.rawFeed || [];
-
-      // check the feed for new posts
-      const url = feed.url;
-      const currentPosts = await feedparser.parse(url);
-      
-      let newPosts: Array<any> = currentPosts.filter(function (post) {
-        return !previousPosts.some(prevPost => {
-          return post.guid === prevPost.guid
-        })
-      })
-
-      // update feed object with new feed data (mutation)
-      var set: any = {};
-      set.rawFeed = currentPosts;
-
-      await editMutation({
-        collection: RSSFeeds,
-        documentId: feed._id,
-        set: set,
-        validate: false,
-      })
-
-      await asyncForeachSequential(newPosts, async newPost => {
-        var body;
-
-        if (newPost['content:encoded'] && newPost.displayFullContent) {
-          body = newPost['content:encoded'];
-        } else if (newPost.description) {
-          body = newPost.description;
-        } else if (newPost.summary) {
-          body = newPost.summary;
-        } else {
-          body = "";
-        }
-
-        var post = {
-          title: newPost.title,
-          userId: feed.userId,
-          canonicalSource: feed.setCanonicalUrl ? newPost.link : undefined,
-          contents: {
-            originalContents: {
-              type: "html",
-              data: body
-            }
-          },
-          feedId: feed._id,
-          feedLink: newPost.link
-        };
-
-        let lwUser = Users.findOne({_id: feed.userId});
-
-        await newMutation({
-          collection: Posts,
-          document: post,
-          currentUser: lwUser,
-          validate: false,
-        })
-      }).catch( (error) => {
-        // console.log(feed);
-        //eslint-disable-next-line no-console
-        console.error('RSS error: ', error);
-      });
-    })
-  }
+  job: runRSSImport
 });
+
+Vulcan.runRSSImpoort = runRSSImport


### PR DESCRIPTION
This fixes a bug in RSS imports that caused some fraction of RSS imports to not properly run, because the changes in [this commit](https://github.com/LessWrong2/Lesswrong2/commit/79609dbe3e885ad44bcbcb189b24342da2431225) made it so that it would break the loop if it errored on any of the feeds, and we have some feeds whose feed URLS are no longer valid, so everything that was usually parsed after that was no longer being imported.

After testing, I can verify that the only RSS feed impacted by this was the AI Alignment Newsletter, which is why I didn't notice this earlier.