### PR TITLE
Allow AdminOnly tags

### DIFF
--- a/packages/lesswrong/components/search/TagsSearchHit.tsx
+++ b/packages/lesswrong/components/search/TagsSearchHit.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import Tags from '../../lib/collections/tags/collection';
 import { Link } from '../../lib/reactRouterWrapper';
+import { useCurrentUser } from '../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -19,13 +20,21 @@ const TagsSearchHit = ({hit, clickAction, classes}: {
   hit: any,
   clickAction?: any,
   classes: ClassesType,
-}) => <div className={classes.root}>
-  <Link to={Tags.getUrl(hit)} onClick={(event) => isLeftClick(event) && clickAction && clickAction()}>
-    <Components.MetaInfo>
-      {hit.name}
-    </Components.MetaInfo>
-  </Link>
-</div>
+}) => {
+
+  const currentUser = useCurrentUser()
+
+  if (hit.adminOnly && !(currentUser && currentUser.isAdmin)) return null
+
+  return <div className={classes.root}>
+    <Link to={Tags.getUrl(hit)} onClick={(event) => isLeftClick(event) && clickAction && clickAction()}>
+      <Components.MetaInfo>
+        {hit.name}
+      </Components.MetaInfo>
+    </Link>
+  </div>
+}
+
 
 const TagsSearchHitComponent = registerComponent("TagsSearchHit", TagsSearchHit, {styles});
 

--- a/packages/lesswrong/components/tagging/TagSearchHit.tsx
+++ b/packages/lesswrong/components/tagging/TagSearchHit.tsx
@@ -5,6 +5,7 @@ import withHover from '../common/withHover';
 import { Tags } from '../../lib/collections/tags/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import classNames from 'classnames';
+import { useCurrentUser } from '../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -54,6 +55,10 @@ const TagSearchHit = ({hit, onClick, hover, anchorEl, classes}: TagSearchHitProp
     fragmentName: "TagFragment",
     fetchPolicy: 'cache-then-network' as any, //TODO
   });
+
+  const currentUser = useCurrentUser()
+
+  if (hit.adminOnly && !(currentUser && currentUser.isAdmin)) return null
   
   return (
     <React.Fragment>

--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -182,7 +182,6 @@ Posts.toAlgolia = async (post: DbPost): Promise<Array<AlgoliaDocument>|null> => 
 
 Tags.toAlgolia = async (tag: DbTag): Promise<Array<AlgoliaDocument>|null> => {
   if (tag.deleted) return null;
-  if (tag.adminOnly) return null;
   
   let description = ""
   if (tag.description?.originalContents?.type) {
@@ -203,6 +202,7 @@ Tags.toAlgolia = async (tag: DbTag): Promise<Array<AlgoliaDocument>|null> => {
     suggestedAsFilter: tag.suggestedAsFilter,
     postCount: tag.postCount,
     description,
+    adminOnly: tag.adminOnly
   }];
 }
 


### PR DESCRIPTION
AdminOnly tags had been hidden from algolia, which meant that there was no easy way to actually apply an admin-only tag to a post.

This makes it so that adminOnly tags are in algolia normally, but are hidden from non-admins on the frontend.