### PR TITLE
Fix styling issues for the new Create Tag form

### DIFF
--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -27,6 +27,7 @@ const styles = theme => ({
     paddingLeft: 8,
     paddingRight: 8,
     paddingBottom: 8,
+    maxWidth: 365,
     background: "rgba(0,0,0,.03)",
     '& .form-input.input-name': {
       marginTop: 0
@@ -135,6 +136,7 @@ const AddTag = ({onTagSelected, classes}: {
     </a>
     {showCreateTag && <div className={classes.newTagForm}><WrappedSmartForm
       collection={Tags}
+      fields={["name", "description"]}
       mutationFragment={getFragment('TagFragment')}
       successCallback={tag => {
         onTagSelected({tagId: tag._id, tagName: tag.name});


### PR DESCRIPTION
The new Create Tag form that lived in the AddTag dropdown didn't have the right width, and admins got an ugly "Advanced Options" section that just made things annoying rather than really helping. 

This PR fixes the width and gets rid of the Advanced Options box (admins can go edit it afterwards on the proper tag page if it's important)