### PR TITLE
Fix crash in cancel-votes callback

### DIFF
--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -107,8 +107,8 @@ addCallback("votes.bigUpvote.client", updateAlignmentKarmaClientCallback);
 addCallback("votes.smallDownvote.client", updateAlignmentKarmaClientCallback);
 addCallback("votes.smallUpvote.client", updateAlignmentKarmaClientCallback);
 
-async function cancelAlignmentKarmaServerCallback ({newDocument, vote}) {
-  return await updateAlignmentKarmaServer(newDocument, vote)
+function cancelAlignmentKarmaServerCallback ({newDocument, vote}) {
+  void updateAlignmentKarmaServer(newDocument, vote)
 }
 
 addCallback("votes.cancel.sync", cancelAlignmentKarmaServerCallback);

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -92,7 +92,7 @@ async function voteUpdatePostDenormalizedTags({newDocument: tagRel, vote}: {
   newDocument: DbTagRel,
   vote: DbVote
 }) {
-  await updatePostDenormalizedTags(tagRel.postId);
+  void updatePostDenormalizedTags(tagRel.postId);
 }
 
 addCallback("votes.cancel.sync", voteUpdatePostDenormalizedTags);


### PR DESCRIPTION
Fixes a crash in the callback when cancelling votes. This causes subsequent callbacks to not run, so cancelling a vote didn't undo its effect on a user's karma.

Introduced in https://github.com/LessWrong2/Lesswrong2/pull/3278 , but the root cause of this is bad design in Vulcan's callbacks system. Callbacks are ambiguous as to whether they are events with no return value, or are returning a chain of successive updates to a variable. Vulcan disambiguates the two based on whether the return value of a callback is undefined; if it's not-undefined, the return value is passed to the next callback, and if it's undefined, the original argument is passed. But the promise returned from an async function that has no return value, is not undefined; so it gets misinterpreted as an updated value, causing the next callback in the chain to fail. This is exacerbated by Vulcan's callbacks system being written in a way that makes it impossible to give it type annotations.