### PR TITLE
Fix curatedDate edit field

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -206,6 +206,7 @@ addFieldsDict(Posts, {
   // if it never has been promoted to curated)
   curatedDate: {
     type: Date,
+    control: 'datetime',
     optional: true,
     viewableBy: ['guests'],
     insertableBy: ['sunshineRegiment', 'admins'],
@@ -216,6 +217,7 @@ addFieldsDict(Posts, {
   // never has been marked as meta)
   metaDate: {
     type: Date,
+    control: 'datetime',
     optional: true,
     viewableBy: ['guests'],
     insertableBy: ['sunshineRegiment', 'admins'],
@@ -264,6 +266,7 @@ addFieldsDict(Posts, {
   // false if it never has been promoted to frontpage)
   frontpageDate: {
     type: Date,
+    control: 'datetime',
     viewableBy: ['guests'],
     editableBy: ['members'],
     insertableBy: ['members'],


### PR DESCRIPTION
Makes it so you can edit the curatedDate field and metaDate field by manually setting them to be a datetime component. (By default Vulcan was rendering them as some kind of confused Text input)