### PR TITLE
more tags on post page, plus styling

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -6,7 +6,6 @@ import { useHover } from '../common/withHover';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Tags } from '../../lib/collections/tags/collection';
 import { tagStyle } from './FooterTag';
-import { tagCardStyle } from './TagPreview'
 import Input from '@material-ui/core/Input';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -81,9 +81,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 50,
     "-webkit-appearance": "none",
     "-moz-appearance": "textfield"
-  },
-  tagDescription: {
-    ...tagCardStyle(theme)
   }
 });
 
@@ -97,7 +94,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
   description?: React.ReactNode
   classes: ClassesType,
 }) => {
-  const { LWTooltip, PopperCard, TagPreviewDescription } = Components
+  const { LWTooltip, PopperCard, TagPreview } = Components
   const { hover, anchorEl, eventHandlers } = useHover({ tagId, label, mode });
 
   const { document: tag } = useSingle({
@@ -187,9 +184,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
             {description}
           </div>}
         </div>
-        <div className={classes.tagDescription}>
-          <TagPreviewDescription tag={tag}/>
-        </div>
+        <TagPreview tag={tag} showCount={false} postCount={3}/>
       </PopperCard>
     </AnalyticsContext>
   </span>

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -6,6 +6,7 @@ import { useHover } from '../common/withHover';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Tags } from '../../lib/collections/tags/collection';
 import { tagStyle } from './FooterTag';
+import { tagCardStyle } from './TagPreview'
 import Input from '@material-ui/core/Input';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
@@ -80,6 +81,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 50,
     "-webkit-appearance": "none",
     "-moz-appearance": "textfield"
+  },
+  tagDescription: {
+    ...tagCardStyle(theme)
   }
 });
 
@@ -93,7 +97,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
   description?: React.ReactNode
   classes: ClassesType,
 }) => {
-  const { LWTooltip, PopperCard, TagPreview } = Components
+  const { LWTooltip, PopperCard, TagPreviewDescription } = Components
   const { hover, anchorEl, eventHandlers } = useHover({ tagId, label, mode });
 
   const { document: tag } = useSingle({
@@ -183,7 +187,9 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
             {description}
           </div>}
         </div>
-        <TagPreview tag={tag} showCount={false}/>
+        <div className={classes.tagDescription}>
+          <TagPreviewDescription tag={tag}/>
+        </div>
       </PopperCard>
     </AnalyticsContext>
   </span>

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -6,16 +6,20 @@ import { TagRels } from '../../lib/collections/tagRels/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
+export const tagCardStyling = theme => ({
+  paddingTop: 8,
+  paddingLeft: 16,
+  paddingRight: 16,
+  paddingBottom: 6,
+  width: 500,
+  [theme.breakpoints.down('xs')]: {
+    width: "100%",
+  }
+})
+
 const styles = (theme: ThemeType): JssStyles => ({
   card: {
-    paddingTop: 8,
-    paddingLeft: 16,
-    paddingRight: 16,
-    paddingBottom: 6,
-    width: 500,
-    [theme.breakpoints.down('xs')]: {
-      width: "100%",
-    }
+    ...tagCardStyling(theme)
   },
   tagDescription: {
     ...commentBodyStyles(theme)
@@ -34,13 +38,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginRight: 4,
   },
   footerCount: {
+    borderTop: "solid 1px rgba(0,0,0,.08)",
+    paddingTop: 6,
     textAlign: "right",
     ...theme.typography.smallFont,
     ...theme.typography.commentStyle,
     color: theme.palette.lwTertiary.main,
     marginTop: 6,
-    marginBottom: 2,
-    marginRight: 6
+    marginBottom: 2
   },
   posts: {
     marginTop: 12,
@@ -50,7 +55,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const TagPreview = ({tag, classes, showCount=true, postCount=3}: {
+const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
   tag: TagPreviewFragment,
   classes: ClassesType,
   showCount?: boolean,

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -6,7 +6,7 @@ import { TagRels } from '../../lib/collections/tagRels/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
-export const tagCardStyling = theme => ({
+export const tagCardStyle = theme => ({
   paddingTop: 8,
   paddingLeft: 16,
   paddingRight: 16,
@@ -19,7 +19,7 @@ export const tagCardStyling = theme => ({
 
 const styles = (theme: ThemeType): JssStyles => ({
   card: {
-    ...tagCardStyling(theme)
+    ...tagCardStyle(theme)
   },
   tagDescription: {
     ...commentBodyStyles(theme)

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -6,20 +6,16 @@ import { TagRels } from '../../lib/collections/tagRels/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
-export const tagCardStyle = theme => ({
-  paddingTop: 8,
-  paddingLeft: 16,
-  paddingRight: 16,
-  paddingBottom: 6,
-  width: 500,
-  [theme.breakpoints.down('xs')]: {
-    width: "100%",
-  }
-})
-
 const styles = (theme: ThemeType): JssStyles => ({
   card: {
-    ...tagCardStyle(theme)
+    paddingTop: 8,
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingBottom: 6,
+    width: 500,
+    [theme.breakpoints.down('xs')]: {
+      width: "100%",
+    }
   },
   tagDescription: {
     ...commentBodyStyles(theme)

--- a/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
+++ b/packages/lesswrong/components/tagging/TagSmallPostLink.tsx
@@ -13,7 +13,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[900],
   },
   karma: {
-    marginLeft: 8,
+    marginLeft: 4,
+    marginRight: 12,
     textAlign: "center",
     width: 20,
     flexShrink: 0,
@@ -74,15 +75,16 @@ const TagSmallPostLink = ({classes, post, hideMeta, wrap, widerSpacing}: {
         <PostsPreviewTooltip post={post}/>
       </LWPopper>
       <div className={classes.post}>
+        {!hideMeta && <MetaInfo className={classes.karma}>
+          <PostsItemKarma post={post} placement="right"/>
+        </MetaInfo>}
         <Link to={Posts.getPageUrl(post)} className={classNames(classes.title, {[classes.wrap]: wrap})}>
           {post.title}
         </Link>
         {!hideMeta && <MetaInfo className={classes.author}>
           <UsersName user={post.user} />
         </MetaInfo>}
-        {!hideMeta && <MetaInfo className={classes.karma}>
-          <PostsItemKarma post={post} placement="right"/>
-        </MetaInfo>}
+
 
       </div>
     </div>


### PR DESCRIPTION
This makes post-lists more involved on the PostPage tags, but removes them from the frontpage filter tags.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3246710/88864453-171b2a80-d1ba-11ea-8010-88b6bfa953d5.png">
