### PR TITLE
Add explicit ThemeType and JssStyles types to style declarations

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -53,7 +53,7 @@ const standaloneNavMenuRouteNames: Record<string,string[]> = {
   'EAForum': ['home', 'allPosts', 'questions', 'Community', 'Shortform'],
 }
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   main: {
     paddingTop: 50,
     paddingBottom: 15,
@@ -127,7 +127,7 @@ interface ExternalProps {
 }
 interface LayoutProps extends ExternalProps, WithLocationProps, WithStylesProps, WithUpdateUserProps {
   cookies: any,
-  theme: any,
+  theme: ThemeType,
 }
 interface LayoutState {
   timezone: string,

--- a/packages/lesswrong/components/admin/migrations/MigrationsDashboard.tsx
+++ b/packages/lesswrong/components/admin/migrations/MigrationsDashboard.tsx
@@ -6,7 +6,7 @@ import { useQuery } from 'react-apollo';
 import gql from 'graphql-tag';
 import { rowStyles } from './MigrationsDashboardRow';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   ...rowStyles,
   row: {
     display: 'flex',

--- a/packages/lesswrong/components/admin/migrations/MigrationsDashboardRow.tsx
+++ b/packages/lesswrong/components/admin/migrations/MigrationsDashboardRow.tsx
@@ -23,7 +23,7 @@ export const rowStyles = {
     minWidth: 140,
   },
 };
-const styles = theme => rowStyles;
+const styles = (theme: ThemeType): JssStyles => rowStyles;
 
 const MigrationsDashboardRow = ({migration: {name, dateWritten, runs, lastRun}, classes}: {
   migration: any,

--- a/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
@@ -11,7 +11,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   modalTextField: {
     marginTop: 10,
   },

--- a/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
+++ b/packages/lesswrong/components/alignment-forum/AlignmentForumHome.tsx
@@ -6,7 +6,7 @@ import { useCurrentUser } from '../common/withUser';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import AddIcon from '@material-ui/icons/Add';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   frontpageSequencesGridList: {
     [legacyBreakpoints.maxSmall]: {
       marginTop: 40,

--- a/packages/lesswrong/components/async/CKPostEditor.tsx
+++ b/packages/lesswrong/components/async/CKPostEditor.tsx
@@ -7,7 +7,7 @@ import { ckEditorUploadUrlSetting, ckEditorWebsocketUrlSetting } from '../../lib
 // Uncomment this line and the reference below to activate the CKEditor debugger
 // import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   sidebar: {
     position: 'absolute',
     right: -350,

--- a/packages/lesswrong/components/async/EditorForm.tsx
+++ b/packages/lesswrong/components/async/EditorForm.tsx
@@ -45,7 +45,7 @@ const HeadlineTwoButton = createBlockStyleButton({
     </svg>),
 });
 
-const styleMap = theme => ({
+const styleMap = (theme: ThemeType) => ({
   'CODE': theme.typography.code
 })
 
@@ -58,7 +58,7 @@ function customBlockStyleFn(contentBlock) {
 
 interface EditorFormProps {
   isClient: boolean,
-  theme: any,
+  theme: ThemeType,
   editorState: any,
   onChange: any,
   commentEditor: boolean,

--- a/packages/lesswrong/components/collections/BigCollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/BigCollectionsCard.tsx
@@ -4,7 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import Typography from '@material-ui/core/Typography';
 import { CoreReadingCollection } from '../sequences/CoreReading';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width:"100%",
     background: "white",

--- a/packages/lesswrong/components/collections/CollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/CollectionsCard.tsx
@@ -6,7 +6,7 @@ import Hidden from '@material-ui/core/Hidden';
 import classNames from 'classnames';
 import { CoreReadingCollection } from '../sequences/CoreReading';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: "100%",
     maxWidth: 347,

--- a/packages/lesswrong/components/collections/CollectionsCardContainer.tsx
+++ b/packages/lesswrong/components/collections/CollectionsCardContainer.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display:"flex",
     flexWrap: "wrap",

--- a/packages/lesswrong/components/comments/CantCommentExplanation.tsx
+++ b/packages/lesswrong/components/comments/CantCommentExplanation.tsx
@@ -5,7 +5,7 @@ import Users from '../../lib/collections/users/collection';
 import classNames from 'classnames';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: "1em 0",
   },

--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -10,7 +10,7 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import withDialog from '../../common/withDialog'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   deleteWithoutTrace: {
     marginRight:"auto"
   },

--- a/packages/lesswrong/components/comments/CommentActions/MoveToAlignmentMenuItem.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/MoveToAlignmentMenuItem.tsx
@@ -11,7 +11,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ArrowRightAlt from '@material-ui/icons/ArrowRightAlt';
 import Undo from '@material-ui/icons/Undo';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   iconRoot: {
     position: "relative",
     width:24,

--- a/packages/lesswrong/components/comments/CommentActions/SuggestAlignmentMenuItem.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/SuggestAlignmentMenuItem.tsx
@@ -9,7 +9,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ExposurePlus1 from '@material-ui/icons/ExposurePlus1';
 import Undo from '@material-ui/icons/Undo';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   iconRoot: {
     position: "relative",
     width:24,

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -4,7 +4,7 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { Comments } from '../../lib/collections/comments';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   dividerMargins: {
     marginTop: 150,
     marginBottom: 150,

--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -5,7 +5,7 @@ import { unflattenComments, addGapIndicators } from '../../lib/utils/unflatten';
 import withRecordPostView from '../common/withRecordPostView';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   showChildren: {
     padding: 4,
     paddingLeft: 12,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { commentExcerptFromHTML } from '../../../lib/editor/ellipsize'
 import { useCurrentUser } from '../../common/withUser'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   commentStyling: {
     ...commentBodyStyles(theme),
     maxWidth: "100%",

--- a/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBottomCaveats.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   blockedReplies: {
     padding: "5px 0",
   },

--- a/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.tsx
@@ -3,7 +3,7 @@ import { useSingle } from '../../../lib/crud/withSingle';
 import React from 'react';
 import { Comments } from '../../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     opacity: 0.5,
   },

--- a/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentOutdatedWarning.tsx
@@ -4,7 +4,7 @@ import { extractVersionsFromSemver } from '../../../lib/editor/utils';
 import HistoryIcon from '@material-ui/icons/History';
 import { QueryLink } from '../../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     fontSize: 'inherit',
     position: 'relative',

--- a/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentShortformIcon.tsx
@@ -4,7 +4,7 @@ import NotesIcon from '@material-ui/icons/Notes';
 import { Comments } from "../../../lib/collections/comments";
 import { Link } from '../../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.grey[600],

--- a/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentUserName.tsx
@@ -1,7 +1,7 @@
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   author: {
     ...theme.typography.body2,
     fontWeight: 600,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -12,7 +12,7 @@ import { Comments } from "../../../lib/collections/comments";
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 
 // Shared with ParentCommentItem
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: theme.spacing.unit*1.5,
     paddingRight: theme.spacing.unit*1.5,

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemDate.tsx
@@ -8,7 +8,7 @@ import { useNavigation, useLocation } from '../../../lib/routeUtil';
 import { useTracking } from '../../../lib/analyticsEvents';
 import qs from 'qs'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     "& a:hover, & a:active": {
       "& $icon": {

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsMenu.tsx
@@ -5,7 +5,7 @@ import Menu from '@material-ui/core/Menu';
 import { useCurrentUser } from '../../common/withUser';
 import { useTracking } from "../../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     fontSize:"1.4rem"

--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -8,7 +8,7 @@ import { TRUNCATION_KARMA_THRESHOLD } from '../../lib/editor/ellipsize'
 import withUser from '../common/withUser';
 import { CommentTreeNode } from '../../lib/utils/unflatten';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   button: {
     color: theme.palette.lwTertiary.main
   },

--- a/packages/lesswrong/components/comments/CommentsListMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsListMeta.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontSize: 14,
     clear: 'both',

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -14,7 +14,7 @@ import { CommentTreeNode } from '../../lib/utils/unflatten';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontWeight: 400,
     maxWidth: 720,

--- a/packages/lesswrong/components/comments/CommentsNewForm.tsx
+++ b/packages/lesswrong/components/comments/CommentsNewForm.tsx
@@ -9,7 +9,7 @@ import { useDialog } from '../common/withDialog';
 import { hideUnreviewedAuthorCommentsSettings } from '../../lib/publicSettings';
 import Users from '../../lib/collections/users/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
   },
   loadingRoot: {

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -11,7 +11,7 @@ import { CommentTreeNode } from '../../lib/utils/unflatten';
 const KARMA_COLLAPSE_THRESHOLD = -4;
 const HIGHLIGHT_DURATION = 3
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   node: {
     border: `solid 1px ${theme.palette.commentBorderGrey}`,
     cursor: "default",

--- a/packages/lesswrong/components/comments/CommentsViews.tsx
+++ b/packages/lesswrong/components/comments/CommentsViews.tsx
@@ -22,7 +22,7 @@ export const viewNames = {
   'postLWComments': 'top scoring (include LW)',
 }
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: 'inline'
   },

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -13,7 +13,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import { frontpageGuidelines, defaultGuidelines } from './ForumModerationGuidelinesContent'
 import { commentBodyStyles } from '../../../themes/stylePiping'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: theme.spacing.unit*2,
     position:"relative"

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -8,7 +8,7 @@ import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formButton: {
     paddingBottom: "2px",
     fontSize: "16px",

--- a/packages/lesswrong/components/comments/RecentComments.tsx
+++ b/packages/lesswrong/components/comments/RecentComments.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme =>  ({
+const styles = (theme: ThemeType): JssStyles =>  ({
   root: {
     [theme.breakpoints.up('sm')]: {
       marginRight: theme.spacing.unit*4,

--- a/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/comments/RecentDiscussionThread.tsx
@@ -14,7 +14,7 @@ import { postHighlightStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 import { Posts } from '../../lib/collections/posts';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: theme.spacing.unit*4,
     position: "relative",

--- a/packages/lesswrong/components/comments/ShowParentComment.tsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.tsx
@@ -4,7 +4,7 @@ import SubdirectoryArrowLeft from '@material-ui/icons/SubdirectoryArrowLeft';
 import classNames from 'classnames';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingRight: theme.spacing.unit,
     paddingTop: theme.spacing.unit,

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -8,7 +8,7 @@ import { Comments } from '../../lib/collections/comments'
 import { isMobile } from '../../lib/utils/isMobile'
 import { styles as commentsItemStyles } from './CommentsItem/CommentsItem';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative",
     cursor: "pointer",

--- a/packages/lesswrong/components/common/BetaTag.tsx
+++ b/packages/lesswrong/components/common/BetaTag.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: 4,
     ...theme.typography.body2,

--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -9,7 +9,7 @@ import { Meteor } from 'meteor/meteor';
 const scrollIndicatorColor = "#ddd";
 const scrollIndicatorHoverColor = "#888";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   scrollIndicatorWrapper: {
     display: "block",
     position: "relative",

--- a/packages/lesswrong/components/common/ErrorMessage.tsx
+++ b/packages/lesswrong/components/common/ErrorMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   errorText: {
     color: theme.palette.error.main,
   }

--- a/packages/lesswrong/components/common/Footer.tsx
+++ b/packages/lesswrong/components/common/Footer.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     height: 150,
   }

--- a/packages/lesswrong/components/common/Header.tsx
+++ b/packages/lesswrong/components/common/Header.tsx
@@ -22,7 +22,7 @@ import { forumTypeSetting, PublicInstanceSetting } from '../../lib/instanceSetti
 
 const forumHeaderTitleSetting = new PublicInstanceSetting<string>('forumSettings.headerTitle', "LESSWRONG", "warning")
 const forumShortTitleSetting = new PublicInstanceSetting<string>('forumSettings.shortForumTitle', "LW", "warning")
-export const getHeaderTextColor = theme => {
+export const getHeaderTextColor = (theme: ThemeType) => {
   if (theme.palette.headerType === 'primary') {
     return theme.palette.primary.contrastText
   } else if (theme.palette.headerType === 'secondary') {
@@ -34,7 +34,7 @@ export const getHeaderTextColor = theme => {
   }
 }
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   appBar: {
     boxShadow: "0 1px 1px rgba(0, 0, 0, 0.05), 0 1px 1px rgba(0, 0, 0, 0.05)",
   },
@@ -138,7 +138,7 @@ interface ExternalProps {
   searchResultsArea: any,
 }
 interface HeaderProps extends ExternalProps, WithUserProps, WithStylesProps, WithTrackingProps, WithUpdateUserProps {
-  theme: any,
+  theme: ThemeType,
 }
 interface HeaderState {
   navigationOpen: boolean,

--- a/packages/lesswrong/components/common/HeaderSubtitle.tsx
+++ b/packages/lesswrong/components/common/HeaderSubtitle.tsx
@@ -4,7 +4,7 @@ import { useSubscribedLocation } from '../../lib/routeUtil';
 import grey from '@material-ui/core/colors/grey';
 import { Link } from '../../lib/reactRouterWrapper';
 
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   subtitle: {
     marginLeft: '1em',
     paddingLeft: '1em',

--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -14,7 +14,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import { sectionTitleStyle } from '../common/SectionTitle';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   titleWrapper: {
     display: "flex",
     marginBottom: 8,

--- a/packages/lesswrong/components/common/LWPopper.tsx
+++ b/packages/lesswrong/components/common/LWPopper.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Popper, { PopperPlacementType } from '@material-ui/core/Popper'
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   popper: {
     position: "absolute",
     zIndex: theme.zIndexes.lwPopper

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -4,7 +4,7 @@ import { useHover } from './withHover';
 import { PopperPlacementType } from '@material-ui/core/Popper'
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     // inline-block makes sure that the popper placement works properly (without flickering). "block" would also work, but there may be situations where we want to wrap an object in a tooltip that shouldn't be a block element.
     display: "inline-block",

--- a/packages/lesswrong/components/common/LinkCard.tsx
+++ b/packages/lesswrong/components/common/LinkCard.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     cursor: "pointer",
     position: "relative",

--- a/packages/lesswrong/components/common/LoadMore.tsx
+++ b/packages/lesswrong/components/common/LoadMore.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { queryIsUpdating } from './queryStatusUtils'
 import {useTracking} from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/common/MetaInfo.tsx
+++ b/packages/lesswrong/components/common/MetaInfo.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "inline",
     color: theme.palette.grey[600],

--- a/packages/lesswrong/components/common/NoContent.tsx
+++ b/packages/lesswrong/components/common/NoContent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     color: theme.palette.grey[600],
     margin: theme.spacing.unit*2

--- a/packages/lesswrong/components/common/RecaptchaWarning.tsx
+++ b/packages/lesswrong/components/common/RecaptchaWarning.tsx
@@ -6,7 +6,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 // ea-forum look here (you will want to set this to whatever is appropriate for you)
 export const spamRiskScoreThreshold = 0.16 // Corresponds to recaptchaScore of 0.2
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   warningText: {
     margin: 10,
     padding: 20,

--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -13,7 +13,7 @@ import qs from 'qs'
 
 const VirtualMenu = connectMenu(() => null);
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: 'flex',
     alignItems: 'center',

--- a/packages/lesswrong/components/common/SectionButton.tsx
+++ b/packages/lesswrong/components/common/SectionButton.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     cursor: "pointer",
     color: theme.palette.lwTertiary.main,

--- a/packages/lesswrong/components/common/SectionFooter.tsx
+++ b/packages/lesswrong/components/common/SectionFooter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 
-export const separatorBulletStyles = theme => ({
+export const separatorBulletStyles = (theme: ThemeType) => ({
   '& > *': {
     marginBottom: theme.spacing.unit,
     '&:after': {
@@ -20,7 +20,7 @@ export const separatorBulletStyles = theme => ({
   }
 })
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     justifyContent: "flex-end",

--- a/packages/lesswrong/components/common/SectionSubtitle.tsx
+++ b/packages/lesswrong/components/common/SectionSubtitle.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/common/SectionTitle.tsx
+++ b/packages/lesswrong/components/common/SectionTitle.tsx
@@ -3,13 +3,13 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-export const sectionTitleStyle = theme => ({
+export const sectionTitleStyle = (theme: ThemeType): JssStyles => ({
   margin:0,
   ...theme.typography.postStyle,
   fontSize: "2.2rem"
 })
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     justifyContent: "space-between",

--- a/packages/lesswrong/components/common/SeparatorBullet.tsx
+++ b/packages/lesswrong/components/common/SeparatorBullet.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: 3,
     marginRight: 3

--- a/packages/lesswrong/components/common/SingleColumnSection.tsx
+++ b/packages/lesswrong/components/common/SingleColumnSection.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 export const SECTION_WIDTH = 765
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: theme.spacing.unit*4,
     maxWidth: SECTION_WIDTH,

--- a/packages/lesswrong/components/common/SubSection.tsx
+++ b/packages/lesswrong/components/common/SubSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: theme.spacing.unit*2.5
   }

--- a/packages/lesswrong/components/common/SubscribeDialog.tsx
+++ b/packages/lesswrong/components/common/SubscribeDialog.tsx
@@ -23,7 +23,7 @@ import withMobileDialog from '@material-ui/core/withMobileDialog';
 import withUser from '../common/withUser';
 import { withTracking } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   thresholdSelector: {
     display: "flex",
     flexDirection: "row",

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   paperWithoutToC: {
     width: 280,
     overflowY: "scroll"

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationStandalone.tsx
@@ -5,7 +5,7 @@ import { useLocation } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: TAB_NAVIGATION_MENU_WIDTH
   },

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationCompressedItem.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 
 const compressedIconSize = 23
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     display: "block",
     opacity: .6,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationFooterItem.tsx
@@ -7,7 +7,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 const smallIconSize = 23
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   selected: {
     '& $icon': {
       opacity: 1,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -7,7 +7,7 @@ import { useLocation } from '../../../lib/routeUtil';
 
 export const iconWidth = 30
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   selected: {
     '& $icon': {
       opacity: 1,

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenu.tsx
@@ -10,7 +10,7 @@ import { forumTypeSetting } from '../../../lib/instanceSettings';
 
 export const TAB_NAVIGATION_MENU_WIDTH = 250
 
-const styles = (theme) => {
+const styles = (theme: ThemeType): JssStyles => {
   return {
     root: {
       display: "flex",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuCompressed.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuCompressed.tsx
@@ -6,7 +6,7 @@ import Divider from '@material-ui/core/Divider';
 import menuTabs from './menuTabs'
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     flexDirection: "column",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationMenuFooter.tsx
@@ -6,7 +6,7 @@ import { AnalyticsContext } from "../../../lib/analyticsEvents";
 import menuTabs from './menuTabs'
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     justifyContent: "space-around",

--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationSubItem.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { iconWidth } from './TabNavigationItem'
 import { TAB_NAVIGATION_MENU_WIDTH } from './TabNavigationMenu';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     display: "block",

--- a/packages/lesswrong/components/common/hocTypes.d.ts
+++ b/packages/lesswrong/components/common/hocTypes.d.ts
@@ -1,5 +1,7 @@
 
 type ClassesType = Record<string,any>
+type ThemeType = any
+type JssStyles = any
 
 interface WithStylesProps {
   classes: ClassesType,

--- a/packages/lesswrong/components/ea-forum/EAHomeHandbook.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHomeHandbook.tsx
@@ -14,7 +14,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 
 const bannerHeight = 250
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   bannerContainer: {
     position: 'absolute',
     top: 120, // desktop header height + layout margin

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -4,7 +4,7 @@ import { postBodyStyles } from '../../themes/stylePiping';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Typography } from '@material-ui/core';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   description: {
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit,

--- a/packages/lesswrong/components/ea-forum/SiteLogo.tsx
+++ b/packages/lesswrong/components/ea-forum/SiteLogo.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { registerComponent, Utils } from '../../lib/vulcan-lib';
 import { forumTitleSetting, PublicInstanceSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     height: 48
   }

--- a/packages/lesswrong/components/editor/EditTitle.tsx
+++ b/packages/lesswrong/components/editor/EditTitle.tsx
@@ -4,7 +4,7 @@ import Input from '@material-ui/core/Input';
 import PropTypes from 'prop-types'
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.display3,
     ...theme.typography.headerStyle,

--- a/packages/lesswrong/components/editor/EditUrl.tsx
+++ b/packages/lesswrong/components/editor/EditUrl.tsx
@@ -7,7 +7,7 @@ import Input from '@material-ui/core/Input';
 import LinkIcon from '@material-ui/icons/Link'
 import LinkOffIcon from '@material-ui/icons/LinkOff';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginRight: theme.spacing.unit
   },

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -25,7 +25,7 @@ const commentEditorHeight = 100;
 const postEditorHeightRows = 15;
 const commentEditorHeightRows = 5;
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   editor: {
     position: 'relative',
   },

--- a/packages/lesswrong/components/editor/SelectVersion.tsx
+++ b/packages/lesswrong/components/editor/SelectVersion.tsx
@@ -6,7 +6,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Tooltip from '@material-ui/core/Tooltip';
 import { Posts } from '../../lib/collections/posts';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   date: {
     marginLeft: theme.spacing.unit*1.5,
     fontStyle: "italic"

--- a/packages/lesswrong/components/form-components/FormComponentCheckbox.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentCheckbox.tsx
@@ -4,7 +4,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginRight:theme.spacing.unit*3,
     marginTop: 5,

--- a/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
+++ b/packages/lesswrong/components/form-components/FormComponentDateTime.tsx
@@ -5,7 +5,7 @@ import DateTimePicker from 'react-datetime';
 import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   input: {
     borderBottom: `solid 1px #999`,
     padding: '6px 0 7px 0'

--- a/packages/lesswrong/components/form-components/FormSubmit.tsx
+++ b/packages/lesswrong/components/form-components/FormSubmit.tsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formButton: {
     paddingBottom: "2px",
     fontFamily: theme.typography.fontFamily,

--- a/packages/lesswrong/components/form-components/ImageUpload.tsx
+++ b/packages/lesswrong/components/form-components/ImageUpload.tsx
@@ -11,7 +11,7 @@ import { cloudinaryCloudNameSetting, DatabasePublicSetting } from '../../lib/pub
 const cloudinaryUploadPresetGridImageSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetGridImage', 'tz0mgw2s')
 const cloudinaryUploadPresetBannerSetting = new DatabasePublicSetting<string>('cloudinary.uploadPresetBanner', 'navcjwf7')
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   button: {
     background: "rgba(0,0,0, 0.5)",
     "&:hover": {

--- a/packages/lesswrong/components/form-components/LocationFormComponent.tsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.tsx
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import { DatabasePublicSetting } from '../../lib/publicSettings';
 
 // Recommended styling for React-geosuggest: https://github.com/ubilabs/react-geosuggest/blob/master/src/geosuggest.css
-export const geoSuggestStyles = theme => ({
+export const geoSuggestStyles = (theme: ThemeType): JssStyles => ({
   "& .geosuggest": {
     fontSize: "1rem",
     position: "relative",
@@ -73,7 +73,7 @@ export const geoSuggestStyles = theme => ({
   }
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...geoSuggestStyles(theme)
   }

--- a/packages/lesswrong/components/form-components/ManageSubscriptionsLink.tsx
+++ b/packages/lesswrong/components/form-components/ManageSubscriptionsLink.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import Button from '@material-ui/core/Button';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   button: {
     marginBottom: theme.spacing.unit,
     marginLeft: theme.spacing.unit

--- a/packages/lesswrong/components/form-components/MuiInput.tsx
+++ b/packages/lesswrong/components/form-components/MuiInput.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { registerComponent } from '../../lib/vulcan-lib';
 import Input from '@material-ui/core/Input';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   // input: {
   //   // This needs to be here because of Bootstrap. I am sorry :(
   //   // padding: "6px 0 7px !important",

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -4,7 +4,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import TextField from '@material-ui/core/TextField';
 import classnames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   labelColor: {
     color: theme.secondary
   },

--- a/packages/lesswrong/components/form-components/MultiSelectButtons.tsx
+++ b/packages/lesswrong/components/form-components/MultiSelectButtons.tsx
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import classnames from 'classnames';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   button: {
     
     // TODO: Pick typography for this button. (This is just the typography that

--- a/packages/lesswrong/components/form-components/SectionFooterCheckbox.tsx
+++ b/packages/lesswrong/components/form-components/SectionFooterCheckbox.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import classNames from 'classnames';
 import { PopperPlacementType } from '@material-ui/core/Popper'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     cursor: "pointer",
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/form-components/SequencesListEditorItem.tsx
+++ b/packages/lesswrong/components/form-components/SequencesListEditorItem.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import DragIcon from '@material-ui/icons/DragHandle';
 import RemoveIcon from '@material-ui/icons/Close';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   box: {
     display: "block",
     marginLeft: 30,

--- a/packages/lesswrong/components/form-components/UsersListEditor.tsx
+++ b/packages/lesswrong/components/form-components/UsersListEditor.tsx
@@ -7,7 +7,7 @@ import withUser from '../common/withUser';
 import * as _ from 'underscore';
 
 
-const sortableItemStyles = theme => ({
+const sortableItemStyles = (theme: ThemeType): JssStyles => ({
   root: {
     listStyle: "none",
     fontFamily: theme.typography.fontFamily
@@ -23,7 +23,7 @@ const SortableItem = withStyles(sortableItemStyles, {name: "SortableItem"})(Sort
 ))
 
 
-const sortableListStyles = createStyles(theme => ({
+const sortableListStyles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     flexWrap: "wrap"
@@ -41,7 +41,7 @@ const SortableList = withStyles(sortableListStyles, {name: "SortableList"})(Sort
   );
 }));
 
-const usersListEditorStyles = theme => ({
+const usersListEditorStyles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex"
   }

--- a/packages/lesswrong/components/icons/KarmaIcon.tsx
+++ b/packages/lesswrong/components/icons/KarmaIcon.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative",
     width: "1em",

--- a/packages/lesswrong/components/icons/OmegaIcon.tsx
+++ b/packages/lesswrong/components/icons/OmegaIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontSize: 24,
     fontWeight: 600,

--- a/packages/lesswrong/components/icons/SettingsButton.tsx
+++ b/packages/lesswrong/components/icons/SettingsButton.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import Settings from '@material-ui/icons/Settings';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.grey[400],

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -148,7 +148,7 @@ const PostLinkPreviewVariantCheck = ({ href, innerHTML, post, targetLocation, co
 }
 const PostLinkPreviewVariantCheckComponent = registerComponent('PostLinkPreviewVariantCheck', PostLinkPreviewVariantCheck);
 
-export const linkStyle = theme => ({
+export const linkStyle = (theme: ThemeType) => ({
   position: "relative",
   marginRight: 6,
   '&:after': {
@@ -160,7 +160,7 @@ export const linkStyle = theme => ({
   }
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   link: {
     ...linkStyle(theme)
   }
@@ -268,7 +268,7 @@ const CommentLinkPreviewWithCommentComponent = registerComponent('CommentLinkPre
   styles,
 });
 
-const defaultPreviewStyles = theme => ({
+const defaultPreviewStyles = (theme: ThemeType): JssStyles => ({
   hovercard: {
     padding: theme.spacing.unit,
     paddingLeft: theme.spacing.unit*1.5,
@@ -320,7 +320,7 @@ const DefaultPreviewComponent = registerComponent('DefaultPreview', DefaultPrevi
   styles: defaultPreviewStyles,
 });
 
-const mozillaHubStyles = (theme) => ({
+const mozillaHubStyles = (theme: ThemeType): JssStyles => ({
   users: {
     marginLeft: 3,
     fontSize: "1.2rem",
@@ -424,7 +424,7 @@ const MozillaHubPreviewComponent = registerComponent('MozillaHubPreview', Mozill
   styles: mozillaHubStyles
 })
 
-const metaculusStyles = (theme) => ({
+const metaculusStyles = (theme: ThemeType): JssStyles => ({
   background: {
     backgroundColor: "#2c3947"
   },

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -12,7 +12,7 @@ import withDialog from '../common/withDialog'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import * as _ from 'underscore';
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   welcomeText: {
     margin: 12
   }

--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -17,7 +17,7 @@ export const mapboxAPIKeySetting = new DatabasePublicSetting<string | null>('map
 export const mapsHeight = 440
 const mapsWidth = "100vw"
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
     width: mapsWidth,
     height: mapsHeight,
@@ -166,7 +166,7 @@ const CommunityMap = ({ groupTerms, eventTerms, initialOpenWindows = [], center 
   </div>
 }
 
-const personalMapMarkerStyles = theme => ({
+const personalMapMarkerStyles = (theme: ThemeType): JssStyles => ({
   icon: {
     height: 15,
     width: 15,

--- a/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMapFilter.tsx
@@ -20,7 +20,7 @@ import * as _ from 'underscore';
 
 const availableFilters = _.map(groupTypes, t => t.shortName);
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 120,
     padding: "10px 10px 5px 10px",

--- a/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
+++ b/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
@@ -22,7 +22,7 @@ const suggestionToGoogleMapsLocation = (suggestion) => {
   return suggestion ? suggestion.gmaps : null
 }
 
-export const sharedStyles = theme => ({
+export const sharedStyles = (theme: ThemeType): JssStyles => ({
   removeButton: {
     color: theme.palette.error.main,
     marginRight: 'auto',
@@ -68,7 +68,7 @@ export const sharedStyles = theme => ({
   },
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   ...sharedStyles(theme),
   distanceSection: {
     marginTop: 30,

--- a/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
@@ -11,7 +11,7 @@ import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import classNames from 'classnames';
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
     display: 'flex',
     marginTop: 20

--- a/packages/lesswrong/components/localGroups/GroupLinks.tsx
+++ b/packages/lesswrong/components/localGroups/GroupLinks.tsx
@@ -12,7 +12,7 @@ const FacebookIcon = (props) => <SvgIcon viewBox="0 0 155.139 155.139" {...props
   c0-7.984,2.208-13.425,13.67-13.425l14.595-0.006V1.08C115.325,0.752,106.661,0,96.577,0C75.52,0,61.104,12.853,61.104,36.452 v20.341H37.29v27.585h23.814v70.761H89.584z"/>
 </SvgIcon>
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   groupTypes: {
     marginLeft: 20,
     display: 'inline-block',

--- a/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalEventMarker.tsx
@@ -5,7 +5,7 @@ import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
 import { ArrowSVG } from './Icons'
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   icon: {
     width: 15, 
     height: 15,

--- a/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupMarker.tsx
@@ -4,7 +4,7 @@ import { GroupIconSVG } from './Icons'
 import { Marker } from 'react-map-gl';
 import { createStyles } from '@material-ui/core/styles';
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   icon: {
     height: 15, 
     width: 15,

--- a/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupPage.tsx
@@ -10,7 +10,7 @@ import { postBodyStyles } from '../../themes/stylePiping'
 import { sectionFooterLeftStyles } from '../users/UsersProfile'
 import qs from 'qs'
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {},
   groupInfo: {
     ...sectionFooterLeftStyles

--- a/packages/lesswrong/components/localGroups/LocalGroupsItem.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsItem.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 
-export const postsItemLikeStyles = theme => ({
+export const postsItemLikeStyles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.postStyle,
     position: "relative",
@@ -63,7 +63,7 @@ export const postsItemLikeStyles = theme => ({
   },
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   ...postsItemLikeStyles(theme),
   location: {
     color: "rgba(0,0,0,.4)",

--- a/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import Localgroups from '../../lib/collections/localgroups/collection';
 import { createStyles } from '@material-ui/core/styles'
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   loadMore: {
     flexGrow: 1,
     textAlign: "left",

--- a/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
+++ b/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
@@ -17,7 +17,7 @@ const suggestionToGoogleMapsLocation = (suggestion) => {
   return suggestion ? suggestion.gmaps : null
 }
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   ...sharedStyles(theme),
 }))
 

--- a/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
+++ b/packages/lesswrong/components/localGroups/SmallMapPreview.tsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet'
 import * as _ from 'underscore';
 import { mapboxAPIKeySetting } from './CommunityMap';
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   previewWrapper: {
     paddingTop: 5,
     marginBottom: 20,

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -5,7 +5,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import { Popup } from 'react-map-gl';
 
 // Shared with LocalEventMarker
-export const styles = createStyles(theme => ({
+export const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     width: 250,

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -15,7 +15,7 @@ const TODAY_STRING = "[Today]"
 const TOMORROW_STRING = "[Tomorrow]"
 const HIGHLIGHT_LENGTH = 600
 
-const styles = createStyles(theme => ({
+const styles = createStyles((theme: ThemeType): JssStyles => ({
   subItemOverride: {
     paddingTop: 0,
     paddingBottom: 0,

--- a/packages/lesswrong/components/messaging/ConversationDetails.tsx
+++ b/packages/lesswrong/components/messaging/ConversationDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useDialog } from '../common/withDialog';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: theme.spacing.unit*2,
     marginBottom: theme.spacing.unit*2,

--- a/packages/lesswrong/components/messaging/ConversationItem.tsx
+++ b/packages/lesswrong/components/messaging/ConversationItem.tsx
@@ -9,7 +9,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import classNames from 'classnames'
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   ...postsItemLikeStyles(theme),
   leftMargin: {
     marginLeft: theme.spacing.unit * 2

--- a/packages/lesswrong/components/messaging/ConversationPage.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPage.tsx
@@ -8,7 +8,7 @@ import Conversations from '../../lib/collections/conversations/collection';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   conversationSection: {
     maxWidth: 550,
   },

--- a/packages/lesswrong/components/messaging/ConversationPreview.tsx
+++ b/packages/lesswrong/components/messaging/ConversationPreview.tsx
@@ -6,7 +6,7 @@ import Messages from "../../lib/collections/messages/collection";
 import Conversations from '../../lib/collections/conversations/collection';
 import Card from '@material-ui/core/Card';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: theme.spacing.unit,
     width: 500,

--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   message: {
     backgroundColor: grey[200],
     paddingTop: theme.spacing.unit,

--- a/packages/lesswrong/components/notifications/EmailPreview.tsx
+++ b/packages/lesswrong/components/notifications/EmailPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   emailPreview: {},
   headerName: {},
   headerContent: {},

--- a/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
+++ b/packages/lesswrong/components/notifications/NotificationTypeSettings.tsx
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import { defaultNotificationTypeSettings } from '../../lib/collections/users/custom_fields';
 import { getNotificationTypeByUserSetting } from '../../lib/notificationTypes';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: 8,
   },

--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -8,7 +8,7 @@ import withHover from '../common/withHover';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { parseRouteWithErrors } from '../linkPreview/HoverPreviewLink';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     "&:hover": {
       backgroundColor: "rgba(0,0,0,0.02) !important",

--- a/packages/lesswrong/components/notifications/NotificationsList.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsList.tsx
@@ -5,7 +5,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import Notifications from '../../lib/collections/notifications/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 270,
     overflowY: "auto",

--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -19,7 +19,7 @@ import * as _ from 'underscore';
 // import { NavDropdown, MenuItem } from 'react-bootstrap';
 import Notifications from '../../lib/collections/notifications/collection'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "inline-block",
     verticalAlign: "top",

--- a/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenuButton.tsx
@@ -9,7 +9,7 @@ import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import { useCurrentUser } from '../common/withUser';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   badgeContainer: {
     padding: "none",
     fontFamily: 'freight-sans-pro, sans-serif',

--- a/packages/lesswrong/components/notifications/SubscribeTo.tsx
+++ b/packages/lesswrong/components/notifications/SubscribeTo.tsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
 import { useTracking } from "../../lib/analyticsEvents";
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     alignItems: "center"

--- a/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
+++ b/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
@@ -3,7 +3,7 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   meta: {
     fontSize: ".9rem",
     color: "rgba(0,0,0,.45)"

--- a/packages/lesswrong/components/posts/AlignmentCrosspostMessage.tsx
+++ b/packages/lesswrong/components/posts/AlignmentCrosspostMessage.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -11,7 +11,7 @@ import withTimezone from '../common/withTimezone';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { forumAllPostsNumDaysSetting, DatabasePublicSetting } from '../../lib/publicSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   title: {
     cursor: "pointer",
   }

--- a/packages/lesswrong/components/posts/BookmarkButton.tsx
+++ b/packages/lesswrong/components/posts/BookmarkButton.tsx
@@ -13,7 +13,7 @@ import {TooltipProps} from '@material-ui/core/Tooltip';
 import { useTracking } from '../../lib/analyticsEvents';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     cursor: "pointer",
     color: theme.palette.grey[400]

--- a/packages/lesswrong/components/posts/EventsPast.tsx
+++ b/packages/lesswrong/components/posts/EventsPast.tsx
@@ -4,7 +4,7 @@ import {getAfterDefault, getBeforeDefault} from './timeframeUtils'
 import { useTimezone } from '../common/withTimezone';
 import { forumAllPostsNumDaysSetting } from '../../lib/publicSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   daily: {
     padding: theme.spacing.unit
   }

--- a/packages/lesswrong/components/posts/LinkPostMessage.tsx
+++ b/packages/lesswrong/components/posts/LinkPostMessage.tsx
@@ -3,7 +3,7 @@ import { Posts } from '../../lib/collections/posts';
 import React from 'react';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle

--- a/packages/lesswrong/components/posts/Pingback.tsx
+++ b/packages/lesswrong/components/posts/Pingback.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useHover } from '../common/withHover';
 import { KARMA_WIDTH } from './PostsItem2';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     marginBottom: 2,

--- a/packages/lesswrong/components/posts/PingbacksList.tsx
+++ b/packages/lesswrong/components/posts/PingbacksList.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Posts } from '../../lib/collections/posts/collection';
 import { useTracking } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: theme.spacing.unit*4,
     marginTop: theme.spacing.unit*2

--- a/packages/lesswrong/components/posts/PostCollaborationEditor.tsx
+++ b/packages/lesswrong/components/posts/PostCollaborationEditor.tsx
@@ -6,7 +6,7 @@ import { useCurrentUser } from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil';
 import { editorStyles, postBodyStyles } from '../../themes/stylePiping'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   title: {
     ...theme.typography.display3,
     ...theme.typography.postStyle,

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -4,7 +4,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Button from '@material-ui/core/Button';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     justifyContent: "flex-end",

--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -6,7 +6,7 @@ import { Posts } from '../../lib/collections/posts';
 import { useLocation, useNavigation } from '../../lib/routeUtil'
 import NoSsr from '@material-ui/core/NoSsr';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     flexWrap: "wrap",

--- a/packages/lesswrong/components/posts/PostsGroupDetails.tsx
+++ b/packages/lesswrong/components/posts/PostsGroupDetails.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import { Localgroups } from '../../lib/index';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   title: {
     display: 'inline-block',
     fontSize: 22,

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { postHighlightStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     maxWidth:570,
     ...postHighlightStyles(theme),

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -20,7 +20,7 @@ export const COMMENTS_WIDTH = 48
 
 const COMMENTS_BACKGROUND_COLOR = "#fafafa"
 
-export const styles = (theme: ThemeType): JssStypes => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative",
     [theme.breakpoints.down('xs')]: {

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -20,7 +20,7 @@ export const COMMENTS_WIDTH = 48
 
 const COMMENTS_BACKGROUND_COLOR = "#fafafa"
 
-export const styles = (theme) => ({
+export const styles = (theme: ThemeType): JssStypes => ({
   root: {
     position: "relative",
     [theme.breakpoints.down('xs')]: {

--- a/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2MetaInfo.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   metaInfo: {
     color: theme.palette.grey[600],
     fontSize: "1.1rem",

--- a/packages/lesswrong/components/posts/PostsItemComments.tsx
+++ b/packages/lesswrong/components/posts/PostsItemComments.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import CommentIcon from '@material-ui/icons/ModeComment';
 import { Posts } from "../../lib/collections/posts";
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   commentCount: {
     position:"absolute",
     right:"50%",

--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -7,7 +7,7 @@ import moment from '../../lib/moment-timezone';
 export const POSTED_AT_WIDTH = 38
 export const START_TIME_WIDTH = 72
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   postedAt: {
     '&&': {
       cursor: "pointer",

--- a/packages/lesswrong/components/posts/PostsItemIcons.tsx
+++ b/packages/lesswrong/components/posts/PostsItemIcons.tsx
@@ -13,7 +13,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 // ea-forum-look-here (JP I think you really just gotta move away from your re-use of meta now)
 const MetaIcon = forumTypeSetting.get() === 'EAForum' ? GroupIcon : DetailsIcon
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   iconSet: {
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,

--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -6,7 +6,7 @@ import moment from '../../lib/moment-timezone';
 import { useTimezone } from '../common/withTimezone';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   read: {
     opacity: ".8"
   },

--- a/packages/lesswrong/components/posts/PostsItemMetaInfo.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMetaInfo.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     color: theme.palette.grey[600],
     fontSize: "1.1rem",

--- a/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
@@ -4,8 +4,8 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 import { unflattenComments } from '../../lib/utils/unflatten';
 
-const styles = theme => ({
-  title: {
+const styles = (theme: ThemeType): JssStyles => ({
+  titlei: {
     fontSize: 10,
     ...theme.typography.commentStyle,
     color: theme.palette.grey[700],

--- a/packages/lesswrong/components/posts/PostsItemWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsItemWrapper.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import DragIcon from '@material-ui/icons/DragHandle';
 import RemoveIcon from '@material-ui/icons/Close';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     alignItems: "center",

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -11,7 +11,7 @@ const Error = ({error}) => <div>
   <FormattedMessage id={error.id} values={{value: error.value}}/>{error.message}
 </div>;
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   itemIsLoading: {
     opacity: .4,
   },

--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -75,7 +75,7 @@ const FILTERS_ALL = {
 }
 const FILTERS = FILTERS_ALL[forumTypeSetting.get()]
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     alignItems: "flex-start",

--- a/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
+++ b/packages/lesswrong/components/posts/PostsListSortDropdown.tsx
@@ -6,7 +6,7 @@ import Menu from '@material-ui/core/Menu';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -7,7 +7,7 @@ import { useLocation, useNavigation } from '../../lib/routeUtil';
 import NoSsr from '@material-ui/core/NoSsr';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     flexWrap: "wrap",

--- a/packages/lesswrong/components/posts/PostsNoResults.tsx
+++ b/packages/lesswrong/components/posts/PostsNoResults.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: theme.spacing.unit,
     fontStyle: "italic",

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -7,7 +7,7 @@ import GroupIcon from '@material-ui/icons/Group';
 import SubjectIcon from '@material-ui/icons/Subject';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     textAlign: 'left',
     display: 'inline-block',

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -25,7 +25,7 @@ const NotFPSubmittedWarning = ({className}) => <div className={className}>
   {' '}<WarningIcon fontSize='inherit' />
 </div>
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     margin: 0,
     ...theme.typography.display3,

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   reviewInfo: {
     textAlign: "center",
     marginBottom: 32

--- a/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsAuthors.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontFamily: theme.typography.uiSecondary.fontFamily,
     textAlign: 'left',

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -19,7 +19,7 @@ const MIN_TOC_WIDTH = 200
 export const MAX_COLUMN_WIDTH = 720
 
 // Also used in PostsCompareRevisions
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative",
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageActions.tsx
@@ -6,7 +6,7 @@ import withUser from '../../common/withUser';
 import { withTracking } from '../../../lib/analyticsEvents';
 import ClickawayListener from '@material-ui/core/ClickAwayListener';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     verticalAlign: 'middle'
   },

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageDate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { ExpandedDate } from '../../common/FormatDate';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   date: {
     color: theme.palette.grey[600],
     whiteSpace: "no-wrap",

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageEventData.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   metadata: {
     marginTop:theme.spacing.unit*3,
     ...theme.typography.postStyle,

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -7,7 +7,7 @@ import { MAX_COLUMN_WIDTH } from './PostsPage';
 
 const HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT = 300
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   footerSection: {
     display: 'flex',
     alignItems: 'center',

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -10,7 +10,7 @@ import { forumTypeSetting } from '../../../lib/instanceSettings';
 
 const SECONDARY_SPACING = 20
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   header: {
     position: 'relative',
     display:"flex",

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import { Posts } from '../../../lib/collections/posts';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.display3,
     ...theme.typography.postStyle,

--- a/packages/lesswrong/components/posts/PostsPage/PostsRevisionMessage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsRevisionMessage.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import React from 'react';
 import { QueryLink } from '../../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.contentNotice,
     ...theme.typography.postStyle

--- a/packages/lesswrong/components/posts/PostsPage/PostsRevisionSelector.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsRevisionSelector.tsx
@@ -6,7 +6,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import moment from '../../../lib/moment-timezone';
 
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     verticalAlign: 'text-top',
     fontSize: 'inherit',

--- a/packages/lesswrong/components/posts/PostsPage/PostsRevisionsList.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsRevisionsList.tsx
@@ -7,7 +7,7 @@ import { QueryLink } from '../../../lib/reactRouterWrapper';
 import { useNavigation } from '../../../lib/routeUtil';
 
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   version: {
     marginRight: 5
   }

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -7,7 +7,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import { Sequences } from '../../../lib/collections/sequences/collection';
 import { Posts } from '../../../lib/collections/posts/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft:-20,
     display: "flex",

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -35,7 +35,7 @@ export const highlightStyles = theme => ({
   }
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: POST_PREVIEW_WIDTH,
     position: "relative",

--- a/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
@@ -6,7 +6,7 @@ import { Comments } from '../../lib/collections/comments';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 import { POST_PREVIEW_WIDTH } from './PostsPreviewTooltip';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   loading: {
     width: POST_PREVIEW_WIDTH,
     paddingTop: theme.spacing.unit,

--- a/packages/lesswrong/components/posts/PostsStats.tsx
+++ b/packages/lesswrong/components/posts/PostsStats.tsx
@@ -1,7 +1,7 @@
 import { Components as C, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     opacity:.5,
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -11,7 +11,7 @@ import withTimezone from '../common/withTimezone';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: theme.spacing.unit*4
   },

--- a/packages/lesswrong/components/posts/PostsTimeframeList.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeframeList.tsx
@@ -7,7 +7,7 @@ import { getDateRange, timeframeToTimeBlock } from './timeframeUtils'
 import withTimezone from '../common/withTimezone';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   loading: {
     opacity: .4,
   },

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -7,7 +7,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { Posts } from '../../lib/collections/posts';
 import { userHasBoldPostItems } from '../../lib/betas';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     color: "rgba(0,0,0,.87)",
     position: "relative",

--- a/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
+++ b/packages/lesswrong/components/posts/PostsUserAndCoauthors.tsx
@@ -4,7 +4,7 @@ import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import classNames from 'classnames';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   lengthLimited: {
     maxWidth: 310,
     textOverflow: "ellipsis",

--- a/packages/lesswrong/components/posts/ShowOrHideHighlightButton.tsx
+++ b/packages/lesswrong/components/posts/ShowOrHideHighlightButton.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 import SubdirectoryArrowLeftIcon from '@material-ui/icons/SubdirectoryArrowLeft';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   button: {
     color: "rgba(0,0,0,.5)",
     fontSize: "12px",

--- a/packages/lesswrong/components/posts/SpreadsheetPage.tsx
+++ b/packages/lesswrong/components/posts/SpreadsheetPage.tsx
@@ -34,7 +34,7 @@ const headerStyle = theme => ({
   zIndex: 1,
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: -150, // adjusting for footer
     position: "relative",

--- a/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
+++ b/packages/lesswrong/components/posts/SubmitToFrontpageCheckbox.tsx
@@ -37,7 +37,7 @@ const forumDefaultTooltip = {
 
 const defaultTooltip = forumDefaultTooltip[forumTypeSetting.get()]
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   submitToFrontpageWrapper: {
     [theme.breakpoints.down('sm')]: {
       width: "100%",

--- a/packages/lesswrong/components/posts/TableOfContents/AnswerTocRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/AnswerTocRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: -theme.spacing.unit,
     display: "flex"

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   stickyBlock: {
     position: "sticky",
     fontSize: 12,

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative",
     ...theme.typography.body2,

--- a/packages/lesswrong/components/questions/Answer.tsx
+++ b/packages/lesswrong/components/questions/Answer.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { Comments } from "../../lib/collections/comments";
 import { styles as commentsItemStyles } from "../comments/CommentsItem/CommentsItem";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   postContent: {
     ...answerStyles(theme),
   },

--- a/packages/lesswrong/components/questions/AnswerCommentsList.tsx
+++ b/packages/lesswrong/components/questions/AnswerCommentsList.tsx
@@ -6,7 +6,7 @@ import { unflattenComments } from "../../lib/utils/unflatten";
 import classNames from 'classnames';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   commentsList: {
     marginLeft: -theme.spacing.unit*1.5,
     marginRight: -theme.spacing.unit*1.5,

--- a/packages/lesswrong/components/questions/AnswersList.tsx
+++ b/packages/lesswrong/components/questions/AnswersList.tsx
@@ -3,7 +3,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import { Comments } from '../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 650 + (theme.spacing.unit*4),
     [theme.breakpoints.down('md')]: {

--- a/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
@@ -7,7 +7,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import FullscreenIcon from '@material-ui/icons/Fullscreen';
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     borderTop: "solid 2px rgba(0,0,0,.5)",
     maxWidth:650 + (theme.spacing.unit*4),

--- a/packages/lesswrong/components/questions/NewAnswerForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerForm.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser'
 import { useDialog } from '../common/withDialog';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   answersForm: {
     maxWidth:650,
     paddingBottom: theme.spacing.unit*4,

--- a/packages/lesswrong/components/questions/NewQuestionDialog.tsx
+++ b/packages/lesswrong/components/questions/NewQuestionDialog.tsx
@@ -11,7 +11,7 @@ import { useNavigation } from '../../lib/routeUtil';
 import withMobileDialog from '@material-ui/core/withMobileDialog';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   formSubmit: {
     display: "flex",
     flexWrap: "wrap",

--- a/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useCurrentUser } from '../common/withUser'
 import { Posts } from '../../lib/collections/posts/collection'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   answersForm: {
     maxWidth:650,
     paddingBottom: theme.spacing.unit*4,

--- a/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
+++ b/packages/lesswrong/components/questions/RelatedQuestionsList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import withErrorBoundary from '../common/withErrorBoundary';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 650 + (theme.spacing.unit*4),
     marginBottom: 100,

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -9,7 +9,7 @@ import { slotSpecificRecommendationSettingDefaults, defaultAlgorithmSettings } f
 import Users from '../../lib/collections/users/collection';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     justifyContent: "space-between",

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -9,7 +9,7 @@ import {AnalyticsContext} from "../../lib/analyticsEvents";
 import Hidden from '@material-ui/core/Hidden';
 export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   section: {
     marginTop: -12,
   },

--- a/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const RecommendationsPage = ({ classes }) => {

--- a/packages/lesswrong/components/review/FrontpageNominationPhase.tsx
+++ b/packages/lesswrong/components/review/FrontpageNominationPhase.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   hideOnMobile: {
     [theme.breakpoints.down('xs')]: {
       display: "none"

--- a/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
@@ -4,7 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useCurrentUser } from '../common/withUser'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   timeRemaining: {
     marginTop: 6,
     marginBottom: 4

--- a/packages/lesswrong/components/review/FrontpageVotingPhase.tsx
+++ b/packages/lesswrong/components/review/FrontpageVotingPhase.tsx
@@ -5,7 +5,7 @@ import { useCurrentUser } from '../common/withUser'
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { reviewAlgorithm } from "./FrontpageReviewPhase";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   timeRemaining: {
     marginTop: 6,
     marginBottom: 4

--- a/packages/lesswrong/components/review/NominatePostDialog.tsx
+++ b/packages/lesswrong/components/review/NominatePostDialog.tsx
@@ -6,7 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   nominating: {
     marginTop: 8,
     fontSize: "1.2rem"

--- a/packages/lesswrong/components/review/Nominations2018.tsx
+++ b/packages/lesswrong/components/review/Nominations2018.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   setting: {
     ...theme.typography.body2,
     color: theme.palette.grey[600]

--- a/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
+++ b/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 import { unflattenComments } from '../../lib/utils/unflatten';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   title: {
     fontSize: "1rem",
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/review/ReviewPostButton.tsx
+++ b/packages/lesswrong/components/review/ReviewPostButton.tsx
@@ -4,7 +4,7 @@ import { useCommentBox } from '../common/withCommentBox';
 import { useDialog } from '../common/withDialog';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/review/ReviewPostForm.tsx
+++ b/packages/lesswrong/components/review/ReviewPostForm.tsx
@@ -5,7 +5,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { Link } from '../../lib/reactRouterWrapper';
 import Posts from '../../lib/collections/posts/collection';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: "white",
     width: 600,

--- a/packages/lesswrong/components/review/Reviews2018.tsx
+++ b/packages/lesswrong/components/review/Reviews2018.tsx
@@ -6,7 +6,7 @@ import Users from '../../lib/collections/users/collection';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   setting: {
     ...theme.typography.body2,
     color: theme.palette.grey[600]

--- a/packages/lesswrong/components/revisions/CompareRevisions.tsx
+++ b/packages/lesswrong/components/revisions/CompareRevisions.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useQuery } from 'react-apollo';
 import gql from 'graphql-tag';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   differences: {
     "& ins": {
       background: "#88ff88",

--- a/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
@@ -5,7 +5,7 @@ import { useSingle } from '../../lib/crud/withSingle';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Posts } from '../../lib/collections/posts';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   revisionList: {
   },
 });

--- a/packages/lesswrong/components/revisions/RevisionComparisonNotice.tsx
+++ b/packages/lesswrong/components/revisions/RevisionComparisonNotice.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
   }
 });

--- a/packages/lesswrong/components/revisions/RevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/RevisionSelect.tsx
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import Radio from '@material-ui/core/Radio';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   revisionRow: {
   },
   radio: {

--- a/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigation } from '../../lib/routeUtil';
 import { useTagBySlug } from '../tagging/useTag';
 import { useMulti } from '../../lib/crud/withMulti';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
 });
 
 const TagPageRevisionSelect = ({ classes }: {

--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -3,7 +3,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { Snippet } from 'react-instantsearch-dom';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: theme.spacing.unit,
     marginBottom: theme.spacing.unit*2

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 
 import grey from '@material-ui/core/colors/grey';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
     root: {
       padding: theme.spacing.unit,
       borderBottom: "solid 1px",

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -6,7 +6,7 @@ import { Snippet} from 'react-instantsearch-dom';
 import grey from '@material-ui/core/colors/grey';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
     root: {
       padding: theme.spacing.unit,
       borderBottom: "solid 1px",

--- a/packages/lesswrong/components/search/SearchAutoComplete.tsx
+++ b/packages/lesswrong/components/search/SearchAutoComplete.tsx
@@ -5,7 +5,7 @@ import { isAlgoliaEnabled, getSearchClient } from '../../lib/algoliaUtil';
 import { connectAutoComplete } from 'react-instantsearch/connectors';
 import Autosuggest from 'react-autosuggest';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   autoComplete: {
     '& input': {
       ...theme.typography.body2,

--- a/packages/lesswrong/components/search/SearchBarResults.tsx
+++ b/packages/lesswrong/components/search/SearchBarResults.tsx
@@ -6,7 +6,7 @@ import { algoliaIndexNames } from '../../lib/algoliaUtil';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     color: "rgba(0,0,0, 0.87)",
     transition: "opacity .1s ease-in-out",

--- a/packages/lesswrong/components/search/SearchPage.tsx
+++ b/packages/lesswrong/components/search/SearchPage.tsx
@@ -6,7 +6,7 @@ import { algoliaIndexNames, isAlgoliaEnabled, getSearchClient } from '../../lib/
 import SearchIcon from '@material-ui/icons/Search';
 import { useLocation } from '../../lib/routeUtil';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: "100%",
     maxWidth: 1200,

--- a/packages/lesswrong/components/search/SearchPagination.tsx
+++ b/packages/lesswrong/components/search/SearchPagination.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import { Pagination } from 'react-instantsearch-dom';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     fontVariant: "small-caps",

--- a/packages/lesswrong/components/search/SequencesSearchHit.tsx
+++ b/packages/lesswrong/components/search/SequencesSearchHit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent} from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   title: {
     display: "inline",
     fontSize: "1.25rem",

--- a/packages/lesswrong/components/search/TagsSearchHit.tsx
+++ b/packages/lesswrong/components/search/TagsSearchHit.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Tags from '../../lib/collections/tags/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: theme.spacing.unit,
     marginTop: theme.spacing.unit/2,

--- a/packages/lesswrong/components/search/UsersAutoCompleteHit.tsx
+++ b/packages/lesswrong/components/search/UsersAutoCompleteHit.tsx
@@ -1,7 +1,7 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     cursor: "pointer"
   }

--- a/packages/lesswrong/components/search/UsersSearchHit.tsx
+++ b/packages/lesswrong/components/search/UsersSearchHit.tsx
@@ -3,7 +3,7 @@ import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: theme.spacing.unit,
     marginTop: theme.spacing.unit/2,

--- a/packages/lesswrong/components/search/UsersSearchInput.tsx
+++ b/packages/lesswrong/components/search/UsersSearchInput.tsx
@@ -4,7 +4,7 @@ import Input from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import PersonAddIcon from '@material-ui/icons/PersonAdd';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   input: {
     // this needs to be here because of Bootstrap. I am sorry :(
     padding: "6px 0 7px",

--- a/packages/lesswrong/components/seasonal/Covid19Notice.tsx
+++ b/packages/lesswrong/components/seasonal/Covid19Notice.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: "#ffe5b4",
     border: "1px solid #888",

--- a/packages/lesswrong/components/seasonal/PetrovDayButton.tsx
+++ b/packages/lesswrong/components/seasonal/PetrovDayButton.tsx
@@ -14,7 +14,7 @@ import Users from '../../lib/collections/users/collection';
 // see this post:
 // https://www.lesswrong.com/posts/vvzfFcbmKgEsDBRHh/honoring-petrov-day-on-lesswrong-in-2019
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.commentStyle,
     position: "absolute",

--- a/packages/lesswrong/components/seasonal/PetrovDayLossScreen.tsx
+++ b/packages/lesswrong/components/seasonal/PetrovDayLossScreen.tsx
@@ -7,7 +7,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 // see this post:
 // https://www.lesswrong.com/posts/vvzfFcbmKgEsDBRHh/honoring-petrov-day-on-lesswrong-in-2019
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "absolute",
     top: 0,

--- a/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
+++ b/packages/lesswrong/components/sequenceEditor/EditSequenceTitle.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import Input from '@material-ui/core/Input';
 import { sequencesImageScrim } from '../sequences/SequencesPage'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 65,
     backgroundColor: "rgba(0,0,0,0.25)",

--- a/packages/lesswrong/components/sequences/BooksItem.tsx
+++ b/packages/lesswrong/components/sequences/BooksItem.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { postBodyStyles } from '../../themes/stylePiping'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
   },
   description: {

--- a/packages/lesswrong/components/sequences/BottomNavigation.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigation.tsx
@@ -4,7 +4,7 @@ import { legacyBreakpoints } from '../../lib/utils/theme';
 import withErrorBoundary from '../common/withErrorBoundary'
 import classnames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "relative"
   },

--- a/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigationItem.tsx
@@ -6,7 +6,7 @@ import { Posts } from '../../lib/collections/posts/collection';
 import { useUpdateContinueReading } from './useUpdateContinueReading';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingTop: 28,
     

--- a/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersEditForm.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib
 import React from 'react';
 import Chapters from '../../lib/collections/chapters/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: theme.spacing.unit
   },

--- a/packages/lesswrong/components/sequences/ChaptersItem.tsx
+++ b/packages/lesswrong/components/sequences/ChaptersItem.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   description: {
     marginLeft: 10,
     fontSize: 20,

--- a/packages/lesswrong/components/sequences/CollectionsPage.tsx
+++ b/packages/lesswrong/components/sequences/CollectionsPage.tsx
@@ -9,7 +9,7 @@ import { useCurrentUser } from '../common/withUser';
 import Typography from '@material-ui/core/Typography';
 import { postBodyStyles } from '../../themes/stylePiping'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: "white",
     padding: 32,

--- a/packages/lesswrong/components/sequences/SequenceTooltip.tsx
+++ b/packages/lesswrong/components/sequences/SequenceTooltip.tsx
@@ -4,7 +4,7 @@ import { truncate } from '../../lib/editor/ellipsize';
 
 const SEQUENCE_DESCRIPTION_TRUNCATION_LENGTH = 750;
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   sequenceDescriptionHighlight: {
   },
 });

--- a/packages/lesswrong/components/sequences/SequencesGrid.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 
 // Shared with SequencesGridWrapper
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   grid: {
   },
   gridContent: {

--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.postStyle,
 

--- a/packages/lesswrong/components/sequences/SequencesHome.tsx
+++ b/packages/lesswrong/components/sequences/SequencesHome.tsx
@@ -5,7 +5,7 @@ import { postBodyStyles } from '../../themes/stylePiping';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
   },
   header: {

--- a/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNavigationLink.tsx
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 import { Link } from '../../lib/reactRouterWrapper';
 
 // Shared with SequencesNavigationLinkDisabled
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   root: {
     padding: 0,
     margin: 12,

--- a/packages/lesswrong/components/sequences/SequencesNewButton.tsx
+++ b/packages/lesswrong/components/sequences/SequencesNewButton.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Link } from '../../lib/reactRouterWrapper';
 import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   newSequence: {
     color: theme.palette.primary.light
   }

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -20,7 +20,7 @@ export const sequencesImageScrim = theme => ({
   background: 'linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 42%, rgba(255, 255, 255, 0) 100%)'
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingTop: 380,
   },

--- a/packages/lesswrong/components/shortform/ShortformPage.tsx
+++ b/packages/lesswrong/components/shortform/ShortformPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   column: {
     maxWidth:680,
     margin:"auto"

--- a/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
+++ b/packages/lesswrong/components/shortform/ShortformSubmitForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: 12,
     paddingRight: 12,

--- a/packages/lesswrong/components/shortform/ShortformThreadList.tsx
+++ b/packages/lesswrong/components/shortform/ShortformThreadList.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   shortformItem: {
     marginTop: theme.spacing.unit*4
   }

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -4,7 +4,7 @@ import { withMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 import {queryIsUpdating} from '../common/queryStatusUtils'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   shortformGroup: {
     marginTop: 12,
   },

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestCommentsList.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Comments } from '../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     marginRight: 4
   }

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestPostsList.tsx
@@ -3,7 +3,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import { Posts } from '../../lib/collections/posts';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     marginRight: 4
   }

--- a/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AFSuggestUsersList.tsx
@@ -3,7 +3,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import Users from "../../lib/collections/users/collection";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     marginRight: 4
   }

--- a/packages/lesswrong/components/sunshineDashboard/AdminHome.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AdminHome.tsx
@@ -8,7 +8,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { useCurrentUser } from '../common/withUser';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   recentLogins: {
     backgroundColor: "rgba(50,100,50,.1)",
   },

--- a/packages/lesswrong/components/sunshineDashboard/AdminMetadata.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/AdminMetadata.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import gql from 'graphql-tag';
 import { useQuery } from 'react-apollo';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   indexesTable: {
     border: "1px solid black",
     padding: 5,

--- a/packages/lesswrong/components/sunshineDashboard/SidebarAction.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarAction.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginRight: theme.spacing.unit*2,
     cursor:"pointer",

--- a/packages/lesswrong/components/sunshineDashboard/SidebarActionMenu.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarActionMenu.tsx
@@ -1,7 +1,7 @@
 import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position: "absolute",
     top:0,

--- a/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
 import Popper from '@material-ui/core/Popper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position:"relative",
     zIndex: theme.zIndexes.sidebarHoverOver,

--- a/packages/lesswrong/components/sunshineDashboard/SidebarInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarInfo.tsx
@@ -3,7 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Typography from '@material-ui/core/Typography';
 import classNames from 'classnames'
 
-const styles = (theme) => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "inline",
     color: theme.palette.grey[600],

--- a/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItemOverview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineCommentsItemOverview.tsx
@@ -5,7 +5,7 @@ import Users from '../../lib/collections/users/collection';
 import { Link } from '../../lib/reactRouterWrapper'
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   comment: {
     fontSize: "1rem",
     lineHeight: "1.5em"

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListCount.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListCount.tsx
@@ -1,7 +1,7 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   overflow: {
     color: "red"
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListItem.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     position:"relative",
     borderTop: "solid 1px rgba(0,0,0,.1)",

--- a/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineListTitle.tsx
@@ -2,7 +2,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     borderTop: "solid 1px rgba(0,0,0,.2)",
     padding: theme.spacing.unit*1.5,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewCommentsList.tsx
@@ -3,7 +3,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import { Comments } from '../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor: "rgba(120,120,0,.08)"
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -18,7 +18,7 @@ import ClearIcon from '@material-ui/icons/Clear';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { postHighlightStyles } from '../../themes/stylePiping'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   icon: {
     width: 14,
     marginRight: 4

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsList.tsx
@@ -5,7 +5,7 @@ import { Posts } from '../../lib/collections/posts';
 import Users from '../../lib/collections/users/collection';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor:"rgba(0,80,0,.08)"
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsItem.tsx
@@ -13,7 +13,7 @@ import { commentBodyStyles, } from '../../themes/stylePiping'
 import { useMulti } from '../../lib/crud/withMulti';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   tagInfo: {
     ...commentBodyStyles(theme),
     marginTop: 0,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsList.tsx
@@ -5,7 +5,7 @@ import Tags from '../../lib/collections/tags/collection';
 import Users from '../../lib/collections/users/collection';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor:"rgba(80,80,0,.08)"
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -6,7 +6,7 @@ import { Comments } from '../../lib/collections/comments';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: theme.spacing.unit
   },

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -5,7 +5,7 @@ import { Posts } from '../../lib/collections/posts';
 import { postHighlightStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   post: {
     marginTop: theme.spacing.unit*2,
     marginBottom: theme.spacing.unit*2,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -17,7 +17,7 @@ import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
 import classNames from 'classnames';
 import DescriptionIcon from '@material-ui/icons/Description'
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   negativeKarma: {
      color: red['A100']
   },

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersList.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Users from '../../lib/collections/users/collection';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   loadMore: {
     fontSize: "1rem",
     textAlign: "right",

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedContentList.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import React from 'react';
 import Reports from '../../lib/collections/reports/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     backgroundColor: "rgba(60,0,0,.08)"
   }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -6,7 +6,7 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     zIndex: theme.zIndexes.sunshineSidebar,
     display:"none",

--- a/packages/lesswrong/components/tagging/AddPostsToTag.tsx
+++ b/packages/lesswrong/components/tagging/AddPostsToTag.tsx
@@ -8,7 +8,7 @@ import AddBoxIcon from '@material-ui/icons/AddBox';
 import classNames from 'classnames';
 import { useMessages } from '../common/withMessages';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 90,
     transition: ".25s",

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -6,7 +6,7 @@ import Divider from '@material-ui/core/Divider';
 import { Tags } from '../../lib/collections/tags/collection';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     "& .ais-SearchBox": {
       padding: 8,

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -6,7 +6,7 @@ import { useCurrentUser } from '../common/withUser';
 import { userCanUseTags } from '../../lib/betas';
 import { useTracking } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   addTagButton: {
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],

--- a/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsAlphabetical.tsx
@@ -6,7 +6,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import AddBoxIcon from '@material-ui/icons/AddBox';
 import _sortBy from 'lodash/sortBy';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     margin: "auto",
     maxWidth: 1000

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -16,7 +16,7 @@ import { wikiGradeDefinitions } from '../../lib/collections/tags/schema';
 import { useLocation } from '../../lib/routeUtil';
 import { useDialog } from '../common/withDialog';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     margin: "auto",
     maxWidth: 1000

--- a/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
+++ b/packages/lesswrong/components/tagging/CoreTagsChecklist.tsx
@@ -4,7 +4,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import Checkbox from '@material-ui/core/Checkbox';
 import { Tags } from '../../lib/collections/tags/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: 8,
     display: "flex",

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -12,7 +12,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { isMobile } from '../../lib/utils/isMobile'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   tag: {
     ...tagStyle(theme),
     display: "inline-block",

--- a/packages/lesswrong/components/tagging/FooterTag.tsx
+++ b/packages/lesswrong/components/tagging/FooterTag.tsx
@@ -32,7 +32,7 @@ const newTagStyle = theme => ({
   fontSize: 15
 })
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "inline-block",
     cursor: "pointer",

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -14,7 +14,7 @@ import { commentBodyStyles } from '../../themes/stylePiping'
 import Card from '@material-ui/core/Card';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 8,
     marginBottom: 8,

--- a/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
+++ b/packages/lesswrong/components/tagging/PostsItemTagRelevance.tsx
@@ -4,7 +4,7 @@ import { useVote } from '../votes/withVote';
 import classNames from 'classnames';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: 30,
     position: "absolute",

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -7,7 +7,7 @@ import * as _ from 'underscore';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useTracking } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginLeft: "auto",
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { useTagBySlug } from './useTag';
 import { linkStyle } from '../linkPreview/PostLinkPreview';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   link: {
     ...linkStyle(theme),
   },

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -16,7 +16,7 @@ import HistoryIcon from '@material-ui/icons/History';
 import { useDialog } from '../common/withDialog';
 
 // Also used in TagCompareRevisions
-export const styles = theme => ({
+export const styles = (theme: ThemeType): JssStyles => ({
   tagPage: {
     ...commentBodyStyles(theme),
     color: theme.palette.grey[600]

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -6,7 +6,7 @@ import { TagRels } from '../../lib/collections/tagRels/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   card: {
     paddingTop: 8,
     paddingLeft: 16,

--- a/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
+++ b/packages/lesswrong/components/tagging/TagPreviewDescription.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { truncate } from '../../lib/editor/ellipsize';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...commentBodyStyles(theme)
   }

--- a/packages/lesswrong/components/tagging/TagRelCard.tsx
+++ b/packages/lesswrong/components/tagging/TagRelCard.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useVote } from '../votes/withVote';
 import { hasVotedClient } from '../../lib/voting/vote';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   relevance: {
     marginTop: 2,
     marginLeft: 16,

--- a/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
+++ b/packages/lesswrong/components/tagging/TagRelevanceButton.tsx
@@ -8,7 +8,7 @@ import { useTracking } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -6,7 +6,7 @@ import { Tags } from '../../lib/collections/tags/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "block",
     padding: 8,

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { Posts } from '../../lib/collections/posts';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     ...theme.typography.body2,

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -7,7 +7,7 @@ import { Posts } from '../../lib/collections/posts';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useVote } from '../votes/withVote';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   voteRow: {
   },
   headerCell: {

--- a/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
@@ -8,7 +8,7 @@ import { EditTagForm } from './EditTagPage';
 import { useMulti } from '../../lib/crud/withMulti';
 import { TagRels } from '../../lib/collections/tagRels/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     background: "white",
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/tagging/TagsListItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsListItem.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useHover } from '../common/withHover';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   tag: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,

--- a/packages/lesswrong/components/tagging/WikiGradeDisplay.tsx
+++ b/packages/lesswrong/components/tagging/WikiGradeDisplay.tsx
@@ -4,7 +4,7 @@ import { wikiGradeDefinitions } from '../../lib/collections/tags/schema';
 import StarIcon from '@material-ui/icons/Star';
 import { Link } from '../../lib/reactRouterWrapper';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: 'flex',
     alignItem: 'center',

--- a/packages/lesswrong/components/users/AccountsVerifyEmail.tsx
+++ b/packages/lesswrong/components/users/AccountsVerifyEmail.tsx
@@ -6,7 +6,7 @@ import withUser from '../common/withUser';
 import { useLocation } from '../../lib/routeUtil'
 import { Accounts } from 'meteor/accounts-base';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     textAlign: "center",
   }

--- a/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifier.tsx
@@ -22,7 +22,7 @@ import { Comments } from '../../lib/collections/comments';
 import { withTracking, AnalyticsContext } from '../../lib/analyticsEvents';
 
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: 'flex',
     alignItems: 'center',

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -14,7 +14,7 @@ import moment from '../../lib/moment-timezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     paddingLeft: 8,
     paddingRight: 8,

--- a/packages/lesswrong/components/users/LoginPopup.tsx
+++ b/packages/lesswrong/components/users/LoginPopup.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import Dialog from '@material-ui/core/Dialog';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   dialog: {
     zIndex: theme.zIndexes.loginDialog
   },

--- a/packages/lesswrong/components/users/LoginPopupButton.tsx
+++ b/packages/lesswrong/components/users/LoginPopupButton.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
 import { useDialog } from '../common/withDialog';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     color: theme.palette.primary.main,

--- a/packages/lesswrong/components/users/ResendVerificationEmailPage.tsx
+++ b/packages/lesswrong/components/users/ResendVerificationEmailPage.tsx
@@ -3,7 +3,7 @@ import { registerComponent, Components } from '../../lib/vulcan-lib';
 import Users from '../../lib/collections/users/collection';
 import withUser from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     textAlign: "center",
   },

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -23,7 +23,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
 import seedrandom from '../../lib/seedrandom';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   grid: {
     display: 'grid',
     gridTemplateColumns: `

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Info from '@material-ui/icons/Info';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     marginBottom: 10,

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -6,7 +6,7 @@ import Popover from '@material-ui/core/Popover';
 import Button from '@material-ui/core/Button';
 import { withTracking } from '../../lib/analyticsEvents';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 5,
   },

--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -10,7 +10,7 @@ import withUser from '../common/withUser';
 import { withApollo } from 'react-apollo'
 import { useNavigation } from '../../lib/routeUtil';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     width: "60%",
     maxWidth: 600,

--- a/packages/lesswrong/components/users/UsersEmailVerification.tsx
+++ b/packages/lesswrong/components/users/UsersEmailVerification.tsx
@@ -6,7 +6,7 @@ import Button from '@material-ui/core/Button';
 import withUser from '../common/withUser';
 import withErrorBoundary from '../common/withErrorBoundary';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.body2,
     marginLeft: theme.spacing.unit

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -24,7 +24,7 @@ import withHover from '../common/withHover'
 import {captureEvent} from "../../lib/analyticsEvents";
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginTop: 5,
     wordBreak: 'break-all',

--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -10,7 +10,7 @@ import withHover from '../common/withHover'
 import classNames from 'classnames';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   userName: {
     whiteSpace: "nowrap",
     color: "inherit"

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -26,7 +26,7 @@ export const sectionFooterLeftStyles = {
   }
 }
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   profilePage: {
     marginLeft: "auto",
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -8,7 +8,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { Comments } from '../../lib/collections/comments/collection';
 import { Tags } from '../../lib/collections/tags/collection';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   subscribedItem: {
     display: "flex",
     ...theme.typography.commentStyle

--- a/packages/lesswrong/components/votes/PostsVote.tsx
+++ b/packages/lesswrong/components/votes/PostsVote.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { useVote } from './withVote';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   upvote: {
     marginBottom: -22
   },

--- a/packages/lesswrong/components/votes/SmallSideVote.tsx
+++ b/packages/lesswrong/components/votes/SmallSideVote.tsx
@@ -9,7 +9,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { Comments } from '../../lib/collections/comments';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   vote: {
     fontSize: 25,
     lineHeight: 0.6,

--- a/packages/lesswrong/components/votes/VoteButton.tsx
+++ b/packages/lesswrong/components/votes/VoteButton.tsx
@@ -12,7 +12,7 @@ import { useDialog } from '../common/withDialog';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useCurrentUser } from '../common/withUser';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     color: theme.palette.grey[400],
     fontSize: 'inherit',

--- a/packages/lesswrong/components/vulcan-forms/FieldErrors.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FieldErrors.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.errorStyle
   }

--- a/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import classNames from 'classnames';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     ...theme.typography.errorStyle
   }

--- a/packages/lesswrong/server/emailComponents/EmailComment.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailComment.tsx
@@ -9,7 +9,7 @@ import './EmailPostAuthors';
 import './EmailContentItemBody';
 import * as _ from 'underscore';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   comment: {
   },
 });

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 import { registerComponent, Utils } from '../../lib/vulcan-lib';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   root: {
     "& img": {
       maxWidth: "100%",

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -7,7 +7,7 @@ import './EmailPostAuthors';
 import './EmailContentItemBody';
 import './EmailPostDate';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   heading: {
     textAlign: "center",
   },

--- a/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/PrivateMessagesEmail.tsx
@@ -8,7 +8,7 @@ import './EmailFormatDate';
 import './EmailContentItemBody';
 import { siteNameWithArticleSetting } from '../../lib/instanceSettings';
 
-const styles = theme => ({
+const styles = (theme: ThemeType): JssStyles => ({
   message: {
   },
 });


### PR DESCRIPTION
Changes the idiom where components have style blocks that look like this:
```
const styles = theme => ({
```
to instead look like this:
```
const styles = (theme: ThemeType): JssStyles => ({
```
Both `ThemeType` and `JssStyles` are defined as synonyms for `any` (in `hocTypes.d.ts`). This is one small insert into `hocTypes.d.ts` plus one giant find-replace; there is nothing else in the PR. (Actually making it a non-`any` type is for another day, and in a PR not mixed together with such a big find/replace.)