### PR TITLE
Fix a prop-types warning on the tag portal

### DIFF
--- a/packages/lesswrong/components/common/HashLink.tsx
+++ b/packages/lesswrong/components/common/HashLink.tsx
@@ -93,7 +93,7 @@ export function NavHashLink(props) {
 
 const propTypes = {
   onClick: PropTypes.func,
-  children: PropTypes.node,
+  children: PropTypes.any,
   scroll: PropTypes.func,
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };


### PR DESCRIPTION
HashLink was annotated using React prop-types as having `children: PropTypes.node`, but sometimes its children would be an array of several nodes instead. This worked fine, but produced an error in the browser console in debug mode.