### PR TITLE
Fix Various Type Errors

### DIFF
--- a/packages/lesswrong/components/revisions/RevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/RevisionSelect.tsx
@@ -38,15 +38,14 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const RevisionSelect = ({ documentId, revisions, getRevisionUrl, onPairSelected, loadMoreProps, classes }: {
-  documentId: string,
+const RevisionSelect = ({ revisions, getRevisionUrl, onPairSelected, loadMoreProps, classes }: {
   revisions: Array<RevisionMetadataWithChangeMetrics>,
   getRevisionUrl: (rev: RevisionMetadata) => React.ReactNode,
   onPairSelected: ({before, after}: {before: RevisionMetadata, after: RevisionMetadata}) => void,
   loadMoreProps: any,
   classes: ClassesType,
 }) => {
-  const { FormatDate, UsersName, LoadMore, TagRevisionItem } = Components;
+  const { FormatDate, UsersName, LoadMore } = Components;
   
   const [beforeRevisionIndex, setBeforeRevisionIndex] = useState(1);
   const [afterRevisionIndex, setAfterRevisionIndex] = useState(0);
@@ -107,18 +106,6 @@ const RevisionSelect = ({ documentId, revisions, getRevisionUrl, onPairSelected,
     })}
     <div><LoadMore {...loadMoreProps}/></div>
     <Button className={classes.button} variant="outlined" onClick={compareRevs} >Compare selected revisions</Button>
-
-    {revisions.map((rev, i)=> {
-      if (i < (revisions.length-1)) {
-        return <TagRevisionItem 
-          key={rev.version} 
-          documentId={documentId} 
-          revision={rev} 
-          previousRevision={revisions[i+1]}
-          getRevisionUrl={getRevisionUrl}
-        />
-      } 
-    })}
   </React.Fragment>
 }
 

--- a/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/TagPageRevisionSelect.tsx
@@ -15,7 +15,7 @@ const TagPageRevisionSelect = ({ classes }: {
   const { params } = useLocation();
   const { slug } = params;
   const { history } = useNavigation();
-  const { SingleColumnSection, Loading, RevisionSelect } = Components;
+  const { SingleColumnSection, Loading, RevisionSelect, TagRevisionItem } = Components;
   
   const { tag, loading: loadingTag } = useTagBySlug(slug, "TagBasicInfo");
   const { results: revisions, loading: loadingRevisions, loadMoreProps } = useMulti({
@@ -30,6 +30,10 @@ const TagPageRevisionSelect = ({ classes }: {
     fragmentName: "RevisionMetadataWithChangeMetrics",
     ssr: true,
   });
+
+  const getRevisionUrl = (rev: RevisionMetadata) => {
+    if (tag) return `${Tags.getUrl(tag)}?revision=${rev.version}`
+  }
   
   const compareRevs = useCallback(({before,after}: {before: RevisionMetadata, after:RevisionMetadata}) => {
     if (!tag) return;
@@ -42,13 +46,25 @@ const TagPageRevisionSelect = ({ classes }: {
     <h1><Link to={Tags.getUrl(tag)}>{tag.name}</Link></h1>
     
     {(loadingTag || loadingRevisions) && <Loading/>}
-    {revisions && <RevisionSelect
-      documentId={tag._id}
-      revisions={revisions}
-      getRevisionUrl={(rev: RevisionMetadata) => `${Tags.getUrl(tag)}?revision=${rev.version}`}
-      onPairSelected={compareRevs}
-      loadMoreProps={loadMoreProps}
-  />}
+    {revisions && <div>
+      <RevisionSelect
+        revisions={revisions}
+        getRevisionUrl={getRevisionUrl}
+        onPairSelected={compareRevs}
+        loadMoreProps={loadMoreProps}
+      />
+      {revisions.map((rev, i)=> {
+        if (i < (revisions.length-1)) {
+          return <TagRevisionItem 
+            key={rev.version} 
+            documentId={tag._id} 
+            revision={rev} 
+            previousRevision={revisions[i+1]}
+            getRevisionUrl={getRevisionUrl}
+          />
+        } 
+      })}
+    </div>}
   </SingleColumnSection>
 }
 

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -103,13 +103,6 @@ registerFragment(`
       _id
       name
     }
-    bestAnswer {
-      ...CommentsList
-    }
-
-    lastPromotedComment {
-      ...CommentsList
-    }
   }
 `);
 
@@ -146,26 +139,39 @@ registerFragment(`
 `);
 
 registerFragment(`
-  fragment PostsList on Post {
+  fragment PostsListBase on Post {
     ...PostsBase
     ...PostsAuthors
-    contents {
-      htmlHighlight
-      wordCount
-      version
-    }
     moderationGuidelines {
       html
     }
     customHighlight {
       html
     }
-
+    lastPromotedComment {
+      ...CommentsList
+    }
+    bestAnswer {
+      ...CommentsList
+    }
     tags {
       ...TagPreviewFragment
     }
   }
 `);
+
+registerFragment(`
+  fragment PostsList on Post {
+    ...PostsListBase
+    contents {
+      htmlHighlight
+      wordCount
+      version
+    }
+  }
+`);
+
+
 
 registerFragment(`
   fragment PostsListTag on Post {
@@ -178,8 +184,7 @@ registerFragment(`
 
 registerFragment(`
   fragment PostsDetails on Post {
-    ...PostsBase
-    ...PostsAuthors
+    ...PostsListBase
 
     # Sort settings
     commentSortOrder
@@ -279,9 +284,6 @@ registerFragment(`
     ...PostsRevision
     ...PostSequenceNavigation
     
-    tags {
-      ...TagPreviewFragment
-    }
     tableOfContentsRevision(version: $version)
   }
 `)
@@ -332,9 +334,6 @@ registerFragment(`
     version
     contents {
       ...RevisionDisplay
-    }
-    tags {
-      ...TagPreviewFragment
     }
   }
 `)

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -106,6 +106,10 @@ registerFragment(`
     bestAnswer {
       ...CommentsList
     }
+
+    lastPromotedComment {
+      ...CommentsList
+    }
   }
 `);
 
@@ -159,9 +163,6 @@ registerFragment(`
 
     tags {
       ...TagPreviewFragment
-    }
-    lastPromotedComment {
-      ...CommentsList
     }
   }
 `);

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -110,8 +110,6 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly nominationCount2018: number,
   readonly reviewCount2018: number,
   readonly group: PostsBase_group,
-  readonly bestAnswer: CommentsList,
-  readonly lastPromotedComment: CommentsList,
 }
 
 interface PostsBase_group { // fragment on Localgroups
@@ -138,11 +136,24 @@ interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
   readonly moderatorAssistance: boolean,
 }
 
-interface PostsList extends PostsBase, PostsAuthors { // fragment on Posts
-  readonly contents: PostsList_contents,
-  readonly moderationGuidelines: PostsList_moderationGuidelines,
-  readonly customHighlight: PostsList_customHighlight,
+interface PostsListBase extends PostsBase, PostsAuthors { // fragment on Posts
+  readonly moderationGuidelines: PostsListBase_moderationGuidelines,
+  readonly customHighlight: PostsListBase_customHighlight,
+  readonly lastPromotedComment: CommentsList,
+  readonly bestAnswer: CommentsList,
   readonly tags: Array<TagPreviewFragment>,
+}
+
+interface PostsListBase_moderationGuidelines { // fragment on Revisions
+  readonly html: string,
+}
+
+interface PostsListBase_customHighlight { // fragment on Revisions
+  readonly html: string,
+}
+
+interface PostsList extends PostsListBase { // fragment on Posts
+  readonly contents: PostsList_contents,
 }
 
 interface PostsList_contents { // fragment on Revisions
@@ -151,19 +162,11 @@ interface PostsList_contents { // fragment on Revisions
   readonly version: string,
 }
 
-interface PostsList_moderationGuidelines { // fragment on Revisions
-  readonly html: string,
-}
-
-interface PostsList_customHighlight { // fragment on Revisions
-  readonly html: string,
-}
-
 interface PostsListTag extends PostsList { // fragment on Posts
   readonly tagRel: WithVoteTagRel,
 }
 
-interface PostsDetails extends PostsBase, PostsAuthors { // fragment on Posts
+interface PostsDetails extends PostsListBase { // fragment on Posts
   readonly commentSortOrder: string,
   readonly collectionTitle: string,
   readonly canonicalPrevPostSlug: string,
@@ -232,7 +235,6 @@ interface PostsRevisionEdit extends PostsDetails { // fragment on Posts
 }
 
 interface PostsWithNavigationAndRevision extends PostsRevision, PostSequenceNavigation { // fragment on Posts
-  readonly tags: Array<TagPreviewFragment>,
   readonly tableOfContentsRevision: any,
 }
 
@@ -280,7 +282,6 @@ interface PostSequenceNavigation_nextPost_sequence { // fragment on Sequences
 interface PostsPage extends PostsDetails { // fragment on Posts
   readonly version: string,
   readonly contents: RevisionDisplay,
-  readonly tags: Array<TagPreviewFragment>,
 }
 
 interface PostsEdit extends PostsPage { // fragment on Posts
@@ -1598,6 +1599,7 @@ interface FragmentTypes {
   PostTagRelevance: PostTagRelevance
   PostsWithVotes: PostsWithVotes
   PostsAuthors: PostsAuthors
+  PostsListBase: PostsListBase
   PostsList: PostsList
   PostsListTag: PostsListTag
   PostsDetails: PostsDetails

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -111,6 +111,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly reviewCount2018: number,
   readonly group: PostsBase_group,
   readonly bestAnswer: CommentsList,
+  readonly lastPromotedComment: CommentsList,
 }
 
 interface PostsBase_group { // fragment on Localgroups
@@ -142,7 +143,6 @@ interface PostsList extends PostsBase, PostsAuthors { // fragment on Posts
   readonly moderationGuidelines: PostsList_moderationGuidelines,
   readonly customHighlight: PostsList_customHighlight,
   readonly tags: Array<TagPreviewFragment>,
-  readonly lastPromotedComment: CommentsList,
 }
 
 interface PostsList_contents { // fragment on Revisions


### PR DESCRIPTION
Previously, I had moved lastPromotedComment from PostsBase to PostsList at Jim's suggestion, and then didn't check for type errors before merging. This turned out to cause a bunch of type errors.

edited to add:

The problem is that PostsList had been implicitly being treated as a subfragment of other larger fragments like PostsDetails, but that wasn't being enforced. After talking it over, habryka and I decided to split out a new subfragment called PostsListBase, which is also used by PostsDetails.

Meanwhile, there were some other random type errors relating to the TagRevisionItem, which I addressed with some refactoring.