### PR TITLE
Logged out users see TagProgressBar gap

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -48,8 +48,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontStyle: "italic"
   },
   posts: {
-    boxShadow: theme.boxShadow,
-    marginBottom
+    boxShadow: theme.boxShadow
   }
 });
 

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -48,7 +48,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontStyle: "italic"
   },
   posts: {
-    boxShadow: theme.boxShadow
+    boxShadow: theme.boxShadow,
+    marginBottom
   }
 });
 
@@ -146,7 +147,7 @@ const RecommendationsAndCurated = ({
         </div>}
 
       {/* Disabled during 2018 Review [and coronavirus season] */}
-      <div className={currentUser ? classes.subsection : null}>
+      <div className={classes.subsection}>
         <div className={classes.posts}>
           {!settings.hideFrontpage &&
             <AnalyticsContext listContext={"frontpageFromTheArchives"} capturePostItemOnMount>


### PR DESCRIPTION
Apparently I put in a gap conditional on whether users were logged in. I'm... not 100% sure what it was originally doing. I think it might have been there to help make the various configurable bookmarks / continue-reading / etc look reliably good? But, I feel like it's probably better to just always have a gap.

We can remove it if it turns out to look weird after we remove the ProgressBar