### PR TITLE
TagPreview post links a little greener

### DIFF
--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -37,7 +37,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     textAlign: "right",
     ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
-    color: theme.palette.primary.main,
+    color: theme.palette.grey[500],
     marginTop: 6,
     marginBottom: 2,
     marginRight: 6
@@ -77,7 +77,7 @@ const TagPreview = ({tag, classes, showCount=true, postCount=3}: {
       {results.map((result,i) => <TagSmallPostLink key={result.post._id} post={result.post} widerSpacing={postCount > 3} />)}
     </div> : <Loading /> }
     {showCount && <div className={classes.footerCount}>
-      <Link to={Tags.getUrl(tag)}>{tag.postCount} posts</Link>
+      <Link to={Tags.getUrl(tag)}>View all {tag.postCount} posts</Link>
     </div>}
   </div>)
 }

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -37,7 +37,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     textAlign: "right",
     ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
-    color: theme.palette.grey[500],
+    color: theme.palette.lwTertiary.main,
     marginTop: 6,
     marginBottom: 2,
     marginRight: 6

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -16,7 +16,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 8,
     textAlign: "center",
     width: 20,
-    flexShrink: 0
+    flexShrink: 0,
+    color: theme.palette.lwTertiary.light
   },
   post: {
     display: "flex",
@@ -32,6 +33,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
     flexGrow: 1,
+    color: theme.palette.lwTertiary.dark
   },
   wrap: {
     whiteSpace: "unset",
@@ -40,7 +42,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   author: {
     marginRight: 0,
-    marginLeft: 20
+    marginLeft: 20,
+    color: theme.palette.lwTertiary.light
   },
   widerSpacing: {
     marginBottom: 4

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -17,7 +17,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     textAlign: "center",
     width: 20,
     flexShrink: 0,
-    color: theme.palette.lwTertiary.light
   },
   post: {
     display: "flex",
@@ -43,7 +42,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   author: {
     marginRight: 0,
     marginLeft: 20,
-    color: theme.palette.lwTertiary.light
   },
   widerSpacing: {
     marginBottom: 4

--- a/packages/lesswrong/themes/alignmentForumTheme.ts
+++ b/packages/lesswrong/themes/alignmentForumTheme.ts
@@ -27,7 +27,8 @@ const palette = {
   primary: indigo,
   secondary: indigo,
   lwTertiary: {
-    main: "#607e88"
+    main: "#607e88",
+    dark: "#607e88",
   },
   error: {
     main: deepOrange[900]

--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -39,7 +39,8 @@ const palette = {
     main: '#0c869b',
   },
   lwTertiary: {
-    main: "#137283"
+    main: "#137283",
+    dark: "#137283",
   },
   error: {
     main: deepOrange[900]

--- a/packages/lesswrong/themes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/lesswrongTheme.ts
@@ -37,7 +37,9 @@ const palette = {
     main: '#5f9b65',
   },
   lwTertiary: {
-    main: "#69886e"
+    light: "#778c7a",
+    main: "#69886e",
+    dark: "#21672b"
   },
   error: {
     main: deepOrange[900]

--- a/packages/lesswrong/themes/lesswrongTheme.ts
+++ b/packages/lesswrong/themes/lesswrongTheme.ts
@@ -37,7 +37,6 @@ const palette = {
     main: '#5f9b65',
   },
   lwTertiary: {
-    light: "#778c7a",
     main: "#69886e",
     dark: "#21672b"
   },


### PR DESCRIPTION
I played around with making the links a little greener. (I initially tried using the existing primary and lwTertiary colors and those felt too hard to read. I then made a darker variant of lwTertiary, and then the author/karma felt a little anemic next to that so I made them slightly greener too)

![image](https://user-images.githubusercontent.com/3246710/88858031-3743ed00-d1ac-11ea-8b58-a33f9ae3eb7e.png)
