### PR TITLE
All users can edit tags on Triple-Dot-Menu

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -12,11 +12,11 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import Tooltip from '@material-ui/core/Tooltip';
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import EditIcon from '@material-ui/icons/Edit'
+import LocalOfferIcon from '@material-ui/icons/LocalOffer'
 import WarningIcon from '@material-ui/icons/Warning'
 import qs from 'qs'
 import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema'
 import { withDialog } from '../../common/withDialog';
-import { tagStyle } from '../../tagging/FooterTag';
 import { forumTypeSetting } from '../../../lib/instanceSettings';
 
 const metaName = forumTypeSetting.get() === 'EAForum' ? 'Community' : 'Meta'
@@ -41,9 +41,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   promoteWarning: {
     fontSize: 20,
     marginLeft: 4,
-  },
-  editTags: {
-    ...tagStyle(theme)
   }
 })
 
@@ -218,7 +215,10 @@ class PostActions extends Component<PostActionsProps,{}> {
         <ReportPostMenuItem post={post}/>
         <div onClick={this.handleOpenTagDialog}>
           <MenuItem>
-            <div className={classes.editTags}>Edit Tags</div>
+            <ListItemIcon>
+              <LocalOfferIcon />
+            </ListItemIcon>
+            Edit Tags
           </MenuItem>
         </div>
         { isRead

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -12,7 +12,7 @@ import { Link } from '../../../lib/reactRouterWrapper';
 import Tooltip from '@material-ui/core/Tooltip';
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import EditIcon from '@material-ui/icons/Edit'
-import LocalOfferIcon from '@material-ui/icons/LocalOffer'
+import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined'
 import WarningIcon from '@material-ui/icons/Warning'
 import qs from 'qs'
 import { subscriptionTypes } from '../../../lib/collections/subscriptions/schema'
@@ -216,7 +216,7 @@ class PostActions extends Component<PostActionsProps,{}> {
         <div onClick={this.handleOpenTagDialog}>
           <MenuItem>
             <ListItemIcon>
-              <LocalOfferIcon />
+              <LocalOfferOutlinedIcon />
             </ListItemIcon>
             Edit Tags
           </MenuItem>

--- a/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostActions.tsx
@@ -216,13 +216,11 @@ class PostActions extends Component<PostActionsProps,{}> {
         <BookmarkButton post={post} menuItem/>
 
         <ReportPostMenuItem post={post}/>
-        { Users.canDo(currentUser, "posts.edit.all") &&
-          <div onClick={this.handleOpenTagDialog}>
-            <MenuItem>
-              <div className={classes.editTags}>Edit Tags</div>
-            </MenuItem>
-          </div>
-        }
+        <div onClick={this.handleOpenTagDialog}>
+          <MenuItem>
+            <div className={classes.editTags}>Edit Tags</div>
+          </MenuItem>
+        </div>
         { isRead
           ? <div onClick={this.handleMarkAsUnread}>
               <MenuItem>


### PR DESCRIPTION
(This is the simplest version of this PR. I briefly looked into improving the Edit Tags option on the triple-dot-menu, but it was fairly annoying, and it seemed better to at least ship this incremental improvement)

It does include a styling switch to make it more harmonious with other menu items. (I prefer the old tag-styling myself, but others kept saying they disliked that)

<img width="438" alt="image" src="https://user-images.githubusercontent.com/3246710/89477743-e64f6e00-d742-11ea-9ba2-42ab3627b4c5.png">
