### PR TITLE
More schema typechecks

### DIFF
--- a/packages/lesswrong/lib/collectionUtils.ts
+++ b/packages/lesswrong/lib/collectionUtils.ts
@@ -1,7 +1,7 @@
 import SimpleSchema from 'simpl-schema';
 import { Meteor } from 'meteor/meteor';
 import * as _ from 'underscore';
-import { addFieldsDict } from './utils/schemaUtils';
+import { addFieldsDict, CollectionFieldSpecification } from './utils/schemaUtils';
 export { getDefaultMutations } from './vulcan-core/default_mutations';
 export { getDefaultResolvers } from './vulcan-core/default_resolvers';
 
@@ -31,11 +31,11 @@ SimpleSchema.extendOptions([ 'denormalized' ]);
 //
 SimpleSchema.extendOptions([ 'foreignKey' ]);
 
-export const expectedIndexes = {};
+export const expectedIndexes: Partial<Record<CollectionNameString,Array<any>>> = {};
 
 // Returns true if the specified index has a name, and the collection has an
 // existing index with the same name but different columns or options.
-async function conflictingIndexExists(collection, index, options)
+async function conflictingIndexExists<T extends DbObject>(collection: CollectionBase<T>, index: any, options: any)
 {
   if (!options.name)
     return false;
@@ -63,12 +63,12 @@ async function conflictingIndexExists(collection, index, options)
   return false;
 }
 
-export function ensureIndex(collection, index, options:any={}): void
+export function ensureIndex<T extends DbObject>(collection: CollectionBase<T>, index: any, options:any={}): void
 {
   void ensureIndexAsync(collection, index, options);
 }
 
