### PR TITLE
Small improvements to tag page

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -560,7 +560,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
     if (!fieldHasCommitMessages) return null;
     
     return <div className={classes.changeDescriptionRow}>
-      <span className={classes.changeDescriptionLabel}>Change description{" "}</span>
+      <span className={classes.changeDescriptionLabel}>Edit summary (Briefly describe your changes):{" "}</span>
       <Input
         className={classes.changeDescriptionInput}
         value={this.state.commitMessage}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -10,7 +10,7 @@ import Typography from '@material-ui/core/Typography';
 import { truncate } from '../../lib/editor/ellipsize';
 import { Tags } from '../../lib/collections/tags/collection';
 import { subscriptionTypes } from '../../lib/collections/subscriptions/schema'
-import { userCanViewRevisionHistory, userCanManageTags} from '../../lib/betas';
+import { userCanViewRevisionHistory } from '../../lib/betas';
 import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import HistoryIcon from '@material-ui/icons/History';
 import { useDialog } from '../common/withDialog';
@@ -137,7 +137,7 @@ const TagPage = ({classes}: {
     limit={terms.limit}
   >
     <HeadTags
-      title={tag.name} description={headTagDescription}
+      description={headTagDescription}
     />
     <SingleColumnSection>
       <div className={classes.wikiSection}>

--- a/packages/lesswrong/components/tagging/TagPageTitle.tsx
+++ b/packages/lesswrong/components/tagging/TagPageTitle.tsx
@@ -24,7 +24,7 @@ const TagPageTitle = ({isSubtitle, classes, siteName}: {
     return null;
   } else {
     return <Helmet>
-      <title>{titleString}l</title>
+      <title>{titleString}</title>
       <meta property='og:title' content={titleString}/>
     </Helmet>
   }
@@ -37,4 +37,3 @@ declare global {
     TagPageTitle: typeof TagPageTitleComponent
   }
 }
-

--- a/packages/lesswrong/components/tagging/TagPageTitle.tsx
+++ b/packages/lesswrong/components/tagging/TagPageTitle.tsx
@@ -6,13 +6,15 @@ import { useTagBySlug } from './useTag';
 import { Link } from '../../lib/reactRouterWrapper';
 import { styles } from '../common/HeaderSubtitle';
 
-const TagPageTitle = ({isSubtitle, classes}: {
+const TagPageTitle = ({isSubtitle, classes, siteName}: {
   isSubtitle: boolean,
   classes: ClassesType,
+  siteName: string
 }) => {
   const { params } = useLocation();
   const { slug } = params;
   const { tag } = useTagBySlug(slug, "TagFragment");
+  const titleString = `${tag?.name} - ${siteName}`
   
   if (isSubtitle) {
     return (<span className={classes.subtitle}>
@@ -22,8 +24,8 @@ const TagPageTitle = ({isSubtitle, classes}: {
     return null;
   } else {
     return <Helmet>
-      <title>{`${tag.name} tag`}</title>
-      <meta property='og:title' content={`Posts tagged ${tag.name}`}/>
+      <title>{titleString}l</title>
+      <meta property='og:title' content={titleString}/>
     </Helmet>
   }
 }

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -24,6 +24,7 @@ registerFragment(`
     description {
       html
       htmlHighlight
+      plaintextDescription
     }
   }
 `);

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -35,6 +35,7 @@ registerFragment(`
     description(version: $version) {
       html
       htmlHighlight
+      plaintextDescription
     }
   }
 `);

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1447,6 +1447,7 @@ interface TagFragment extends TagBasicInfo { // fragment on Tags
 interface TagFragment_description { // fragment on Revisions
   readonly html: string,
   readonly htmlHighlight: string,
+  readonly plaintextDescription: string,
 }
 
 interface TagRevisionFragment extends TagBasicInfo { // fragment on Tags

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1457,6 +1457,7 @@ interface TagRevisionFragment extends TagBasicInfo { // fragment on Tags
 interface TagRevisionFragment_description { // fragment on Revisions
   readonly html: string,
   readonly htmlHighlight: string,
+  readonly plaintextDescription: string,
 }
 
 interface TagPreviewFragment extends TagBasicInfo { // fragment on Tags


### PR DESCRIPTION
This PR: 
+ Improves the "Change Description" help text to make it more useful
+ Makes it so that logged out users don't just go to a broken edit-tag page when they click on the big "Edit Wiki" button
+ Properly populates the description and title meta HTML tags to improve search results and shareability of tag pages