### PR TITLE
Fix performance problems with the `truncatise` library

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "simpl-schema": "^1.5.0",
     "speakingurl": "^9.0.0",
     "tlds": "^1.203.1",
-    "truncatise": "0.0.7",
     "turndown": "^4.0.2",
     "typescript": "^3.7.3",
     "underscore": "^1.9.1",

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -2,7 +2,7 @@ import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import React, { useState } from 'react';
 import {useNewEvents} from '../../../lib/events/withNewEvents';
 import { useCurrentUser } from '../../common/withUser';
-import truncatise from 'truncatise';
+import truncatise from '../../../lib/truncatise';
 import Edit from '@material-ui/icons/Edit';
 import Users from '../../../lib/collections/users/collection';
 import { Posts } from '../../../lib/collections/posts/collection';

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -2,7 +2,7 @@ import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import React, { useState } from 'react';
 import {useNewEvents} from '../../../lib/events/withNewEvents';
 import { useCurrentUser } from '../../common/withUser';
-import truncatise from '../../../lib/truncatise';
+import { truncatise } from '../../../lib/truncatise';
 import Edit from '@material-ui/icons/Edit';
 import Users from '../../../lib/collections/users/collection';
 import { Posts } from '../../../lib/collections/posts/collection';

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -1,4 +1,4 @@
-import truncatise from 'truncatise';
+import truncatise from '../truncatise';
 
 const highlightMaxChars = 2400;
 export const GTP2_TRUNCATION_CHAR_COUNT = 400;

--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -1,4 +1,4 @@
-import truncatise from '../truncatise';
+import { truncatise } from '../truncatise';
 
 const highlightMaxChars = 2400;
 export const GTP2_TRUNCATION_CHAR_COUNT = 400;