-export async function ensureIndexAsync(collection, index, options:any={})
+export async function ensureIndexAsync<T extends DbObject>(collection: CollectionBase<T>, index: any, options:any={})
 {
   if (Meteor.isServer) {
     const buildIndex = async () => {
@@ -84,7 +84,7 @@ export async function ensureIndexAsync(collection, index, options:any={})
         
         if (!expectedIndexes[collection.collectionName])
           expectedIndexes[collection.collectionName] = [];
-        expectedIndexes[collection.collectionName].push({
+        expectedIndexes[collection.collectionName]!.push({
           key: index,
           partialFilterExpression: options.partialFilterExpression,
         });
@@ -126,7 +126,11 @@ export async function ensureIndexAsync(collection, index, options:any={})
 //   prefix: [ordered dictionary] Collection fields from the default view
 //   suffix: [ordered dictionary] Collection fields from the default view
 //
-export function combineIndexWithDefaultViewIndex({viewFields, prefix, suffix})
+export function combineIndexWithDefaultViewIndex({viewFields, prefix, suffix}: {
+  viewFields: any,
+  prefix: any,
+  suffix: any,
+})
 {
   let combinedIndex = {...prefix};
   for (let key in viewFields) {
@@ -140,16 +144,23 @@ export function combineIndexWithDefaultViewIndex({viewFields, prefix, suffix})
   return combinedIndex;
 }
 
-export function schemaDefaultValue(defaultValue) {
+export function schemaDefaultValue<T extends DbObject>(defaultValue: any): Partial<CollectionFieldSpecification<T>> {
   // Used for both onCreate and onUpdate
-  const fillIfMissing = ({newDocument, fieldName}) => {
+  const fillIfMissing = ({newDocument, fieldName}: {
+    newDocument: T,
+    fieldName: string,
+  }) => {
     if (newDocument[fieldName] === undefined) {
       return defaultValue;
     } else {
       return undefined;
     }
   };
-  const throwIfSetToNull = ({oldDocument, document, fieldName}) => {
+  const throwIfSetToNull = ({oldDocument, document, fieldName}: {
+    oldDocument: T,
+    document: T,
+    fieldName: string,
+  }) => {
     const wasValid = (oldDocument[fieldName] !== undefined && oldDocument[fieldName] !== null);
     const isValid = (document[fieldName] !== undefined && document[fieldName] !== null);
     if (wasValid && !isValid) {
@@ -168,7 +179,7 @@ export function schemaDefaultValue(defaultValue) {
 export function addUniversalFields<T extends DbObject>({ collection, schemaVersion=1 }: {
   collection: CollectionBase<T>,
   schemaVersion?: number
-}) {
+}): void {
   addFieldsDict(collection, {
     _id: {
       optional: true,
@@ -186,13 +197,14 @@ export function addUniversalFields<T extends DbObject>({ collection, schemaVersi
   ensureIndex(collection, {schemaVersion: 1});
 }
 
-export function isUniversalField(fieldName: string) {
+export function isUniversalField(fieldName: string): boolean {
   return fieldName=="_id" || fieldName=="schemaVersion";
 }
 
-export function isUnbackedCollection(collection)
+export function isUnbackedCollection<T extends DbObject>(collection: CollectionBase<T>): boolean
 {
-  if (collection.collectionName === 'Settings' || collection.collectionName === 'Callbacks') {
+  const collectionName: string = collection.collectionName;
+  if (collectionName === 'Settings' || collectionName === 'Callbacks') {
     // Vulcan collections with no backing database table
     return true;
   }

--- a/packages/lesswrong/lib/collections/bans/schema.ts
+++ b/packages/lesswrong/lib/collections/bans/schema.ts
@@ -1,7 +1,7 @@
 import SimpleSchema from 'simpl-schema';
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbBan> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/books/schema.ts
+++ b/packages/lesswrong/lib/collections/books/schema.ts
@@ -1,6 +1,6 @@
-import { arrayOfForeignKeysField } from '../../utils/schemaUtils'
+import { arrayOfForeignKeysField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbBook> = {
 
   // default properties
 

--- a/packages/lesswrong/lib/collections/chapters/schema.ts
+++ b/packages/lesswrong/lib/collections/chapters/schema.ts
@@ -1,4 +1,4 @@
-import { foreignKeyField, arrayOfForeignKeysField } from '../../utils/schemaUtils'
+import { foreignKeyField, arrayOfForeignKeysField, SchemaType } from '../../utils/schemaUtils'
 
 export const formGroups = {
   chapterDetails: {
@@ -9,7 +9,7 @@ export const formGroups = {
   },
 }
 
-const schema = {
+const schema: SchemaType<DbChapter> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/collections/schema.ts
+++ b/packages/lesswrong/lib/collections/collections/schema.ts
@@ -1,6 +1,6 @@
-import { foreignKeyField, resolverOnlyField, accessFilterMultiple } from '../../utils/schemaUtils'
+import { foreignKeyField, resolverOnlyField, accessFilterMultiple, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbCollection> = {
 
   // default properties
 

--- a/packages/lesswrong/lib/collections/collections/schema.ts
+++ b/packages/lesswrong/lib/collections/collections/schema.ts
@@ -47,7 +47,7 @@ const schema: SchemaType<DbCollection> = {
     type: Array,
     graphQLtype: '[Book]',
     viewableBy: ['guests'],
-    resolver: async (collection, args, context: ResolverContext) => {
+    resolver: async (collection: DbCollection, args: void, context: ResolverContext) => {
       const { currentUser, Books } = context;
       const books = Books.find(
         {collectionId: collection._id},

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -1,11 +1,11 @@
 import Users from '../users/collection';
-import { foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences } from '../../../lib/utils/schemaUtils';
+import { foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences, SchemaType } from '../../../lib/utils/schemaUtils';
 import { Posts } from '../posts/collection'
 import { Comments } from '../comments/collection';
 import { schemaDefaultValue } from '../../collectionUtils';
 import { Utils } from '../../vulcan-lib';
 
-const schema = {
+const schema: SchemaType<DbComment> = {
   // The `_id` of the parent comment, if there is one
   parentCommentId: {
     ...foreignKeyField({

--- a/packages/lesswrong/lib/collections/comments/schema.ts
+++ b/packages/lesswrong/lib/collections/comments/schema.ts
@@ -132,7 +132,7 @@ const schema: SchemaType<DbComment> = {
   pageUrl: resolverOnlyField({
     type: String,
     canRead: ['guests'],
-    resolver: (comment, args, context: ResolverContext) => {
+    resolver: (comment: DbComment, args: void, context: ResolverContext) => {
       return Comments.getPageUrl(comment, true)
     },
   }),
@@ -140,7 +140,7 @@ const schema: SchemaType<DbComment> = {
   pageUrlRelative: resolverOnlyField({
     type: String,
     canRead: ['guests'],
-    resolver: (comment, args, context: ResolverContext) => {
+    resolver: (comment: DbComment, args: void, context: ResolverContext) => {
       return Comments.getPageUrl(comment, false)
     },
   }),
@@ -177,7 +177,7 @@ const schema: SchemaType<DbComment> = {
       foreignCollectionName: "Comments",
       foreignTypeName: "comment",
       foreignFieldName: "parentCommentId",
-      filterFn: comment => !comment.deleted
+      filterFn: (comment: DbComment) => !comment.deleted
     }),
     canRead: ['guests'],
   },
@@ -186,7 +186,7 @@ const schema: SchemaType<DbComment> = {
     type: Array,
     graphQLtype: '[Comment]',
     viewableBy: ['guests'],
-    resolver: async (comment, args, context: ResolverContext) => {
+    resolver: async (comment: DbComment, args: void, context: ResolverContext) => {
       const { Comments } = context;
       const params = Comments.getParameters({view:"shortformLatestChildren", comment: comment})
       return await Comments.find(params.selector, params.options).fetch()
@@ -328,7 +328,7 @@ const schema: SchemaType<DbComment> = {
   wordCount: resolverOnlyField({
     type: Number,
     viewableBy: ['guests'],
-    resolver: (comment, args, context: ResolverContext) => {
+    resolver: (comment: DbComment, args: void, context: ResolverContext) => {
       const contents = comment.contents;
       if (!contents) return 0;
       return contents.wordCount;
@@ -338,7 +338,7 @@ const schema: SchemaType<DbComment> = {
   htmlBody: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (comment, args, context: ResolverContext) => {
+    resolver: (comment: DbComment, args: void, context: ResolverContext) => {
       const contents = comment.contents;
       if (!contents) return "";
       return contents.html;

--- a/packages/lesswrong/lib/collections/conversations/schema.ts
+++ b/packages/lesswrong/lib/collections/conversations/schema.ts
@@ -1,7 +1,7 @@
-import { arrayOfForeignKeysField, denormalizedCountOfReferences } from '../../utils/schemaUtils'
+import { arrayOfForeignKeysField, denormalizedCountOfReferences, SchemaType } from '../../utils/schemaUtils'
 import * as _ from 'underscore';
 
-const schema = {
+const schema: SchemaType<DbConversation> = {
   createdAt: {
     optional: true,
     type: Date,

--- a/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
+++ b/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
@@ -1,10 +1,11 @@
+import { SchemaType } from '../../utils/schemaUtils';
 
 // The databaseMetadata collection is a collection of named, mostly-singleton
 // values. (Currently just databaseId, which is used for ensuring you don't
 // connect to a production database without using the corresponding config
 // file.)
 
-const schema = {
+const schema: SchemaType<DbDatabaseMetadata> = {
   name: {
     type: String,
   },

--- a/packages/lesswrong/lib/collections/emailTokens/schema.ts
+++ b/packages/lesswrong/lib/collections/emailTokens/schema.ts
@@ -1,6 +1,6 @@
-import { foreignKeyField } from '../../../lib/utils/schemaUtils';
+import { foreignKeyField, SchemaType } from '../../../lib/utils/schemaUtils';
 
-const schema = {
+const schema: SchemaType<DbEmailTokens> = {
   token: {
     type: String,
   },

--- a/packages/lesswrong/lib/collections/legacyData/collection.ts
+++ b/packages/lesswrong/lib/collections/legacyData/collection.ts
@@ -1,7 +1,8 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields, ensureIndex } from '../../collectionUtils'
+import { SchemaType} from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbLegacyData> = {
   objectId: {
     type: String,
   },

--- a/packages/lesswrong/lib/collections/localgroups/schema.ts
+++ b/packages/lesswrong/lib/collections/localgroups/schema.ts
@@ -1,8 +1,8 @@
-import { arrayOfForeignKeysField, denormalizedField, googleLocationToMongoLocation } from '../../utils/schemaUtils'
+import { arrayOfForeignKeysField, denormalizedField, googleLocationToMongoLocation, SchemaType } from '../../utils/schemaUtils'
 import { localGroupTypeFormOptions } from './groupTypes';
 import { schemaDefaultValue } from '../../collectionUtils';
 
-const schema = {
+const schema: SchemaType<DbLocalgroup> = {
   createdAt: {
     optional: true,
     type: Date,

--- a/packages/lesswrong/lib/collections/lwevents/schema.ts
+++ b/packages/lesswrong/lib/collections/lwevents/schema.ts
@@ -1,6 +1,6 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbLWEvent> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -1,7 +1,7 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import Users from '../users/collection';
 
-const schema = {
+const schema: SchemaType<DbMessage> = {
   userId: {
     ...foreignKeyField({
       idFieldName: "userId",

--- a/packages/lesswrong/lib/collections/migrations/collection.ts
+++ b/packages/lesswrong/lib/collections/migrations/collection.ts
@@ -1,11 +1,12 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils'
+import { SchemaType } from '../../utils/schemaUtils'
 
 // A collection which records whenever a migration is run, when it started and
 // finished, and whether it succeeded. This can be cross-checked against the
 // set of available migrations to find ones that need running.
 
-const schema = {
+const schema: SchemaType<DbMigration> = {
   name: {
     type: String,
   },

--- a/packages/lesswrong/lib/collections/notifications/schema.ts
+++ b/packages/lesswrong/lib/collections/notifications/schema.ts
@@ -1,7 +1,8 @@
 import Users from '../users/collection';
 import { schemaDefaultValue } from '../../collectionUtils';
+import { SchemaType } from '../../utils/schemaUtils';
 
-const schema = {
+const schema: SchemaType<DbNotification> = {
   userId: {
     type: String,
     foreignKey: "Users",

--- a/packages/lesswrong/lib/collections/postRelations/schema.ts
+++ b/packages/lesswrong/lib/collections/postRelations/schema.ts
@@ -1,6 +1,6 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbPostRelation> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -71,7 +71,7 @@ export const formGroups = {
 };
 
 
-const userHasModerationGuidelines = (currentUser) => {
+const userHasModerationGuidelines = (currentUser: DbUser|null): boolean => {
   return !!(currentUser && ((currentUser.moderationGuidelines && currentUser.moderationGuidelines.html) || currentUser.moderationStyle))
 }
 
@@ -162,7 +162,7 @@ addFieldsDict(Posts, {
   lastVisitedAt: resolverOnlyField({
     type: Date,
     viewableBy: ['guests'],
-    resolver: async (post, args, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, context: ResolverContext) => {
       const { ReadStatuses, currentUser } = context;
       if (!currentUser) return null;
 
@@ -179,7 +179,7 @@ addFieldsDict(Posts, {
   isRead: resolverOnlyField({
     type: Boolean,
     viewableBy: ['guests'],
-    resolver: async (post, args, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, context: ResolverContext) => {
       const { ReadStatuses, currentUser } = context;
       if (!currentUser) return false;
       
@@ -416,7 +416,8 @@ addFieldsDict(Posts, {
     graphQLtype: "Post",
     viewableBy: ['guests'],
     graphqlArguments: 'sequenceId: String',
-    resolver: async (post, { sequenceId }, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: {sequenceId: string}, context: ResolverContext) => {
+      const { sequenceId } = args;
       const { currentUser, Posts } = context;
       if (sequenceId) {
         const nextPostID = await Sequences.getNextPostID(sequenceId, post._id);
@@ -448,7 +449,8 @@ addFieldsDict(Posts, {
     graphQLtype: "Post",
     viewableBy: ['guests'],
     graphqlArguments: 'sequenceId: String',
-    resolver: async (post, { sequenceId }, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: {sequenceId: string}, context: ResolverContext) => {
+      const { sequenceId } = args;
       const { currentUser, Posts } = context;
       if (sequenceId) {
         const prevPostID = await Sequences.getPrevPostID(sequenceId, post._id);
@@ -482,7 +484,8 @@ addFieldsDict(Posts, {
     graphQLtype: "Sequence",
     viewableBy: ['guests'],
     graphqlArguments: 'sequenceId: String',
-    resolver: async (post, { sequenceId }, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: {sequenceId: string}, context: ResolverContext) => {
+      const { sequenceId } = args;
       const { currentUser, Sequences: SequencesContext } = context;
       let sequence = null;
       if (sequenceId && await Sequences.sequenceContainsPost(sequenceId, post._id)) {
@@ -921,7 +924,7 @@ addFieldsDict(Posts, {
     type: Object,
     viewableBy: ['guests'],
     graphQLtype: GraphQLJSON,
-    resolver: async (document, args, context: ResolverContext) => {
+    resolver: async (document: DbPost, args: void, context: ResolverContext) => {
       const { currentUser } = context;
       try {
         return await Utils.getTableOfContentsData({document, version: null, currentUser, context});
@@ -937,7 +940,8 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     graphQLtype: GraphQLJSON,
     graphqlArguments: 'version: String',
-    resolver: async (document, { version=null }, context: ResolverContext) => {
+    resolver: async (document: DbPost, args: {version:string}, context: ResolverContext) => {
+      const { version=null } = args;
       const { currentUser } = context;
       try {
         return await Utils.getTableOfContentsData({document, version, currentUser, context});
@@ -1037,7 +1041,8 @@ addFieldsDict(Posts, {
     graphQLtype: "[Comment]",
     viewableBy: ['guests'],
     graphqlArguments: 'commentsLimit: Int, maxAgeHours: Int, af: Boolean',
-    resolver: async (post, { commentsLimit=5, maxAgeHours=18, af=false }, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: {commentsLimit?: number, maxAgeHours?: number, af?: boolean}, context: ResolverContext) => {
+      const { commentsLimit=5, maxAgeHours=18, af=false } = args;
       const { currentUser, Comments } = context;
       const timeCutoff = moment().subtract(maxAgeHours, 'hours').toDate();
       const comments = await Comments.find({

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -1,7 +1,7 @@
 import Users from '../users/collection';
 import { Utils, getCollection } from '../../vulcan-lib';
 import moment from 'moment';
-import { foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences, accessFilterMultiple, accessFilterSingle } from '../../utils/schemaUtils'
+import { foreignKeyField, resolverOnlyField, denormalizedField, denormalizedCountOfReferences, accessFilterMultiple, accessFilterSingle, SchemaType } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 import { PostRelations } from "../postRelations/collection"
 import { Posts } from "../posts/collection"
@@ -25,7 +25,7 @@ const formGroups = {
   }
 };
 
-const schema = {
+const schema: SchemaType<DbPost> = {
   // Timestamp of post creation
   createdAt: {
     type: Date,

--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -274,25 +274,25 @@ const schema: SchemaType<DbPost> = {
   domain: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Utils.getDomain(post.url),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Utils.getDomain(post.url),
   }),
 
   pageUrl: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Posts.getPageUrl(post, true),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getPageUrl(post, true),
   }),
   
   pageUrlRelative: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Posts.getPageUrl(post, false),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getPageUrl(post, false),
   }),
 
   linkUrl: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => {
+    resolver: (post: DbPost, args: void, context: ResolverContext) => {
       return post.url ? Utils.getOutgoingUrl(post.url) : Posts.getPageUrl(post, true);
     },
   }),
@@ -300,7 +300,7 @@ const schema: SchemaType<DbPost> = {
   postedAtFormatted: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => {
+    resolver: (post: DbPost, args: void, context: ResolverContext) => {
       return moment(post.postedAt).format('dddd, MMMM Do YYYY');
     }
   }),
@@ -308,19 +308,19 @@ const schema: SchemaType<DbPost> = {
   emailShareUrl: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Posts.getEmailShareUrl(post),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getEmailShareUrl(post),
   }),
 
   twitterShareUrl: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Posts.getTwitterShareUrl(post),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getTwitterShareUrl(post),
   }),
 
   facebookShareUrl: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, context: ResolverContext) => Posts.getFacebookShareUrl(post),
+    resolver: (post: DbPost, args: void, context: ResolverContext) => Posts.getFacebookShareUrl(post),
   }),
 
   question: {
@@ -347,7 +347,7 @@ const schema: SchemaType<DbPost> = {
   wordCount: resolverOnlyField({
     type: Number,
     viewableBy: ['guests'],
-    resolver: (post, args, { Posts }: ResolverContext) => {
+    resolver: (post: DbPost, args: void, { Posts }: ResolverContext) => {
       const contents = post.contents;
       if (!contents) return 0;
       return contents.wordCount;
@@ -357,7 +357,7 @@ const schema: SchemaType<DbPost> = {
   htmlBody: resolverOnlyField({
     type: String,
     viewableBy: ['guests'],
-    resolver: (post, args, { Posts }: ResolverContext) => {
+    resolver: (post: DbPost, args: void, { Posts }: ResolverContext) => {
       const contents = post.contents;
       if (!contents) return "";
       return contents.html;
@@ -406,7 +406,7 @@ const schema: SchemaType<DbPost> = {
     type: Array,
     graphQLtype: '[PostRelation!]',
     viewableBy: ['guests'],
-    resolver: async (post, args, { Posts }: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, { Posts }: ResolverContext) => {
       return await PostRelations.find({targetPostId: post._id}).fetch()
     }
   }),
@@ -419,7 +419,7 @@ const schema: SchemaType<DbPost> = {
     type: Array,
     graphQLtype: '[PostRelation!]',
     viewableBy: ['guests'],
-    resolver: async (post, args, { Posts }: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, { Posts }: ResolverContext) => {
       const postRelations = await Posts.rawCollection().aggregate([
         { $match: { _id: post._id }},
         { $graphLookup: { 
@@ -512,7 +512,8 @@ const schema: SchemaType<DbPost> = {
     graphQLtype: "TagRel",
     viewableBy: ['guests'],
     graphqlArguments: 'tagId: String',
-    resolver: async (post, {tagId}, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: {tagId: string}, context: ResolverContext) => {
+      const { tagId } = args;
       const { currentUser } = context;
       const tagRels = await getWithLoader(TagRels,
         "tagRelByDocument",
@@ -532,7 +533,7 @@ const schema: SchemaType<DbPost> = {
     type: "[Tag]",
     graphQLtype: "[Tag]",
     viewableBy: ['guests'],
-    resolver: async (post:DbPost, args, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, context: ResolverContext) => {
       const { currentUser } = context;
       const tagRelevanceRecord:Record<string, number> = post.tagRelevance || {}
       const tagIds = Object.entries(tagRelevanceRecord).filter(([id, score]) => score && score > 0).map(([id]) => id)
@@ -559,7 +560,7 @@ const schema: SchemaType<DbPost> = {
     type: "Comment",
     graphQLtype: "Comment",
     viewableBy: ['guests'],
-    resolver: async (post, args, context: ResolverContext) => {
+    resolver: async (post: DbPost, args: void, context: ResolverContext) => {
       const { currentUser } = context;
       if (post.question) {
         if (post.lastCommentPromotedAt) {

--- a/packages/lesswrong/lib/collections/readStatus/collection.ts
+++ b/packages/lesswrong/lib/collections/readStatus/collection.ts
@@ -1,8 +1,8 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields, ensureIndex } from '../../collectionUtils'
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbReadStatus> = {
   postId: {
     ...foreignKeyField({
       idFieldName: "postId",

--- a/packages/lesswrong/lib/collections/reports/schema.ts
+++ b/packages/lesswrong/lib/collections/reports/schema.ts
@@ -1,6 +1,6 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 
-const schema = {
+const schema: SchemaType<DbReport> = {
   userId: {
     ...foreignKeyField({
       idFieldName: "userId",

--- a/packages/lesswrong/lib/collections/reviewVotes/schema.ts
+++ b/packages/lesswrong/lib/collections/reviewVotes/schema.ts
@@ -1,9 +1,9 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 
 import SimpleSchema from 'simpl-schema'
 
-const schema = {
+const schema: SchemaType<DbReviewVote> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/revisions/schema.ts
+++ b/packages/lesswrong/lib/collections/revisions/schema.ts
@@ -1,4 +1,4 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import SimpleSchema from 'simpl-schema'
 
 export const ContentType = new SimpleSchema({
@@ -14,7 +14,7 @@ export const ContentType = new SimpleSchema({
 
 SimpleSchema.extendOptions([ 'inputType' ]);
 
-const schema = {
+const schema: SchemaType<DbRevision> = {
   documentId: {
     type: String,
     viewableBy: ['guests'],

--- a/packages/lesswrong/lib/collections/rssfeeds/schema.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/schema.ts
@@ -1,7 +1,7 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 
-const schema = {
+const schema: SchemaType<DbRSSFeed> = {
   userId: {
     ...foreignKeyField({
       idFieldName: "userId",

--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -1,7 +1,7 @@
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils';
 
-const schema = {
+const schema: SchemaType<DbSequence> = {
 
   // default properties
 

--- a/packages/lesswrong/lib/collections/subscriptions/schema.ts
+++ b/packages/lesswrong/lib/collections/subscriptions/schema.ts
@@ -1,5 +1,5 @@
 import Users from '../users/collection'
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import { schemaDefaultValue } from '../../collectionUtils'
 
 export const subscriptionTypes = {
@@ -12,7 +12,7 @@ export const subscriptionTypes = {
   newTagPosts: 'newTagPosts'
 }
 
-const schema = {
+const schema: SchemaType<DbSubscription> = {
   createdAt: {
     type: Date,
     optional: true,

--- a/packages/lesswrong/lib/collections/tagRels/collection.ts
+++ b/packages/lesswrong/lib/collections/tagRels/collection.ts
@@ -1,10 +1,10 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields, getDefaultResolvers, getDefaultMutations, schemaDefaultValue } from '../../collectionUtils'
-import { foreignKeyField } from '../../utils/schemaUtils'
+import { foreignKeyField, SchemaType } from '../../utils/schemaUtils'
 import { makeVoteable } from '../../make_voteable';
 import { userCanUseTags } from '../../betas';
 
-const schema = {
+const schema: SchemaType<DbTagRel> = {
   createdAt: {
     optional: true,
     type: Date,

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -1,5 +1,5 @@
 import { schemaDefaultValue } from '../../collectionUtils'
-import { denormalizedCountOfReferences, foreignKeyField } from '../../utils/schemaUtils';
+import { denormalizedCountOfReferences, foreignKeyField, SchemaType } from '../../utils/schemaUtils';
 import SimpleSchema from 'simpl-schema';
 import { Utils } from '../../vulcan-lib';
 
@@ -12,7 +12,7 @@ const formGroups = {
   },
 };
   
-export const schema = {
+export const schema: SchemaType<DbTag> = {
   createdAt: {
     optional: true,
     type: Date,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -10,7 +10,7 @@ import { Utils } from '../../vulcan-lib';
 import { Posts } from '../posts/collection';
 import Users from "./collection";
 
-export const hashPetrovCode = (code) => {
+export const hashPetrovCode = (code: string): string => {
   // @ts-ignore
   const crypto = Npm.require('crypto');
   var hash = crypto.createHash('sha256');
@@ -173,7 +173,7 @@ const partiallyReadSequenceItem = new SimpleSchema({
 addFieldsDict(Users, {
   createdAt: {
     type: Date,
-    onInsert: (user, options) => {
+    onInsert: (user: DbUser, currentUser: DbUser) => {
       return user.createdAt || new Date();
     },
     canRead: ["guests"]
@@ -594,7 +594,7 @@ addFieldsDict(Users, {
     graphQLtype: '[String]',
     group: formGroups.banUser,
     canRead: ['sunshineRegiment', 'admins'],
-    resolver: async (user, args, context: ResolverContext) => {
+    resolver: async (user: DbUser, args: void, context: ResolverContext) => {
       const { currentUser, LWEvents } = context;
       const events: Array<DbLWEvent> = LWEvents.find(
         {userId: user._id, name: 'login'},
@@ -1390,7 +1390,7 @@ makeEditable({
 addUniversalFields({collection: Users})
 
 // Copied over utility function from Vulcan
-const createDisplayName = user => {
+const createDisplayName = (user: DbUser): string=> {
   const profileName = Utils.getNestedProperty(user, 'profile.name');
   const linkedinFirstName = Utils.getNestedProperty(user, 'services.linkedin.firstName');
   if (profileName) return profileName;

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1397,5 +1397,5 @@ const createDisplayName = (user: DbUser): string=> {
   if (linkedinFirstName) return `${linkedinFirstName} ${Utils.getNestedProperty(user, 'services.linkedin.lastName')}`;
   if (user.username) return user.username;
   if (user.email) return user.email.slice(0, user.email.indexOf('@'));
-  return undefined;
+  return "[missing username]";
 }

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1,6 +1,7 @@
 import SimpleSchema from 'simpl-schema';
 import { Utils, getCollection } from '../../vulcan-lib';
 import Users from "./collection";
+import { SchemaType } from '../../utils/schemaUtils';
 import * as _ from 'underscore';
 
 ///////////////////////////////////////
@@ -45,7 +46,7 @@ const ownsOrIsAdmin = (user, document) => {
  * @summary Users schema
  * @type {Object}
  */
-const schema = {
+const schema: SchemaType<DbUser> = {
   _id: {
     type: String,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -20,7 +20,7 @@ import * as _ from 'underscore';
 // Anything else..
 ///////////////////////////////////////
 
-const createDisplayName = user => {
+const createDisplayName = (user: DbUser): string => {
   const profileName = Utils.getNestedProperty(user, 'profile.name');
   const twitterName = Utils.getNestedProperty(user, 'services.twitter.screenName');
   const linkedinFirstName = Utils.getNestedProperty(user, 'services.linkedin.firstName');
@@ -38,7 +38,7 @@ const adminGroup = {
   order: 100,
 };
 
-const ownsOrIsAdmin = (user, document) => {
+const ownsOrIsAdmin = (user: DbUser|null, document: any) => {
   return getCollection('Users').owns(user, document) || getCollection('Users').isAdmin(user);
 };
 

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -30,7 +30,7 @@ const createDisplayName = (user: DbUser): string => {
     return `${linkedinFirstName} ${Utils.getNestedProperty(user, 'services.linkedin.lastName')}`;
   if (user.username) return user.username;
   if (user.email) return user.email.slice(0, user.email.indexOf('@'));
-  return undefined;
+  return "[missing username]";
 };
 
 const adminGroup = {

--- a/packages/lesswrong/lib/collections/votes/schema.ts
+++ b/packages/lesswrong/lib/collections/votes/schema.ts
@@ -100,7 +100,7 @@ const schema: SchemaType<DbVote> = {
     type: "TagRel",
     graphQLtype: 'TagRel',
     canRead: ['admins'],
-    resolver: (vote, args, { TagRels }: ResolverContext) => {
+    resolver: (vote: DbVote, args: void, { TagRels }: ResolverContext) => {
       if (vote.collectionName === "TagRels") {
         const tagRel = TagRels.find({_id: vote.documentId}).fetch()[0]
         if (tagRel) {

--- a/packages/lesswrong/lib/collections/votes/schema.ts
+++ b/packages/lesswrong/lib/collections/votes/schema.ts
@@ -1,6 +1,6 @@
 import Users from '../users/collection';
 import { schemaDefaultValue, } from '../../collectionUtils';
-import { resolverOnlyField } from '../../../lib/utils/schemaUtils';
+import { resolverOnlyField, SchemaType } from '../../../lib/utils/schemaUtils';
 //
 // Votes. From the user's perspective, they have a vote-state for each voteable
 // entity (post/comment), which is either neutral (the default), upvote,
@@ -14,7 +14,7 @@ import { resolverOnlyField } from '../../../lib/utils/schemaUtils';
 // that was reversed.
 //
 
-const schema = {
+const schema: SchemaType<DbVote> = {
   // The id of the document that was voted on
   documentId: {
     type: String,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -674,3 +674,34 @@ interface CollectionsByName {
   EmailTokens: EmailTokensCollection
 }
 
+interface ObjectsByCollectionName {
+  Users: DbUser
+  DatabaseMetadata: DbDatabaseMetadata
+  Votes: DbVote
+  Notifications: DbNotification
+  Conversations: DbConversation
+  Messages: DbMessage
+  RSSFeeds: DbRSSFeed
+  Reports: DbReport
+  LWEvents: DbLWEvent
+  Migrations: DbMigration
+  DebouncerEvents: DbDebouncerEvents
+  ReadStatuses: DbReadStatus
+  Bans: DbBan
+  Sequences: DbSequence
+  PostRelations: DbPostRelation
+  TagRels: DbTagRel
+  Comments: DbComment
+  Tags: DbTag
+  Posts: DbPost
+  Chapters: DbChapter
+  Books: DbBook
+  Collections: DbCollection
+  ReviewVotes: DbReviewVote
+  Localgroups: DbLocalgroup
+  Subscriptions: DbSubscription
+  Revisions: DbRevision
+  LegacyData: DbLegacyData
+  EmailTokens: DbEmailTokens
+}
+

--- a/packages/lesswrong/lib/types/collectionTypes.d.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.d.ts
@@ -28,6 +28,7 @@ interface CollectionBase<T extends DbObject> {
   remove: any
   insert: any
   aggregate: any
+  _ensureIndex: any
 }
 
 interface FindResult<T> {

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -21,10 +21,17 @@ interface CollectionFieldSpecification<T extends DbObject> {
   blackbox?: boolean,
   denormalized?: boolean,
   foreignKey?: any,
+  
   min?: number,
   max?: number,
+  regEx?: any,
+  minCount?: number,
+  options?: any,
+  allowedValues?: any,
+  query?: any,
   
   form?: any,
+  input?: any,
   beforeComponent?: string,
   order?: number,
   label?: string,
@@ -35,6 +42,7 @@ interface CollectionFieldSpecification<T extends DbObject> {
   group?: any,
   
   onInsert?: any,
+  onCreate?: any,
   onEdit?: any,
   onUpdate?: any,
   
@@ -46,6 +54,8 @@ interface CollectionFieldSpecification<T extends DbObject> {
   canUpdate?: any,
   canCreate?: any,
 }
+
+export type SchemaType<T extends DbObject> = Record<string,CollectionFieldSpecification<T>>
 
 const generateIdResolverSingle = ({collectionName, fieldName}) => {
   return async (doc, args, context: ResolverContext) => {

--- a/packages/lesswrong/server/codegen/generateDbTypes.ts
+++ b/packages/lesswrong/server/codegen/generateDbTypes.ts
@@ -73,6 +73,12 @@ function generateNameMapTypes(): string {
     sb.push(`  ${collectionName}: ${collectionName}Collection\n`);
   }
   sb.push('}\n\n');
+  sb.push('interface ObjectsByCollectionName {\n');
+  for (let collection of Collections) {
+    const {collectionName, typeName} = collection;
+    sb.push(`  ${collectionName}: Db${typeName}\n`);
+  }
+  sb.push('}\n\n');
   return sb.join('');
 }
 


### PR DESCRIPTION
Type-annotates functions in `schemaUtils` and `collectionUtils`, and fills in a bunch of missing types in the schema files themselves. The collection schemas are now mostly free of `noImplicitAny` warnings.