### PR TITLE
All Tags Tweaks

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemKarma.tsx
+++ b/packages/lesswrong/components/posts/PostsItemKarma.tsx
@@ -2,18 +2,20 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import React from 'react';
 import withHover from '../common/withHover';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { PopperPlacementType } from '@material-ui/core/Popper'
 
-const PostsItemKarma = ({post, hover, anchorEl}: {
+const PostsItemKarma = ({post, hover, anchorEl, placement="left"}: {
   post: PostsBase,
   hover?: any,
   anchorEl?: any,
+  placement?: PopperPlacementType
 }) => {
   const baseScore = forumTypeSetting.get() === 'AlignmentForum' ? post.afBaseScore : post.baseScore
   const afBaseScore = forumTypeSetting.get() !== 'AlignmentForum' && post.af ? post.afBaseScore : null
   const { LWPopper } = Components
   return (
     <span>
-      <LWPopper open={hover} anchorEl={anchorEl} tooltip placement="left">
+      <LWPopper open={hover} anchorEl={anchorEl} tooltip placement={placement}>
         <div>
           <div>{ baseScore || 0 } karma</div>
           <div>({ post.voteCount} votes)</div>

--- a/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
@@ -47,7 +47,7 @@ const AllTagsAlphabetical = ({classes}: {
       </SectionTitle>
       {loading && <Loading/>}
       <div className={classes.alphabetical}>
-        {alphabetical.map(tag => <TagsListItem key={tag._id} tag={tag}/>)}
+        {alphabetical.map(tag => <TagsListItem key={tag._id} tag={tag} postCount={6}/>)}
       </div>
     </div>
   );

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -8,6 +8,8 @@ import { EditTagForm } from './EditTagPage';
 import { userCanEditTagPortal } from '../../lib/betas'
 import { useCurrentUser } from '../common/withUser';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { Link } from '../../lib/reactRouterWrapper';
+import AddBoxIcon from '@material-ui/icons/AddBox';
 
 const styles = theme => ({
   root: {
@@ -66,7 +68,7 @@ const AllTagsPage = ({classes}: {
   const { tag } = useTagBySlug("portal", "TagFragment");
   const [ editing, setEditing ] = useState(false)
 
-  const { AllTagsAlphabetical, TagsDetailsItem, SectionTitle, LoadMore, SectionFooter, ContentItemBody } = Components;
+  const { AllTagsAlphabetical, SectionButton, TagsDetailsItem, SectionTitle, LoadMore, SectionFooter, ContentItemBody } = Components;
 
   return (
     <AnalyticsContext pageContext="allTagsPage">
@@ -90,7 +92,12 @@ const AllTagsPage = ({classes}: {
           </AnalyticsContext>
         </div>
         <AnalyticsContext pageSectionContext="tagDetails">
-          <SectionTitle title="Tag Details"/>
+          <SectionTitle title={`Tag Details (${results?.length || "loading"})`}>
+            <SectionButton>
+              <AddBoxIcon/>
+              <Link to="/tag/create">New Tag</Link>
+            </SectionButton>
+          </SectionTitle>
           <div>
             {results && results.map(tag => {
               return <TagsDetailsItem key={tag._id} tag={tag} />

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -23,11 +23,12 @@ const styles = theme => ({
 });
 
 
-const TagHoverPreview = ({href, targetLocation, innerHTML, classes}: {
+const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=3}: {
   href: string,
   targetLocation: any,
   innerHTML: string,
   classes: ClassesType,
+  postCount?: number
 }) => {
   const { params: {slug} } = targetLocation;
   const { tag } = useTagBySlug(slug, "TagFragment");
@@ -40,7 +41,7 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes}: {
   return <span {...eventHandlers}>
     <PopperCard open={hover} anchorEl={anchorEl}>
       {tag
-        ? <TagPreview tag={tag}/>
+        ? <TagPreview tag={tag} postCount={postCount}/>
         : <Loading/>}
     </PopperCard>
     <Link

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -23,7 +23,7 @@ const styles = theme => ({
 });
 
 
-const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=3}: {
+const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}: {
   href: string,
   targetLocation: any,
   innerHTML: string,

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -50,12 +50,11 @@ const styles = theme => ({
   }
 });
 
-const previewPostCount = 3;
-
-const TagPreview = ({tag, classes, showCount=true}: {
+const TagPreview = ({tag, classes, showCount=true, postCount=3}: {
   tag: TagPreviewFragment,
   classes: ClassesType,
-  showCount?: boolean
+  showCount?: boolean,
+  postCount?: number
 }) => {
   const { TagPreviewDescription, TagSmallPostLink, Loading } = Components;
   const { results } = useMulti({
@@ -66,7 +65,7 @@ const TagPreview = ({tag, classes, showCount=true}: {
     },
     collection: TagRels,
     fragmentName: "TagRelFragment",
-    limit: previewPostCount,
+    limit: postCount,
     ssr: true,
   });
 
@@ -75,7 +74,7 @@ const TagPreview = ({tag, classes, showCount=true}: {
   return (<div className={classes.card}>
     <TagPreviewDescription tag={tag}/>
     {results ? <div className={classes.posts}>
-      {results.map((result,i) => <TagSmallPostLink key={result.post._id} post={result.post} />)}
+      {results.map((result,i) => <TagSmallPostLink key={result.post._id} post={result.post} widerSpacing={postCount > 3} />)}
     </div> : <Loading /> }
     {showCount && <div className={classes.footerCount}>
       <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -13,8 +13,9 @@ const styles = theme => ({
     color: theme.palette.grey[900],
   },
   karma: {
-    width: 27,
+    marginLeft: 8,
     textAlign: "center",
+    width: 20,
     flexShrink: 0
   },
   post: {
@@ -40,20 +41,24 @@ const styles = theme => ({
   author: {
     marginRight: 0,
     marginLeft: 20
+  },
+  widerSpacing: {
+    marginBottom: 4
   }
 });
 
-const TagSmallPostLink = ({classes, post, hideMeta, wrap}: {
+const TagSmallPostLink = ({classes, post, hideMeta, wrap, widerSpacing}: {
   classes: ClassesType,
   post: PostsList,
   hideMeta?: boolean,
-  wrap?: boolean
+  wrap?: boolean,
+  widerSpacing?: boolean
 }) => {
-  const { LWPopper, PostsPreviewTooltip, UsersName, MetaInfo } = Components
+  const { LWPopper, PostsPreviewTooltip, UsersName, MetaInfo, PostsItemKarma } = Components
   const { eventHandlers, hover, anchorEl } = useHover();
 
   return <span {...eventHandlers}>
-    <div className={classes.root}>
+    <div className={classNames(classes.root, {[classes.widerSpacing]: widerSpacing})}>
       <LWPopper 
         open={hover} 
         anchorEl={anchorEl} 
@@ -68,13 +73,16 @@ const TagSmallPostLink = ({classes, post, hideMeta, wrap}: {
         <PostsPreviewTooltip post={post}/>
       </LWPopper>
       <div className={classes.post}>
-        {!hideMeta && <MetaInfo className={classes.karma}>{post.baseScore}</MetaInfo>}
         <Link to={Posts.getPageUrl(post)} className={classNames(classes.title, {[classes.wrap]: wrap})}>
           {post.title}
         </Link>
         {!hideMeta && <MetaInfo className={classes.author}>
           <UsersName user={post.user} />
         </MetaInfo>}
+        {!hideMeta && <MetaInfo className={classes.karma}>
+          <PostsItemKarma post={post} placement="right"/>
+        </MetaInfo>}
+
       </div>
     </div>
   </span>

--- a/packages/lesswrong/components/tagging/TagsListItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsListItem.tsx
@@ -29,9 +29,10 @@ const styles = theme => ({
   }
 });
 
-const TagsListItem = ({tag, classes}: {
+const TagsListItem = ({tag, classes, postCount=3}: {
   tag: TagPreviewFragment,
   classes: ClassesType,
+  postCount?: number,
 }) => {
   const { PopperCard, TagPreview } = Components;
   const { hover, anchorEl, eventHandlers } = useHover();
@@ -42,7 +43,7 @@ const TagsListItem = ({tag, classes}: {
       anchorEl={anchorEl} 
       placement="right-start"
     >
-      <div className={classes.hideOnMobile}><TagPreview tag={tag}/></div>
+      <div className={classes.hideOnMobile}><TagPreview tag={tag} postCount={postCount}/></div>
     </PopperCard>
     <Link to={`/tag/${tag.slug}`}>
       {tag.name} { tag.needsReview }


### PR DESCRIPTION
Makes a number of changes for the All Tags page:

– TagSmallPostsLinks have karma to the right instead of left (makes it easier to read)
– the alphabetical section shows 6 posts instead of 3 (this comes along with adding more spacing, since it's harder to parse larger numbers of posts otherwise)
– added a "create tag" button to the Tag Details section, which was a bit easier to find. (I'm not sure how to put it at the very top of the page without looking weird)

I think there should also be 6 tags instead of 3 for in the Concepts Portal section, but wasn't sure if there should be 6 posts when you encounter a tag-link in the wild on a post page. I went ahead and changed it for now because I don't expect it to come up that often, and I added a little infrastructure to make it easier to change in different contexts in the future (but, I wasn't quite sure how to actually make use of that infrastructure)