### PR TITLE
Tag Post Search hover

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
@@ -14,10 +14,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const PostsPreviewTooltipSingle = ({ classes, postId, truncateLimit=600, }: {
+const PostsPreviewTooltipSingle = ({ classes, postId, truncateLimit=600, postsList=false }: {
   classes: ClassesType,
   postId: string,
   truncateLimit?: number,
+  postsList?: boolean
 }) => {
   const { Loading, PostsPreviewTooltip  } = Components
 
@@ -32,7 +33,7 @@ const PostsPreviewTooltipSingle = ({ classes, postId, truncateLimit=600, }: {
       <Loading/>
     </div>
   
-  return <PostsPreviewTooltip post={post} />
+  return <PostsPreviewTooltip post={post} postsList={postsList}/>
 }
 
 const PostsPreviewTooltipSingleComponent = registerComponent('PostsPreviewTooltipSingle', PostsPreviewTooltipSingle, {styles});

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
@@ -26,7 +26,7 @@ const PostsListEditorSearchHit = ({hit, classes}) => {
     pageElementContext: "postListEditorSearchHit",
   });
   const { LWPopper, PostsPreviewTooltipSingle, PostsTitle, MetaInfo, FormatDate} = Components
-  console.log(hit)
+
   return (
     <div className={classes.root} {...eventHandlers}>
       <LWPopper

--- a/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsListEditorSearchHit.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Components, registerComponent} from '../../lib/vulcan-lib';
 import { Posts } from '../../lib/collections/posts';
 import { Link } from '../../lib/reactRouterWrapper';
+import { useHover } from '../common/withHover';
 
 import grey from '@material-ui/core/colors/grey';
 
@@ -21,20 +22,37 @@ const styles = (theme: ThemeType): JssStyles => ({
   })
 
 const PostsListEditorSearchHit = ({hit, classes}) => {
+  const { eventHandlers, hover, anchorEl } = useHover({
+    pageElementContext: "postListEditorSearchHit",
+  });
+  const { LWPopper, PostsPreviewTooltipSingle, PostsTitle, MetaInfo, FormatDate} = Components
+  console.log(hit)
   return (
-    <div className={classes.root}>
+    <div className={classes.root} {...eventHandlers}>
+      <LWPopper
+        open={hover}
+        anchorEl={anchorEl}
+        placement="left"
+        modifiers={{
+          flip: {
+            enabled: false,
+          }
+        }}
+      >
+        <PostsPreviewTooltipSingle postId={hit._id} postsList/>
+      </LWPopper>
       <div>
-        <Components.PostsTitle post={hit} isLink={false}/>
+        <PostsTitle post={hit} isLink={false}/>
       </div>
-      {hit.authorDisplayName && <Components.MetaInfo>
+      {hit.authorDisplayName && <MetaInfo>
         {hit.authorDisplayName}
-      </Components.MetaInfo>}
-      <Components.MetaInfo>
+      </MetaInfo>}
+      <MetaInfo>
         {hit.baseScore} points
-      </Components.MetaInfo>
-      {hit.postedAt && <Components.MetaInfo>
-        <Components.FormatDate date={hit.postedAt}/>
-      </Components.MetaInfo>}
+      </MetaInfo>
+      {hit.postedAt && <MetaInfo>
+        <FormatDate date={hit.postedAt}/>
+      </MetaInfo>}
       <Link to={Posts.getLink(hit)} target={Posts.getLinkTarget(hit)} className={classes.postLink}>
         (Link)
       </Link>


### PR DESCRIPTION
This makes it so the AddPostsToTag search function includes hoverovers for the posts, which display the existing tags. 

(notes for followup work: we have a lot of duplicate search-item components which I'm not sure are pulling their weight)