### PR TITLE
Tag Preview posts match TagPage posts

### DIFF
--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -92,12 +92,15 @@ export const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-export const tagPostTerms = (tag: TagBasicInfo, query: any) => ({
-  ...query,
-  filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
-  view: "tagRelevance",
-  tagId: tag._id,
-})
+export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
+  if (!tag) return
+  return ({
+    ...query,
+    filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
+    view: "tagRelevance",
+    tagId: tag._id,
+  })
+}
 
 const TagPage = ({classes}: {
   classes: ClassesType

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -92,6 +92,13 @@ export const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
+export const tagPostTerms = (tag: TagBasicInfo, query: any) => ({
+  ...query,
+  filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
+  view: "tagRelevance",
+  tagId: tag._id,
+})
+
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
@@ -117,11 +124,8 @@ const TagPage = ({classes}: {
   }
 
   const terms = {
-    ...query,
-    filterSettings: {tags:[{tagId: tag._id, tagName: tag.name, filterMode: "Required"}]},
-    view: "tagRelevance",
-    limit: 15,
-    tagId: tag._id,
+    ...tagPostTerms(tag, query),
+    limit: 15
   }
 
   const clickReadMore = () => {

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Tags } from '../../lib/collections/tags/collection';
-import { TagRels } from '../../lib/collections/tagRels/collection';
+import { Posts } from '../../lib/collections/posts/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 
@@ -61,11 +61,12 @@ const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
   const { results } = useMulti({
     skip: !(tag?._id),
     terms: {
-      view: "postsWithTag",
+      filterSettings: {tags:[{tagId: tag?._id, tagName: tag?.name, filterMode: "Required"}]},
+      view: "tagRelevance",
       tagId: tag?._id,
     },
-    collection: TagRels,
-    fragmentName: "TagRelFragment",
+    collection: Posts,
+    fragmentName: "PostsList",
     limit: postCount,
     ssr: true,
   });
@@ -75,7 +76,7 @@ const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
   return (<div className={classes.card}>
     <TagPreviewDescription tag={tag}/>
     {results ? <div className={classes.posts}>
-      {results.map((result,i) => result.post && <TagSmallPostLink key={result.post._id} post={result.post} widerSpacing={postCount > 3} />)}
+      {results.map((post,i) => post && <TagSmallPostLink key={post._id} post={post} widerSpacing={postCount > 3} />)}
     </div> : <Loading /> }
     {showCount && <div className={classes.footerCount}>
       <Link to={Tags.getUrl(tag)}>View all {tag.postCount} posts</Link>

--- a/packages/lesswrong/components/tagging/TagPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagPreview.tsx
@@ -5,6 +5,7 @@ import { Tags } from '../../lib/collections/tags/collection';
 import { Posts } from '../../lib/collections/posts/collection';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
+import { tagPostTerms } from './TagPage';
 
 const styles = (theme: ThemeType): JssStyles => ({
   card: {
@@ -60,11 +61,7 @@ const TagPreview = ({tag, classes, showCount=true, postCount=6}: {
   const { TagPreviewDescription, TagSmallPostLink, Loading } = Components;
   const { results } = useMulti({
     skip: !(tag?._id),
-    terms: {
-      filterSettings: {tags:[{tagId: tag?._id, tagName: tag?.name, filterMode: "Required"}]},
-      view: "tagRelevance",
-      tagId: tag?._id,
-    },
+    terms: tagPostTerms(tag, {}),
     collection: Posts,
     fragmentName: "PostsList",
     limit: postCount,


### PR DESCRIPTION
Previously, TagPreview was using TagRels, which doesn't let you sort by post karma. Switches to fetch posts using the same algorithm the TagPage does.