### PR TITLE
Fix on-site batching

### DIFF
--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -39,19 +39,18 @@ const sendNotificationBatch = async ({ userId, notificationIds }) => {
     { $set: { waitingForBatch: false } },
     { multi: true }
   );
-  const notifications = await Notifications.find(
-    { _id: {$in: notificationIds} }
+  const notificationsToEmail = await Notifications.find(
+    { _id: {$in: notificationIds}, emailed: true }
   ).fetch();
   
-  if (!notifications.length)
-    throw new Error("Failed to find notifications");
-  
-  const emails: any = await notificationBatchToEmails({
-    user, notifications
-  });
-  
-  for (let email of emails) {
-    await wrapAndSendEmail(email);
+  if (notificationsToEmail.length) {
+    const emails: any = await notificationBatchToEmails({
+      user, notifications: notificationsToEmail
+    });
+    
+    for (let email of emails) {
+      await wrapAndSendEmail(email);
+    }
   }
 }
 

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -124,9 +124,11 @@ const createNotification = async (userId, notificationType, documentType, docume
     link: getLink(notificationType, documentType, documentId),
   }
 
+  
+
   if (notificationTypeSettings.channel === "onsite" || notificationTypeSettings.channel === "both")
   {
-    await createMutator({
+    const createdNotification = await createMutator({
       collection: Notifications,
       document: {
         ...notificationData,
@@ -136,6 +138,14 @@ const createNotification = async (userId, notificationType, documentType, docume
       currentUser: user,
       validate: false
     });
+    if (notificationTypeSettings.batchingFrequency !== "realtime") {
+      await notificationDebouncers[notificationType].recordEvent({
+        key: {notificationType, userId},
+        data: createdNotification.data._id,
+        timing: getNotificationTiming(notificationTypeSettings),
+        af: false, //TODO: Handle AF vs non-AF notifications
+      });
+    }
   }
   if (notificationTypeSettings.channel === "email" || notificationTypeSettings.channel === "both") {
     const createdNotification = await createMutator({


### PR DESCRIPTION
When we wrote the original notification system, we failed to properly handle the case of on-site only notifications to get properly batched. The notification system was making an assumption that all batched notifications are emailed, which this PR fixes, restoring the functionality of batched on-site notifications.

While this bug has been present for over a year, not many people use the batched on-site notifications (and those who do usually also get email notifications, which compensates for a bunch of the problems). Only about 4 users were affected by this.