--- a/packages/lesswrong/lib/truncatise.ts
+++ b/packages/lesswrong/lib/truncatise.ts
@@ -24,197 +24,187 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 //
-(function(exportTo) {
-    "use strict";
+"use strict";
 
-    var selfClosingTags = ["area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"];
+var selfClosingTags = ["area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"];
 
-    /**
-     * Truncates a given HTML string to the specified length.
-     * @param {string} text This is the HTMl string to be truncated
-     * @param {object} options An options object defining how to truncate
-     *      Default values:
-     *      {
-     *          TruncateBy : 'words',   // Options are 'words', 'characters' or 'paragraphs'
-     *          TruncateLength : 50,    // The count to be used with TruncatedBy
-     *          StripHTML : false,      // Whether or not the truncated text should contain HTML tags
-     *          Strict : true,          // When set to false the truncated text finish at the end of the word
-     *          Suffix : '...'          // Text to be appended to the end of the truncated text
-     *      }
-     * @return {string} This returns the provided string truncated to the
-     *      length provided by the options. HTML tags may be stripped based
-     *      on the given options.
-     */
-    var truncatise = function(text,options) {
-        var options         = options || {},
-            text            = (text || "").trim(),
-            truncatedText   = "",
-            currentState    = 0,
-            isEndOfWord     = false,
-            isTagOpen       = false,
-            currentTag      = "",
-            tagStack        = [],
-            nextChar        = "";
-        //Counters
-        var charCounter         = 0,
-            wordCounter         = 0,
-            paragraphCounter    = 0;
-        //currentState values
-        var NOT_TAG         = 0,
-            TAG_START       = 1,
-            TAG_ATTRIBUTES  = 2;
+/**
+ * Truncates a given HTML string to the specified length.
+ * @param {string} text This is the HTMl string to be truncated
+ * @param {object} options An options object defining how to truncate
+ *      Default values:
+ *      {
+ *          TruncateBy : 'words',   // Options are 'words', 'characters' or 'paragraphs'
+ *          TruncateLength : 50,    // The count to be used with TruncatedBy
+ *          StripHTML : false,      // Whether or not the truncated text should contain HTML tags
+ *          Strict : true,          // When set to false the truncated text finish at the end of the word
+ *          Suffix : '...'          // Text to be appended to the end of the truncated text
+ *      }
+ * @return {string} This returns the provided string truncated to the
+ *      length provided by the options. HTML tags may be stripped based
+ *      on the given options.
+ */
+export const truncatise = function(text,options) {
+    var options         = options || {},
+        text            = (text || "").trim(),
+        truncatedText   = "",
+        currentState    = 0,
+        isEndOfWord     = false,
+        isTagOpen       = false,
+        currentTag      = "",
+        tagStack: Array<any> = [],
+        nextChar        = "";
+    //Counters
+    var charCounter         = 0,
+        wordCounter         = 0,
+        paragraphCounter    = 0;
+    //currentState values
+    var NOT_TAG         = 0,
+        TAG_START       = 1,
+        TAG_ATTRIBUTES  = 2;
 
-        //Set default values
-        options.TruncateBy      = (options.TruncateBy === undefined
-                                    || typeof options.TruncateBy !==  "string"
-                                    || !options.TruncateBy.match(/(word(s)?|character(s)?|paragraph(s)?)/))
-                                ? 'words'
-                                : options.TruncateBy.toLowerCase();
-        options.TruncateLength  = (options.TruncateLength === undefined
-                                    || typeof options.TruncateLength !== "number")
-                                ? 50
-                                : options.TruncateLength;
-        options.StripHTML       = (options.StripHTML === undefined
-                                    || typeof options.StripHTML !== "boolean")
-                                ? false
-                                : options.StripHTML;
-        options.Strict          = (options.Strict === undefined
-                                    || typeof options.Strict !== "boolean")
-                                ? true
-                                : options.Strict;
-        options.Suffix          = (options.Suffix === undefined
-                                    || typeof options.Suffix !== "string")
-                                ? '...'
-                                : options.Suffix;
+    //Set default values
+    options.TruncateBy      = (options.TruncateBy === undefined
+                                || typeof options.TruncateBy !==  "string"
+                                || !options.TruncateBy.match(/(word(s)?|character(s)?|paragraph(s)?)/))
+                            ? 'words'
+                            : options.TruncateBy.toLowerCase();
+    options.TruncateLength  = (options.TruncateLength === undefined
+                                || typeof options.TruncateLength !== "number")
+                            ? 50
+                            : options.TruncateLength;
+    options.StripHTML       = (options.StripHTML === undefined
+                                || typeof options.StripHTML !== "boolean")
+                            ? false
+                            : options.StripHTML;
+    options.Strict          = (options.Strict === undefined
+                                || typeof options.Strict !== "boolean")
+                            ? true
+                            : options.Strict;
+    options.Suffix          = (options.Suffix === undefined
+                                || typeof options.Suffix !== "string")
+                            ? '...'
+                            : options.Suffix;
 
-        var matchByWords = options.TruncateBy==="word"||options.TruncateBy==="words";
-        var matchByCharacters = options.TruncateBy==="character"||options.TruncateBy==="characters";
-        var matchByParagraphs = options.TruncateBy==="paragraph"||options.TruncateBy==="paragraphs";
-        
-        if(text === "" || (text.length <= options.TruncateLength && options.StripHTML === false)){
-            return text;
-        }
-
-        if(options.StripHTML) {
-            text = String(text).replace(/<br( \/)?>/gi, ' ');
-        }
-
-        //If not splitting on paragraphs we can quickly remove tags using regex
-        if(options.StripHTML && !matchByParagraphs){
-            text = String(text).replace(/<!--(.*?)-->/gm, '').replace(/<\/?[^>]+>/gi, '');
-        }
-        //Remove newline seperating paragraphs
-        text = String(text).replace(/<\/p>(\r?\n)+<p>/gm, '</p><p>');
-        //Replace double newlines with paragraphs
-        if(options.StripHTML && String(text).match(/\r?\n\r?\n/)){
-            text = String(text).replace(/((.+)(\r?\n\r?\n|$))/gi, "<p>$2</p>");
-        }
-
-        for (var pointer = 0; pointer < text.length; pointer++ ) {
-
-            var currentChar = text[pointer];
-
-            switch(currentChar){
-                case "<":
-                    if(currentState === NOT_TAG){
-                        currentState = TAG_START;
-                        currentTag = "";
-                    }
-                    if(!options.StripHTML){
-                        truncatedText += currentChar;
-                    }
-                    break;
-                case ">":
-                    if(currentState === TAG_START || currentState === TAG_ATTRIBUTES){
-                        currentState = NOT_TAG;
-                        currentTag = currentTag.toLowerCase();
-                        if(currentTag === "/p"){
-                            paragraphCounter++;
-                            if(options.StripHTML){
-                                truncatedText += " ";
-                            }
-                        }
-
-                        // Ignore self-closing tags.
-                        if ((selfClosingTags.indexOf(currentTag) === -1) && (selfClosingTags.indexOf(currentTag + '/') === -1)) {
-                            if(currentTag.indexOf("/") >= 0){
-                                tagStack.pop();
-                            } else {
-                                tagStack.push(currentTag);
-                            }
-                        }
-                    }
-                    if(!options.StripHTML){
-                        truncatedText += currentChar;
-                    }
-                    break;
-                case " ":
-                    if(currentState === TAG_START){
-                        currentState = TAG_ATTRIBUTES;
-                    }
-                    if(currentState === NOT_TAG){
-                        wordCounter++;
-                        charCounter++;
-                    }
-                    if(currentState === NOT_TAG || !options.StripHTML){
-                        truncatedText += currentChar;
-                    }
-                    break;
-                default:
-                    if(currentState === NOT_TAG){
-                        charCounter++;
-                    }
-                    if(currentState === TAG_START){
-                        currentTag += currentChar;
-                    }
-                    if(currentState === NOT_TAG || !options.StripHTML){
-                        truncatedText += currentChar;
-                    }
-                    break;
-            }
-
-            nextChar = text[pointer + 1] || "";
-
-            if(matchByWords && options.TruncateLength <= wordCounter){
-                truncatedText = truncatedText.replace(/\s+$/, '');
-                break;
-            }
-            if(matchByCharacters && options.TruncateLength <= charCounter) {
-              isEndOfWord = options.Strict ? true : (!currentChar.match(/[a-zA-ZÇ-Ü']/i) || !nextChar.match(/[a-zA-ZÇ-Ü']/i));
-              if (isEndOfWord) {
-                break;
-              }
-            }
-            if(matchByParagraphs && options.TruncateLength === paragraphCounter){
-                break;
-            }
-        }
-
-        if(!options.StripHTML && tagStack.length > 0){
-            while(tagStack.length > 0){
-                var tag = tagStack.pop();
-                if(tag!=="!--"){
-                    truncatedText += "</"+tag+">";
-                }
-            }
-        }
-
-        if(pointer < text.length - 1) {
-          if(truncatedText.match(/<\/p>$/gi)){
-              truncatedText = truncatedText.replace(/(<\/p>)$/gi, options.Suffix + "$1");
-          }else{
-              truncatedText = truncatedText + options.Suffix;
-          }
-        }
-
-        return truncatedText.trim();
-    };
-
-    // Export to node
-    if (typeof module !== 'undefined' && module.exports){
-        return module.exports = truncatise;
+    var matchByWords = options.TruncateBy==="word"||options.TruncateBy==="words";
+    var matchByCharacters = options.TruncateBy==="character"||options.TruncateBy==="characters";
+    var matchByParagraphs = options.TruncateBy==="paragraph"||options.TruncateBy==="paragraphs";
+    
+    if(text === "" || (text.length <= options.TruncateLength && options.StripHTML === false)){
+        return text;
     }
 
-    // Nope, export to the browser instead.
-    exportTo.truncatise = truncatise;
-}(this));
+    if(options.StripHTML) {
+        text = String(text).replace(/<br( \/)?>/gi, ' ');
+    }
+
+    //If not splitting on paragraphs we can quickly remove tags using regex
+    if(options.StripHTML && !matchByParagraphs){
+        text = String(text).replace(/<!--(.*?)-->/gm, '').replace(/<\/?[^>]+>/gi, '');
+    }
+    //Remove newline seperating paragraphs
+    text = String(text).replace(/<\/p>(\r?\n)+<p>/gm, '</p><p>');
+    //Replace double newlines with paragraphs
+    if(options.StripHTML && String(text).match(/\r?\n\r?\n/)){
+        text = String(text).replace(/((.+)(\r?\n\r?\n|$))/gi, "<p>$2</p>");
+    }
+
+    for (var pointer = 0; pointer < text.length; pointer++ ) {
+
+        var currentChar = text[pointer];
+
+        switch(currentChar){
+            case "<":
+                if(currentState === NOT_TAG){
+                    currentState = TAG_START;
+                    currentTag = "";
+                }
+                if(!options.StripHTML){
+                    truncatedText += currentChar;
+                }
+                break;
+            case ">":
+                if(currentState === TAG_START || currentState === TAG_ATTRIBUTES){
+                    currentState = NOT_TAG;
+                    currentTag = currentTag.toLowerCase();
+                    if(currentTag === "/p"){
+                        paragraphCounter++;
+                        if(options.StripHTML){
+                            truncatedText += " ";
+                        }
+                    }
+
+                    // Ignore self-closing tags.
+                    if ((selfClosingTags.indexOf(currentTag) === -1) && (selfClosingTags.indexOf(currentTag + '/') === -1)) {
+                        if(currentTag.indexOf("/") >= 0){
+                            tagStack.pop();
+                        } else {
+                            tagStack.push(currentTag);
+                        }
+                    }
+                }
+                if(!options.StripHTML){
+                    truncatedText += currentChar;
+                }
+                break;
+            case " ":
+                if(currentState === TAG_START){
+                    currentState = TAG_ATTRIBUTES;
+                }
+                if(currentState === NOT_TAG){
+                    wordCounter++;
+                    charCounter++;
+                }
+                if(currentState === NOT_TAG || !options.StripHTML){
+                    truncatedText += currentChar;
+                }
+                break;
+            default:
+                if(currentState === NOT_TAG){
+                    charCounter++;
+                }
+                if(currentState === TAG_START){
+                    currentTag += currentChar;
+                }
+                if(currentState === NOT_TAG || !options.StripHTML){
+                    truncatedText += currentChar;
+                }
+                break;
+        }
+
+        nextChar = text[pointer + 1] || "";
+
+        if(matchByWords && options.TruncateLength <= wordCounter){
+            truncatedText = truncatedText.replace(/\s+$/, '');
+            break;
+        }
+        if(matchByCharacters && options.TruncateLength <= charCounter) {
+          isEndOfWord = options.Strict ? true : (!currentChar.match(/[a-zA-ZÇ-Ü']/i) || !nextChar.match(/[a-zA-ZÇ-Ü']/i));
+          if (isEndOfWord) {
+            break;
+          }
+        }
+        if(matchByParagraphs && options.TruncateLength === paragraphCounter){
+            break;
+        }
+    }
+
+    if(!options.StripHTML && tagStack.length > 0){
+        while(tagStack.length > 0){
+            var tag = tagStack.pop();
+            if(tag!=="!--"){
+                truncatedText += "</"+tag+">";
+            }
+        }
+    }
+
+    if(pointer < text.length - 1) {
+      if(truncatedText.match(/<\/p>$/gi)){
+          truncatedText = truncatedText.replace(/(<\/p>)$/gi, options.Suffix + "$1");
+      }else{
+          truncatedText = truncatedText + options.Suffix;
+      }
+    }
+
+    return truncatedText.trim();
+};

--- a/packages/lesswrong/lib/truncatise.ts
+++ b/packages/lesswrong/lib/truncatise.ts
@@ -87,6 +87,10 @@
                                 ? '...'
                                 : options.Suffix;
 
+        var matchByWords = options.TruncateBy==="word"||options.TruncateBy==="words";
+        var matchByCharacters = options.TruncateBy==="character"||options.TruncateBy==="characters";
+        var matchByParagraphs = options.TruncateBy==="paragraph"||options.TruncateBy==="paragraphs";
+        
         if(text === "" || (text.length <= options.TruncateLength && options.StripHTML === false)){
             return text;
         }
@@ -96,7 +100,7 @@
         }
 
         //If not splitting on paragraphs we can quickly remove tags using regex
