### PR TITLE
Add fancy Mongo expression

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1003,9 +1003,19 @@ Posts.addView("reviews2018", terms => {
 
 Posts.addView("tagProgressTagged", terms => {
   return {
-    selector: {
-      tagRelevance: {$ne: {}},
-      baseScore: {$gt:30},
+    selector: {  
+      tagRelevance: {$ne: null},
+      baseScore: {$gt: 30},
+      $expr: {
+          $gt: [
+              {$size: 
+                  {$filter: {
+                      input: {$objectToArray: "$tagRelevance"},
+                      cond: {$not: {$in: ["$$this", ["xexCWMyds6QLWognu", "sYm3HiWcfZvrGu3ui", "izp6eeJJEg9v5zcur", "fkABsGCJZ6y9qConW", "Ng8Gice9KNkncxqcj", "MfpEPj6kJneT9gWT6", "3uE2pXvbcnS9nnZRE"]]}}
+                  }}
+              }, 
+              0]
+      } 
     },
   }
 })

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1004,7 +1004,7 @@ Posts.addView("reviews2018", terms => {
 Posts.addView("tagProgressTagged", terms => {
   return {
     selector: {  
-      tagRelevance: {$ne: null},
+      tagRelevance: {$exists: true},
       baseScore: {$gt: 30},
       $expr: {
           $gt: [


### PR DESCRIPTION
This is a reasonably performant way to do a query for posts without core tags. Created for review and discussion (also, note that this is being merged into the `tagProgressBar` PR).