### PR TITLE
Fix a visual artifact where the top pixel of sequences grid titles is truncated

### DIFF
--- a/packages/lesswrong/components/sequences/SequencesGridItem.tsx
+++ b/packages/lesswrong/components/sequences/SequencesGridItem.tsx
@@ -1,7 +1,6 @@
 import { Components, registerComponent, } from '../../lib/vulcan-lib';
 import NoSSR from 'react-no-ssr';
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import classNames from 'classnames';
 
@@ -33,6 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: 16,
     lineHeight: 1.0,
     maxHeight: 32,
+    paddingTop: 2,
     display: "-webkit-box",
     "-webkit-line-clamp": 2,
     "-webkit-box-orient": "vertical",
@@ -57,7 +57,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
   meta: {
     paddingLeft: 12,
-    paddingTop: 12,
+    paddingTop: 10,
     paddingRight: 8,
     paddingBottom: 5,
     flexGrow: 1,
@@ -123,10 +123,10 @@ const SequencesGridItem = ({ sequence, showAuthor=false, classes, bookItemStyle 
       </NoSSR>
     </div>
     <div className={classNames(classes.meta, {[classes.hiddenAuthor]:!showAuthor, [classes.bookItemContentStyle]: bookItemStyle})}>
-      <Typography variant='title' className={classes.title}>
+      <div className={classes.title}>
         {sequence.draft && <span className={classes.draft}>[Draft] </span>}
         {sequence.title}
-      </Typography>
+      </div>
       { showAuthor &&
         <div className={classes.author}>
           by <Components.UsersName user={sequence.user} />


### PR DESCRIPTION
Specific to zoomed out views (eg 80% zoom) and low DPI, but reproduces in both Firefox and Chrome.

Left: before. Right: after.

![TextTruncationBugBeforeAfter](https://user-images.githubusercontent.com/101191/89493683-8d470080-d769-11ea-8b14-01b75f34f6f3.png)