-        if(options.StripHTML && !options.TruncateBy.match(/(paragraph(s)?)/)){
+        if(options.StripHTML && !matchByParagraphs){
             text = String(text).replace(/<!--(.*?)-->/gm, '').replace(/<\/?[^>]+>/gi, '');
         }
         //Remove newline seperating paragraphs
@@ -170,16 +174,18 @@
             }
 
             nextChar = text[pointer + 1] || "";
-            isEndOfWord = options.Strict ? true : (!currentChar.match(/[a-zA-ZÇ-Ü']/i) || !nextChar.match(/[a-zA-ZÇ-Ü']/i));
 
-            if(options.TruncateBy.match(/word(s)?/i) && options.TruncateLength <= wordCounter){
+            if(matchByWords && options.TruncateLength <= wordCounter){
                 truncatedText = truncatedText.replace(/\s+$/, '');
                 break;
             }
-            if(options.TruncateBy.match(/character(s)?/i) && options.TruncateLength <= charCounter && isEndOfWord){
+            if(matchByCharacters && options.TruncateLength <= charCounter) {
+              isEndOfWord = options.Strict ? true : (!currentChar.match(/[a-zA-ZÇ-Ü']/i) || !nextChar.match(/[a-zA-ZÇ-Ü']/i));
+              if (isEndOfWord) {
                 break;
+              }
             }
-            if(options.TruncateBy.match(/paragraph(s)?/i) && options.TruncateLength === paragraphCounter){
+            if(matchByParagraphs && options.TruncateLength === paragraphCounter){
                 break;
             }
         }

--- a/packages/lesswrong/lib/truncatise.ts
+++ b/packages/lesswrong/lib/truncatise.ts
@@ -1,0 +1,214 @@
+//
+// truncatise, by Marcus Noble. Forked from
+// https://github.com/AverageMarcus/Truncatise
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 Marcus Noble
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+(function(exportTo) {
+    "use strict";
+
+    var selfClosingTags = ["area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"];
+
+    /**
+     * Truncates a given HTML string to the specified length.
+     * @param {string} text This is the HTMl string to be truncated
+     * @param {object} options An options object defining how to truncate
+     *      Default values:
+     *      {
+     *          TruncateBy : 'words',   // Options are 'words', 'characters' or 'paragraphs'
+     *          TruncateLength : 50,    // The count to be used with TruncatedBy
+     *          StripHTML : false,      // Whether or not the truncated text should contain HTML tags
+     *          Strict : true,          // When set to false the truncated text finish at the end of the word
+     *          Suffix : '...'          // Text to be appended to the end of the truncated text
+     *      }
+     * @return {string} This returns the provided string truncated to the
+     *      length provided by the options. HTML tags may be stripped based
+     *      on the given options.
+     */
+    var truncatise = function(text,options) {
+        var options         = options || {},
+            text            = (text || "").trim(),
+            truncatedText   = "",
+            currentState    = 0,
+            isEndOfWord     = false,
+            isTagOpen       = false,
+            currentTag      = "",
+            tagStack        = [],
+            nextChar        = "";
+        //Counters
+        var charCounter         = 0,
+            wordCounter         = 0,
+            paragraphCounter    = 0;
+        //currentState values
+        var NOT_TAG         = 0,
+            TAG_START       = 1,
+            TAG_ATTRIBUTES  = 2;
+
+        //Set default values
+        options.TruncateBy      = (options.TruncateBy === undefined
+                                    || typeof options.TruncateBy !==  "string"
+                                    || !options.TruncateBy.match(/(word(s)?|character(s)?|paragraph(s)?)/))
+                                ? 'words'
+                                : options.TruncateBy.toLowerCase();
+        options.TruncateLength  = (options.TruncateLength === undefined
+                                    || typeof options.TruncateLength !== "number")
+                                ? 50
+                                : options.TruncateLength;
+        options.StripHTML       = (options.StripHTML === undefined
+                                    || typeof options.StripHTML !== "boolean")
+                                ? false
+                                : options.StripHTML;
+        options.Strict          = (options.Strict === undefined
+                                    || typeof options.Strict !== "boolean")
+                                ? true
+                                : options.Strict;
+        options.Suffix          = (options.Suffix === undefined
+                                    || typeof options.Suffix !== "string")
+                                ? '...'
+                                : options.Suffix;
+
+        if(text === "" || (text.length <= options.TruncateLength && options.StripHTML === false)){
+            return text;
+        }
+
+        if(options.StripHTML) {
+            text = String(text).replace(/<br( \/)?>/gi, ' ');
+        }
+
+        //If not splitting on paragraphs we can quickly remove tags using regex
+        if(options.StripHTML && !options.TruncateBy.match(/(paragraph(s)?)/)){
+            text = String(text).replace(/<!--(.*?)-->/gm, '').replace(/<\/?[^>]+>/gi, '');
+        }
+        //Remove newline seperating paragraphs
+        text = String(text).replace(/<\/p>(\r?\n)+<p>/gm, '</p><p>');
+        //Replace double newlines with paragraphs
+        if(options.StripHTML && String(text).match(/\r?\n\r?\n/)){
+            text = String(text).replace(/((.+)(\r?\n\r?\n|$))/gi, "<p>$2</p>");
+        }
+
+        for (var pointer = 0; pointer < text.length; pointer++ ) {
+
+            var currentChar = text[pointer];
+
+            switch(currentChar){
+                case "<":
+                    if(currentState === NOT_TAG){
+                        currentState = TAG_START;
+                        currentTag = "";
+                    }
+                    if(!options.StripHTML){
+                        truncatedText += currentChar;
+                    }
+                    break;
+                case ">":
+                    if(currentState === TAG_START || currentState === TAG_ATTRIBUTES){
+                        currentState = NOT_TAG;
+                        currentTag = currentTag.toLowerCase();
+                        if(currentTag === "/p"){
+                            paragraphCounter++;
+                            if(options.StripHTML){
+                                truncatedText += " ";
+                            }
+                        }
+
+                        // Ignore self-closing tags.
+                        if ((selfClosingTags.indexOf(currentTag) === -1) && (selfClosingTags.indexOf(currentTag + '/') === -1)) {
+                            if(currentTag.indexOf("/") >= 0){
+                                tagStack.pop();
+                            } else {
+                                tagStack.push(currentTag);
+                            }
+                        }
+                    }
+                    if(!options.StripHTML){
+                        truncatedText += currentChar;
+                    }
+                    break;
+                case " ":
+                    if(currentState === TAG_START){
+                        currentState = TAG_ATTRIBUTES;
+                    }
+                    if(currentState === NOT_TAG){
+                        wordCounter++;
+                        charCounter++;
+                    }
+                    if(currentState === NOT_TAG || !options.StripHTML){
+                        truncatedText += currentChar;
+                    }
+                    break;
+                default:
+                    if(currentState === NOT_TAG){
+                        charCounter++;
+                    }
+                    if(currentState === TAG_START){
+                        currentTag += currentChar;
+                    }
+                    if(currentState === NOT_TAG || !options.StripHTML){
+                        truncatedText += currentChar;
+                    }
+                    break;
+            }
+
+            nextChar = text[pointer + 1] || "";
+            isEndOfWord = options.Strict ? true : (!currentChar.match(/[a-zA-ZÇ-Ü']/i) || !nextChar.match(/[a-zA-ZÇ-Ü']/i));
+
+            if(options.TruncateBy.match(/word(s)?/i) && options.TruncateLength <= wordCounter){
+                truncatedText = truncatedText.replace(/\s+$/, '');
+                break;
+            }
+            if(options.TruncateBy.match(/character(s)?/i) && options.TruncateLength <= charCounter && isEndOfWord){
+                break;
+            }
+            if(options.TruncateBy.match(/paragraph(s)?/i) && options.TruncateLength === paragraphCounter){
+                break;
+            }
+        }
+
+        if(!options.StripHTML && tagStack.length > 0){
+            while(tagStack.length > 0){
+                var tag = tagStack.pop();
+                if(tag!=="!--"){
+                    truncatedText += "</"+tag+">";
+                }
+            }
+        }
+
+        if(pointer < text.length - 1) {
+          if(truncatedText.match(/<\/p>$/gi)){
+              truncatedText = truncatedText.replace(/(<\/p>)$/gi, options.Suffix + "$1");
+          }else{
+              truncatedText = truncatedText + options.Suffix;
+          }
+        }
+
+        return truncatedText.trim();
+    };
+
+    // Export to node
+    if (typeof module !== 'undefined' && module.exports){
+        return module.exports = truncatise;
+    }
+
+    // Nope, export to the browser instead.
+    exportTo.truncatise = truncatise;
+}(this));


### PR DESCRIPTION
Best viewed commit-by-commit, as the first and last commits are bulk changes, while the middle commit does the actual speedup.

This reduces the amount of time spent in truncatise for a front-page SSR render from ~431ms to ~67ms (single measurements), speeding up overall SSR time by the same amount, by hoisting some config setting parsing that shouldn'tve been in the inner loop, out of the inner loop.