### PR TITLE
Add /concepts redirect

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -584,6 +584,11 @@ switch (forumTypeSetting.get()) {
         componentName: 'EASequencesHome'
       },
       {
+        name: "Concepts",
+        path:'/concepts',
+        redirect: () => `/tags/all`,
+      },
+      {
         name: "TagsAll",
         path:'/tags',
         redirect: () => `/tags/all`,


### PR DESCRIPTION
Possibly the /tags/all page should be formally changed to /concepts, but meanwhile seemed good to have /concepts at least point _somewhere_.