### PR TITLE
Change tagging url in Progress Bar

### DIFF
--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -127,7 +127,7 @@ const TagProgressBar = ({classes}: {
             Tagging Progress
           </Link>
           <LWTooltip title={<div>
-            <div>View all completely untagged posts, sorted by karma</div>
+            <div>View all completely untagged posts, sorted by oldest</div>
             <div><em>(Click through to read posts, and then tag them)</em></div>
           </div>}>
             <PostsItem2MetaInfo>

--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -131,7 +131,7 @@ const TagProgressBar = ({classes}: {
             <div><em>(Click through to read posts, and then tag them)</em></div>
           </div>}>
             <PostsItem2MetaInfo>
-              <Link className={classes.link} to={"/allPosts?filter=untagged&timeframe=allTime&sortedBy=top"}>
+              <Link className={classes.link} to={"/allPosts?filter=untagged&timeframe=allTime&sortedBy=old&karmaThreshold=25"}>
                 Tag Posts
               </Link>
             </PostsItem2MetaInfo>


### PR DESCRIPTION
Now that we're approaching 50 karma (the threshold at which I'd originally wanted the progress bar to filter for, I think it's mildly better to change the sorting of the default search page to "sortedBy=old", with a karmathreshold of 25. 

This way people's attention is directed back to old posts, which are the ones I'm most excited about getting tagged, and also, it means there won't be this progressively lower-karma set of posts that get increasingly unexciting over time.

(not that confident this is better, but it seemed maybe good for at least switching up the tagging experience)