### PR TITLE
Create Tag and Show All Tags now display within the AddTag dropdown menu

### DIFF
--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
 import { InstantSearch, SearchBox, Hits, Configure } from 'react-instantsearch-dom';
 import { algoliaIndexNames, isAlgoliaEnabled, getSearchClient } from '../../lib/algoliaUtil';
-import { Link } from '../../lib/reactRouterWrapper';
 import Divider from '@material-ui/core/Divider';
 import { Tags } from '../../lib/collections/tags/collection';
 import classNames from 'classnames';
@@ -48,7 +47,7 @@ const styles = theme => ({
   showAll: {
     '& ul': {
       columns: 4,
-      columnWidth: 160
+      columnWidth: 180
     }
   }
 });

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -113,6 +113,10 @@ const AddTag = ({onTagSelected, classes}: {
         * null is the only option that actually suppresses the extra X button.
        // @ts-ignore */}
       <SearchBox reset={null} focusShortcuts={[]}/>
+      {showAllTags && <a onClick={()=>setShowAllTags(!showAllTags)} className={classes.newTag}>
+        Show fewer tags
+      </a>}
+      {showAllTags && <Divider/>}
       <Configure hitsPerPage={showAllTags ? 500 : (searchOpen ? 12 : 6)} />
       <Hits hitComponent={({hit}) =>
         <TagSearchHit hit={hit}

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -47,7 +47,8 @@ const styles = theme => ({
   },
   showAll: {
     '& ul': {
-      columns: 4
+      columns: 4,
+      columnWidth: 160
     }
   }
 });

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -113,10 +113,10 @@ const AddTag = ({onTagSelected, classes}: {
         * null is the only option that actually suppresses the extra X button.
        // @ts-ignore */}
       <SearchBox reset={null} focusShortcuts={[]}/>
+      {showAllTags && <Divider/>}
       {showAllTags && <a onClick={()=>setShowAllTags(!showAllTags)} className={classes.newTag}>
         Show fewer tags
       </a>}
-      {showAllTags && <Divider/>}
       <Configure hitsPerPage={showAllTags ? 500 : (searchOpen ? 12 : 6)} />
       <Hits hitComponent={({hit}) =>
         <TagSearchHit hit={hit}

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -46,7 +46,7 @@ const AddTagButton = ({onTagSelected, classes, children}: {
     <LWPopper
       open={isOpen}
       anchorEl={anchorEl}
-      placement="bottom-start"
+      placement="bottom"
       modifiers={{
         flip: {
           enabled: false

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -4,13 +4,18 @@ import { useSingle } from '../../lib/crud/withSingle';
 import withHover from '../common/withHover';
 import { Tags } from '../../lib/collections/tags/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
+import classNames from 'classnames';
 
 const styles = theme => ({
   root: {
     display: "block",
     padding: 8,
     cursor: "pointer",
-    ...theme.typography.commentStyle
+    ...theme.typography.commentStyle,
+    color: theme.palette.grey[500],
+    '&:hover': {
+      color: theme.palette.lwTertiary.main
+    }
   },
   card: {
     padding: 16,
@@ -22,6 +27,16 @@ const styles = theme => ({
       display: "none",
     },
   },
+  tagDescription: {
+    marginBottom: 12
+  },
+  hasDescription: {
+    color: theme.palette.grey[900]
+  },
+  postCount: {
+    fontSize: ".85em",
+    color: theme.palette.grey[500]
+  }
 });
 
 interface ExternalProps {
@@ -44,15 +59,19 @@ const TagSearchHit = ({hit, onClick, hover, anchorEl, classes}: TagSearchHitProp
       <PopperCard open={hover} anchorEl={anchorEl} placement="right-start">
         <div className={classes.card}>
           {!tag && <Loading/>}
-          {tag && <ContentItemBody
-            dangerouslySetInnerHTML={{__html: tag.description?.htmlHighlight}}
-            description={`tag ${tag.name}`}
-          />}
+          <div className={classes.tagDescription}>
+            {tag && tag.description?.htmlHighlight ? <ContentItemBody
+                dangerouslySetInnerHTML={{__html: tag.description?.htmlHighlight}}
+                description={`tag ${tag.name}`}
+              /> 
+            : <em>No description</em>}
+          </div>
+          <div className={classes.postCount}>{hit.postCount} posts</div>
         </div>
       </PopperCard>
-      <a className={classes.root} onClick={onClick} >
-        {hit.name}
-      </a>
+      <span className={classNames(classes.root, {[classes.hasDescription]: tag?.description?.htmlHighlight})} onClick={onClick} >
+        {hit.name} <span className={classes.postCount}>({hit.postCount})</span>
+      </span>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
It seemed to work basically fine to just show all tags immediately when users click the "all tags" button. Only issue is that they're not sorted alphabetically, and probably should be. (I think it should be alphabetical once you're showing all, but sorted by postCount if you're not)

This also tries out a thing where tags without descriptions show up as grey, so you don't try to hover over them and get disappointed. The current implementation feels a little wonky (because it takes awhile for them to load and check if a description exists). 

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3246710/88233445-8b8b2200-cc2c-11ea-92ee-db94b9697d16.png">


Create Tag now works within editor, and automatically adds the tag afterwards.

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/3246710/88230650-a4450900-cc27-11ea-9fa7-db33ecf403d4.png">
