### PR TITLE
Actually fix the vote cancel crash

### DIFF
--- a/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
+++ b/packages/lesswrong/server/callbacks/alignment-forum/callbacks.ts
@@ -84,7 +84,6 @@ addCallback("votes.smallUpvote.async", updateAlignmentUserServerCallback);
 
 async function cancelAlignmentUserKarmaServer ({newDocument, vote}) {
   await updateAlignmentUserServer(newDocument, vote, -1)
-
 }
 
 addCallback("votes.cancel.async", cancelAlignmentUserKarmaServer);
@@ -111,7 +110,7 @@ function cancelAlignmentKarmaServerCallback ({newDocument, vote}) {
   void updateAlignmentKarmaServer(newDocument, vote)
 }
 
-addCallback("votes.cancel.sync", cancelAlignmentKarmaServerCallback);
+addCallback("votes.cancel.async", cancelAlignmentKarmaServerCallback);
 
 function cancelAlignmentKarmaClientCallback (document, collection, voter, voteType) {
   const votePower = getVotePower(voter.afKarma, voteType)

--- a/packages/lesswrong/server/tagging/tagCallbacks.ts
+++ b/packages/lesswrong/server/tagging/tagCallbacks.ts
@@ -95,7 +95,7 @@ async function voteUpdatePostDenormalizedTags({newDocument: tagRel, vote}: {
   void updatePostDenormalizedTags(tagRel.postId);
 }
 
-addCallback("votes.cancel.sync", voteUpdatePostDenormalizedTags);
+addCallback("votes.cancel.async", voteUpdatePostDenormalizedTags);
 addCallback("votes.smallUpvote.async", voteUpdatePostDenormalizedTags);
 addCallback("votes.bigUpvote.async", voteUpdatePostDenormalizedTags);
 addCallback("votes.smallDownvote.async", voteUpdatePostDenormalizedTags);


### PR DESCRIPTION
I think Jim tried to fix a vote-cancelling crash error in https://github.com/LessWrong2/Lesswrong2/pull/3382, but I don't actually think it did anything. 

In general the API for sync callbacks seems pretty clear, in that it definitely requires documents to return an updated document. I think Jim had seen some special around `undefined` but that didn't actually change the core API very much. 

This PR sidesteps the problem by just moving these async callbacks that are just firing off some async operations to the async handlers, where they belong as far as I can tell. Though jim should definitely review this. 
