### PR TITLE
When loading the logged-in user for resolver context, reuse it for currentUser

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
@@ -21,6 +21,7 @@ import { Collections } from '../../../lib/vulcan-lib/collections';
 import { GraphQLSchema } from '../../../lib/vulcan-lib/graphql';
 import findByIds from '../findbyids';
 import { getHeaderLocale } from '../intl';
+import Users from '../../../lib/collections/users/collection';
 
 // From https://github.com/apollographql/meteor-integration/blob/master/src/server.js
 const getUser = async loginToken => {
@@ -29,7 +30,7 @@ const getUser = async loginToken => {
 
     const hashedToken = Accounts._hashLoginToken(loginToken)
 
-    const user = await Meteor.users.rawCollection().findOne({
+    const user = Users.findOne({
       'services.resume.loginTokens.hashedToken': hashedToken
     })
 
@@ -98,12 +99,8 @@ export const computeContextFromUser = async (user, headers): Promise<ResolverCon
   let context: ResolverContext = {...GraphQLSchema.context};
 
   generateDataLoaders(context);
-
-  // note: custom default resolver doesn't currently work
-  // see https://github.com/apollographql/apollo-server/issues/716
-  // @options.fieldResolver = (source, args, context, info) => {
-  //   return source[info.fieldName];
-  // }
+  if (user)
+    context.Users.loader.prime(user._id, user);
 
   setupAuthToken(user, context);
 

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
@@ -14,7 +14,6 @@ import Sentry from '@sentry/node';
 import DataLoader from 'dataloader';
 import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
-import { Meteor } from 'meteor/meteor';
 import Cookies from 'universal-cookie';
 import { runCallbacks } from '../../../lib/vulcan-lib/callbacks';
 import { Collections } from '../../../lib/vulcan-lib/collections';
@@ -24,7 +23,7 @@ import { getHeaderLocale } from '../intl';
 import Users from '../../../lib/collections/users/collection';
 
 // From https://github.com/apollographql/meteor-integration/blob/master/src/server.js
-const getUser = async loginToken => {
+const getUser = async (loginToken: string): Promise<DbUser|null> => {
   if (loginToken) {
     check(loginToken, String)
 
@@ -50,6 +49,8 @@ const getUser = async loginToken => {
       }
     }
   }
+  
+  return null;
 }
 
 // initial request will get the login token from a cookie, subsequent requests from


### PR DESCRIPTION
When you make a request, we look up your user object based on the login token. Save that user object to the dataloader, so that when the currentUser resolver runs, it doesn't have to make a roundtrip to the database. Speeds up SSR by one database roundtrip time (significant in development, less significant in production).


