### PR TITLE
Fix crash in tag hover-over when a tagged draft post is in the top 6

### DIFF
--- a/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
+++ b/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
@@ -31,7 +31,7 @@ export const TagRelNotificationItem = ({classes, tagRelId}: {
 
   return <div className={classes.root}>
     <div className={classes.meta}>New post tagged <em>{tagRel.tag.name}</em>:</div>
-    <div className={classes.title}>{tagRel.post.title}</div>
+    <div className={classes.title}>{tagRel.post?.title}</div>
   </div>;
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewTagsItem.tsx
@@ -96,7 +96,7 @@ const SunshineNewTagsItem = ({tag, classes}: {
             {tag.postCount} posts
           </div>
           {results && results.map(tagRel=><div key={tagRel._id} className={classes.post}>
-            <TagSmallPostLink post={tagRel.post}/>
+            {tagRel.post && <TagSmallPostLink post={tagRel.post}/>}
           </div>)}
           {!results && loading && <Loading/>}
         </SidebarHoverOver>

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -75,7 +75,7 @@ const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
   return (<div className={classes.card}>
     <TagPreviewDescription tag={tag}/>
     {results ? <div className={classes.posts}>
-      {results.map((result,i) => <TagSmallPostLink key={result.post._id} post={result.post} widerSpacing={postCount > 3} />)}
+      {results.map((result,i) => result.post && <TagSmallPostLink key={result.post._id} post={result.post} widerSpacing={postCount > 3} />)}
     </div> : <Loading /> }
     {showCount && <div className={classes.footerCount}>
       <Link to={Tags.getUrl(tag)}>View all {tag.postCount} posts</Link>

--- a/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
+++ b/packages/lesswrong/components/tagging/TagsDetailsItem.tsx
@@ -91,7 +91,7 @@ const TagsDetailsItem = ({tag, classes }: {
         </Link>
         {!tagRels && loading && <Loading/>}
         {tagRels && tagRels.map(tagRel=>
-          <TagSmallPostLink key={tagRel._id} post={tagRel.post} hideMeta wrap/>
+          {tagRel.post && <TagSmallPostLink key={tagRel._id} post={tagRel.post} hideMeta wrap/>}
         )}
       </div>
     </div>


### PR DESCRIPTION
Fixes a crash when tag hover-overs (and some other places) would show a tagged post in the top 6, but the post is a draft and you don't have access. This showed up in Sentry, and I think we had a mention of it in #bugs-channel; it completely broke a couple tags, except that admins are unaffected.

I used nullability typechecking from a different PR to mark tagRel.post as though it were nullable, fixed all the resulting type errors, and made this separate PR based on that.