### PR TITLE
Progress Bar update

### DIFF
--- a/packages/lesswrong/components/common/SeparatorBullet.tsx
+++ b/packages/lesswrong/components/common/SeparatorBullet.tsx
@@ -3,8 +3,9 @@ import { registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    marginLeft: 3,
-    marginRight: 3
+    marginLeft: 10,
+    marginRight: 10,
+    color: theme.palette.primary.main
   }
 })
 const SeparatorBullet = ({classes}: {

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -22,6 +22,11 @@ const styles = theme => ({
   tooltip: {
     display: "block"
   },
+  title: {
+    flexGrow: 1,
+    flexBasis: 1,
+    marginRight: "auto"
+  },
   link: {
     color: theme.palette.primary.main
   },
@@ -29,6 +34,7 @@ const styles = theme => ({
     display: "flex",
     justifyContent: "space-between",
     marginBottom: 4,
+    alignItems: "center"
   }
 });
 
@@ -36,7 +42,7 @@ const TagProgressBar = ({classes}: {
   classes: ClassesType,
 }) => {
 
-  const { LWTooltip, PostsItem2MetaInfo } = Components;
+  const { LWTooltip, PostsItem2MetaInfo, SeparatorBullet } = Components;
 
   const { totalCount: taggedTotal } = useMulti({
     terms: {
@@ -67,13 +73,27 @@ const TagProgressBar = ({classes}: {
   return <div className={classes.root}>
       <div className={classes.inner}>
         <div className={classes.text}>
-          <Link to={"/posts/uqXQAWxLFW8WgShtk/open-call-for-taggers"}>
+          <Link className={classes.title} to={"/posts/uqXQAWxLFW8WgShtk/open-call-for-taggers"}>
             Tagging Progress
           </Link>
-          <LWTooltip title={<div><div>List of the most important posts to tag.</div><div><em>(Click any post title to go that post page, and tag the post)</em></div></div>}>
+          <LWTooltip title={<div>
+            <div>View all completely untagged posts, sorted by karma</div>
+            <div><em>(Click through to read posts, and then tag them)</em></div>
+          </div>}>
             <PostsItem2MetaInfo>
               <Link className={classes.link} to={"/allPosts?filter=unNonCoreTagged&timeframe=allTime&sortBy=top"}>
-                Tag Priority Posts
+                Tag Posts
+              </Link>
+            </PostsItem2MetaInfo>
+          </LWTooltip>
+          <SeparatorBullet/>
+          <LWTooltip title={<div>
+            <div>View top posts that have been given generic core-tags, but could use more specific tags</div>
+            <div><em>(Click through to read posts, and then search for tags that will help users find specific, relevant content)</em></div>
+          </div>}>
+            <PostsItem2MetaInfo>
+              <Link className={classes.link} to={"/allPosts?filter=unNonCoreTagged&timeframe=allTime&sortBy=top"}>
+                Improve Post Tags
               </Link>
             </PostsItem2MetaInfo>
           </LWTooltip>
@@ -82,7 +102,7 @@ const TagProgressBar = ({classes}: {
           className={classes.tooltip}
           title={<div>
             <div>{taggedTotal} out of {postsTotal} posts have been tagged</div>
-            <div><em>(Filtered for 25+ karma. Only counting non-core tags (i.e. tags other than "Rationality", "AI", etc)</em></div>
+            <div><em>(Filtered for 25+ karma)</em></div>
           </div>}
         >
           <LinearProgress variant="buffer" value={(taggedTotal/postsTotal)*100} />

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -81,7 +81,7 @@ const TagProgressBar = ({classes}: {
             <div><em>(Click through to read posts, and then tag them)</em></div>
           </div>}>
             <PostsItem2MetaInfo>
-              <Link className={classes.link} to={"/allPosts?filter=unNonCoreTagged&timeframe=allTime&sortBy=top"}>
+              <Link className={classes.link} to={"/allPosts?filter=untagged&timeframe=allTime&sortBy=top"}>
                 Tag Posts
               </Link>
             </PostsItem2MetaInfo>

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1020,20 +1020,8 @@ Posts.addView("reviews2018", terms => {
 Posts.addView("tagProgressTagged", terms => {
   return {
     selector: {  
-      tagRelevance: {$exists: true},
       baseScore: {$gt: 25},
-      $expr: {
-          $gt: [
-              {$size: 
-                  {$filter: {
-                      // ea-forum-look-here
-                      // this was a hack during the Tagging Sprint, where we wanted people to tag posts with non-core-tags
-                      input: {$objectToArray: "$tagRelevance"},
-                      cond: {$not: {$in: ["$$this.k", ["xexCWMyds6QLWognu", "sYm3HiWcfZvrGu3ui", "izp6eeJJEg9v5zcur", "fkABsGCJZ6y9qConW", "Ng8Gice9KNkncxqcj", "MfpEPj6kJneT9gWT6", "3uE2pXvbcnS9nnZRE"]]}}
-                  }}
-              }, 
-              0]
-      } 
+      $or: [{tagRelevance: {$ne: {}}}, {tagRelevance: null}]
     },
   }
 })

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1021,7 +1021,7 @@ Posts.addView("tagProgressTagged", terms => {
   return {
     selector: {  
       baseScore: {$gt: 25},
-      $or: [{tagRelevance: {$ne: {}}}, {tagRelevance: null}]
+      $or: [{tagRelevance: {}}, {tagRelevance: null}]
     },
   }
 })


### PR DESCRIPTION
The progress bar query was slow. But, also, I wasn't even that sure it was good to directly encourage people to tag every single post with an Oddly Specific Tag. So we didn't bother fixing the slowishness, instead just switching to a direct "untagged" query.

I still do want people to think about about adding specific tags, though, so I also had it link to two different /allposts filters. (One of which is the somewhat slower "non-core tags" query, but Oli and I thought it'd be fine to do as long as it wasn't on the frontpage)

<img width="897" alt="image" src="https://user-images.githubusercontent.com/3246710/88969874-4c7d5200-d266-11ea-846a-c0bfec70d632.png">
