### PR TITLE
fix /concepts route

### DIFF
--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -233,6 +233,11 @@ addRoute(
     title: "All Tags",
   },
   {
+    name: "Concepts",
+    path:'/concepts',
+    redirect: () => `/tags/all`,
+  },
+  {
     name: 'tagVoting',
     path: '/tagVoting',
     componentName: 'TagVoteActivity',
@@ -582,11 +587,6 @@ switch (forumTypeSetting.get()) {
         name: 'eaSequencesHome',
         path: '/sequences',
         componentName: 'EASequencesHome'
-      },
-      {
-        name: "Concepts",
-        path:'/concepts',
-        redirect: () => `/tags/all`,
       },
       {
         name: "TagsAll",


### PR DESCRIPTION
Previously I had accidentally put this in the section of the routes under "EAForum", so it didn't work for us. It is not in what I'm _pretty sure_ is the general routes section. And it seems to work correctly.