### PR TITLE
Distinguish tag types with styling

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -32,7 +32,7 @@ export const contentTypes = {
     frontpage: {
       tooltipTitle: 'Frontpage Post',
       tooltipBody: <React.Fragment>
-        <div>Moderators promote posts to frontpage based on:</div>
+        <p><b>Frontpage Posts</b> are promoted by moderators based on:</p><br/>
         <ul>
           <li>Usefulness, novelty, relevance</li>
           <li>Timeless content (minimizing reference to current events)</li>
@@ -42,8 +42,9 @@ export const contentTypes = {
       Icon: HomeIcon
     },
     personal: {
-      tooltipTitle: 'Personal Blog Post',
+      tooltipTitle: 'Personal Blogpost',
       tooltipBody: <React.Fragment>
+        <div><b>Personal Blogpost</b></div>
         <div>
           Members can write whatever they want on their personal blog. Personal
           blogposts are a good fit for:

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { FilterMode } from '../../lib/filterSettings';
 import classNames from 'classnames';
-import withHover from '../common/withHover';
+import { useHover } from '../common/withHover';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Tags } from '../../lib/collections/tags/collection';
 import { tagStyle } from './FooterTag';
@@ -83,19 +83,18 @@ const styles = theme => ({
   }
 });
 
-const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemove=false, onChangeMode, onRemove, classes, description}: {
+const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChangeMode, onRemove, description, classes}: {
   tagId?: string,
   label?: string,
   mode: FilterMode,
   canRemove?: boolean,
   onChangeMode: (mode: FilterMode)=>void,
   onRemove?: ()=>void,
-  classes: ClassesType,
-  hover?: boolean,
-  anchorEl?: any,
   description?: React.ReactNode
+  classes: ClassesType,
 }) => {
   const { LWTooltip, PopperCard, TagPreview } = Components
+  const { hover, anchorEl, eventHandlers } = useHover({ tagId, label, mode });
 
   const { document: tag } = useSingle({
     documentId: tagId,
@@ -111,7 +110,7 @@ const FilterModeRawComponent = ({tagId="", label, hover, anchorEl, mode, canRemo
   </span>
 
   const otherValue = ["Hidden", -25,-10,0,10,25,"Required"].includes(mode) ? "" : (mode || "")
-  return <span>
+  return <span {...eventHandlers}>
     <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag?._id} tagName={tag?.name}>
       {(tag && !isMobile()) ? <Link to={`tag/${tag.slug}`}>
         {tagLabel}
@@ -220,9 +219,7 @@ function filterModeToStr(mode: FilterMode): string {
   }
 }
 
-const FilterModeComponent = registerComponent("FilterMode", FilterModeRawComponent,
-  {styles, hocs: [withHover({pageElementContext: "tagFilterMode"}, ({tagId, label, mode})=>({tagId, label, mode}))]
-  });
+const FilterModeComponent = registerComponent("FilterMode", FilterModeRawComponent, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
-import withHover from '../common/withHover';
+import { useHover } from '../common/withHover';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { DatabasePublicSetting } from '../../lib/publicSettings';
 
@@ -74,22 +74,25 @@ interface ExternalProps {
 interface FooterTagProps extends ExternalProps, WithHoverProps, WithStylesProps {
 }
 
-const FooterTag = ({tagRel, tag, hideScore=false, hover, anchorEl, classes}: {
+const FooterTag = ({tagRel, tag, hideScore=false, classes}: {
   tagRel?: TagRelMinimumFragment,
   tag: TagFragment,
   hideScore?: boolean,
 
-  hover: boolean,
-  anchorEl: any,
   classes: ClassesType,
 }) => {
-
+  const { hover, anchorEl, eventHandlers } = useHover({
+    pageElementContext: "tagItem",
+    tagId: tag._id,
+    tagName: tag.name,
+    tagSlug: tag.slug
+  });
   const { PopperCard, TagRelCard } = Components
 
   if (tag.adminOnly) { return null }
 
   return (<AnalyticsContext tagName={tag.name} tagId={tag._id} tagSlug={tag.slug} pageElementContext="tagItem">
-    <span className={classes.root}>
+    <span {...eventHandlers} className={classes.root}>
       <Link to={`/tag/${tag.slug}`}>
         <span className={classes.name}>{tag.name}</span>
         {!hideScore && tagRel && <span className={classes.score}>{tagRel.baseScore}</span>}
@@ -105,7 +108,6 @@ const FooterTag = ({tagRel, tag, hideScore=false, hover, anchorEl, classes}: {
 
 const FooterTagComponent = registerComponent<ExternalProps>("FooterTag", FooterTag, {
   styles: useExperimentalTagStyleSetting.get() ? experimentalStyles : styles,
-  hocs: [withHover({pageElementContext: "tagItem"}, ({tag}:{tag: TagFragment})=>({tagId: tag._id, tagName: tag.name, tagSlug: tag.slug}))]
 });
 
 declare global {

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -4,6 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useHover } from '../common/withHover';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { DatabasePublicSetting } from '../../lib/publicSettings';
+import classNames from 'classnames';
 
 const useExperimentalTagStyleSetting = new DatabasePublicSetting<boolean>('useExperimentalTagStyle', false)
 
@@ -42,6 +43,9 @@ const styles = theme => ({
       : tagStyle(theme)
     )
   },
+  core: {
+    backgroundColor: "rgba(0,150,0,.2)",
+  },
   score:  {
     paddingLeft: 5,
     color: 'rgba(0,0,0,0.7)',
@@ -71,7 +75,7 @@ const FooterTag = ({tagRel, tag, hideScore=false, classes}: {
   if (tag.adminOnly) { return null }
 
   return (<AnalyticsContext tagName={tag.name} tagId={tag._id} tagSlug={tag.slug} pageElementContext="tagItem">
-    <span {...eventHandlers} className={classes.root}>
+    <span {...eventHandlers} className={classNames(classes.root, {[classes.core]: tag.core})}>
       <Link to={`/tag/${tag.slug}`}>
         <span className={classes.name}>{tag.name}</span>
         {!hideScore && tagRel && <span className={classes.score}>{tagRel.baseScore}</span>}

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -12,10 +12,12 @@ export const tagStyle = theme => ({
   marginRight: 3,
   padding: 5,
   paddingLeft: 6,
-  paddingRight: 5,
+  paddingRight: 6,
   marginBottom: 8,
   backgroundColor: 'rgba(0,0,0,0.07)',
   borderRadius: 3,
+  ...theme.typography.commentStyle,
+  cursor: "pointer"
 })
 
 const newTagStyle = theme => ({
@@ -44,7 +46,11 @@ const styles = theme => ({
     )
   },
   core: {
-    backgroundColor: "rgba(0,150,0,.2)",
+    backgroundColor: "white",
+    paddingTop: 4,
+    paddingBottom: 4,
+    border: "solid 1px rgba(0,0,0,.12)",
+    color: theme.palette.grey[600]
   },
   score:  {
     paddingLeft: 5,
@@ -80,7 +86,7 @@ const FooterTag = ({tagRel, tag, hideScore=false, classes}: {
         <span className={classes.name}>{tag.name}</span>
         {!hideScore && tagRel && <span className={classes.score}>{tagRel.baseScore}</span>}
       </Link>
-      {tagRel && <PopperCard open={hover} anchorEl={anchorEl}>
+      {tagRel && <PopperCard open={hover} anchorEl={anchorEl} modifiers={{flip:{enabled:false}}}>
         <div className={classes.hovercard}>
           <TagRelCard tagRel={tagRel} />
         </div>

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -8,7 +8,6 @@ import { DatabasePublicSetting } from '../../lib/publicSettings';
 const useExperimentalTagStyleSetting = new DatabasePublicSetting<boolean>('useExperimentalTagStyle', false)
 
 export const tagStyle = theme => ({
-  display: "inline-block",
   marginRight: 3,
   padding: 5,
   paddingLeft: 6,
@@ -16,33 +15,33 @@ export const tagStyle = theme => ({
   marginBottom: 8,
   backgroundColor: 'rgba(0,0,0,0.07)',
   borderRadius: 3,
-  cursor: "pointer",
-  ...theme.typography.commentStyle,
-  "&:hover": {
-    opacity: 1
-  }
 })
 
 const newTagStyle = theme => ({
-  display: "inline-block",
   marginRight: 4,
   padding: 5,
   paddingLeft: 8,
   paddingRight: 7,
   marginBottom: 8,
   borderRadius: 4,
-  cursor: "pointer",
   boxShadow: '1px 2px 5px rgba(0,0,0,.2)',
-  ...theme.typography.commentStyle,
   color: theme.palette.primary.main,
-  "&:hover": {
-    opacity: 1
-  },
   fontSize: 15
 })
 
 const styles = theme => ({
-  root: tagStyle(theme),
+  root: {
+    display: "inline-block",
+    cursor: "pointer",
+    ...theme.typography.commentStyle,
+    "&:hover": {
+      opacity: 1
+    },
+    ...(useExperimentalTagStyleSetting.get()
+      ? newTagStyle(theme)
+      : tagStyle(theme)
+    )
+  },
   score:  {
     paddingLeft: 5,
     color: 'rgba(0,0,0,0.7)',
@@ -54,29 +53,9 @@ const styles = theme => ({
   },
 });
 
-const experimentalStyles = theme => ({
-  root: newTagStyle(theme),
-  score: {
-    display: "none"
-  },
-  name: {
-    display: 'inline-block',
-  },
-  hovercard: {
-  }
-})
-
-interface ExternalProps {
-  tagRel?: TagRelMinimumFragment,
-  tag: TagPreviewFragment,
-  hideScore?: boolean
-}
-interface FooterTagProps extends ExternalProps, WithHoverProps, WithStylesProps {
-}
-
 const FooterTag = ({tagRel, tag, hideScore=false, classes}: {
   tagRel?: TagRelMinimumFragment,
-  tag: TagFragment,
+  tag: TagBasicInfo,
   hideScore?: boolean,
 
   classes: ClassesType,
@@ -106,9 +85,7 @@ const FooterTag = ({tagRel, tag, hideScore=false, classes}: {
   </AnalyticsContext>);
 }
 
-const FooterTagComponent = registerComponent<ExternalProps>("FooterTag", FooterTag, {
-  styles: useExperimentalTagStyleSetting.get() ? experimentalStyles : styles,
-});
+const FooterTagComponent = registerComponent("FooterTag", FooterTag, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -10,6 +10,8 @@ import { contentTypes } from '../posts/PostsPage/ContentType';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { tagStyle } from './FooterTag';
 import classNames from 'classnames';
+import { commentBodyStyles } from '../../themes/stylePiping'
+import Card from '@material-ui/core/Card';
 import * as _ from 'underscore';
 
 const styles = theme => ({
@@ -25,8 +27,19 @@ const styles = theme => ({
     opacity: .8
   },
   frontpageOrPersonal: {
-    backgroundColor: "rgba(150,0,150,.1)",
+    ...tagStyle(theme),
+    backgroundColor: "white",
+    paddingTop: 4,
+    paddingBottom: 4,
+    border: "solid 1px rgba(0,0,0,.12)",
+    color: theme.palette.grey[600]
   },
+  card: {
+    ...commentBodyStyles(theme),
+    width: 450,
+    padding: 16,
+    paddingBottom: 8
+  }
 });
 
 function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
@@ -82,11 +95,11 @@ const FooterTagList = ({post, classes, hideScore}: {
   const { Loading, FooterTag } = Components
 
   const postType = post.frontpageDate ?
-    <LWTooltip title={contentTypes[forumTypeSetting.get()].frontpage.tooltipBody}>
-      <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Frontpage</div>
+    <LWTooltip title={<Card className={classes.card}>{contentTypes[forumTypeSetting.get()].frontpage.tooltipBody}</Card>} tooltip={false}>
+      <div className={classes.frontpageOrPersonal}>Frontpage</div>
     </LWTooltip>
     :
-    <LWTooltip title={contentTypes[forumTypeSetting.get()].personal.tooltipBody}>
+    <LWTooltip title={<Card className={classes.card}>{contentTypes[forumTypeSetting.get()].personal.tooltipBody}</Card>} tooltip={false}>
       <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
     </LWTooltip>
 

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -81,18 +81,19 @@ const FooterTagList = ({post, classes, hideScore}: {
       <div className={classes.tag}>Personal Blog</div>
     </LWTooltip>
 
-  if (loading || !results)
+  if (loading || !results) {
     return <div className={classes.root}>
-       {postType}
-       {post.tags.map(tag => <FooterTag key={tag._id} tag={tag} hideScore />)}
+     {post.tags.map(tag => <FooterTag key={tag._id} tag={tag} hideScore />)}
+     {postType}
     </div>;
+  }
   
 
   return <div className={classes.root}>
-    { postType }
     {results.filter(tagRel => !!tagRel?.tag).map(tagRel =>
       <FooterTag key={tagRel._id} tagRel={tagRel} tag={tagRel.tag} hideScore={hideScore}/>
     )}
+    { postType }
     {currentUser && <AddTagButton onTagSelected={onTagSelected} />}
     { isAwaiting && <Loading/>}
   </div>

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -9,6 +9,7 @@ import { useTracking } from "../../lib/analyticsEvents";
 import { contentTypes } from '../posts/PostsPage/ContentType';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { tagStyle } from './FooterTag';
+import classNames from 'classnames';
 import * as _ from 'underscore';
 
 const styles = theme => ({
@@ -22,7 +23,10 @@ const styles = theme => ({
   tagLoading: {
     ...tagStyle(theme),
     opacity: .8
-  }
+  },
+  frontpageOrPersonal: {
+    backgroundColor: "rgba(150,0,150,.1)",
+  },
 });
 
 function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
@@ -79,11 +83,11 @@ const FooterTagList = ({post, classes, hideScore}: {
 
   const postType = post.frontpageDate ?
     <LWTooltip title={contentTypes[forumTypeSetting.get()].frontpage.tooltipBody}>
-      <div className={classes.tag}>Frontpage</div>
+      <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Frontpage</div>
     </LWTooltip>
     :
     <LWTooltip title={contentTypes[forumTypeSetting.get()].personal.tooltipBody}>
-      <div className={classes.tag}>Personal Blog</div>
+      <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
     </LWTooltip>
 
   if (loading || !results) {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -9,6 +9,7 @@ import { useTracking } from "../../lib/analyticsEvents";
 import { contentTypes } from '../posts/PostsPage/ContentType';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { tagStyle } from './FooterTag';
+import * as _ from 'underscore';
 
 const styles = theme => ({
   root: {
@@ -23,6 +24,10 @@ const styles = theme => ({
     opacity: .8
   }
 });
+
+function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
+  return _.sortBy(list, item=>toTag(item).core);
+}
 
 const FooterTagList = ({post, classes, hideScore}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
@@ -83,14 +88,14 @@ const FooterTagList = ({post, classes, hideScore}: {
 
   if (loading || !results) {
     return <div className={classes.root}>
-     {post.tags.map(tag => <FooterTag key={tag._id} tag={tag} hideScore />)}
+     {sortTags(post.tags, t=>t).map(tag => <FooterTag key={tag._id} tag={tag} hideScore />)}
      {postType}
     </div>;
   }
   
 
   return <div className={classes.root}>
-    {results.filter(tagRel => !!tagRel?.tag).map(tagRel =>
+    {sortTags(results, t=>t.tag).filter(tagRel => !!tagRel?.tag).map(tagRel =>
       <FooterTag key={tagRel._id} tagRel={tagRel} tag={tagRel.tag} hideScore={hideScore}/>
     )}
     { postType }


### PR DESCRIPTION
Sort core tags and the frontpage/personal marker to the end of the tag list in post headers/footers, and style them differently. This makes it easy to see which tags are non-core tags, which are likely to be the most interesting ones.

![DistinguishTagTypes](https://user-images.githubusercontent.com/101191/88117087-04c43f80-cb6f-11ea-88cc-21974245582f.png)

(Feel free to suggest different colors.)