### PR TITLE
Set the recentComments cutoff relative to lastCommentedAt date

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -1039,7 +1039,7 @@ addFieldsDict(Posts, {
     graphqlArguments: 'commentsLimit: Int, maxAgeHours: Int, af: Boolean',
     resolver: async (post, { commentsLimit=5, maxAgeHours=18, af=false }, context: ResolverContext) => {
       const { currentUser, Comments } = context;
-      const timeCutoff = moment().subtract(maxAgeHours, 'hours').toDate();
+      const timeCutoff = moment(post.lastCommentedAt).subtract(maxAgeHours, 'hours').toDate();
       const comments = await Comments.find({
         ...Comments.defaultView({}).selector,
         postId: post._id,


### PR DESCRIPTION
This makes it so that you can go arbitrarily back in recent discussion without stuff just kind of not having comments anymore, and also weirdly breaking.