### PR TITLE
PostsItemPreview tag sort order

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -7,6 +7,7 @@ import Card from '@material-ui/core/Card';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import { Link } from '../../lib/reactRouterWrapper';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { sortTags } from '../tagging/FooterTagList';
 
 export const POST_PREVIEW_WIDTH = 400
 
@@ -154,6 +155,8 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
 
   const renderedComment = comment || post.bestAnswer
 
+  const tags = sortTags(post.tags, t=>t)
+
   return <AnalyticsContext pageElementContext="hoverPreview">
       <Card className={classes.root}>
         <div className={classes.header}>
@@ -164,8 +167,8 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
             <div className={classes.tooltipInfo}>
               { postsList && <span> 
                 {getPostCategory(post)}
-                {(post.tags?.length > 0) && " – "}
-                {post.tags?.map((tag, i) => <span key={tag._id}>{tag.name}{(i !== (post.tags?.length - 1)) ? ",  " : ""}</span>)}
+                {(tags?.length > 0) && " – "}
+                {tags?.map((tag, i) => <span key={tag._id}>{tag.name}{(i !== (post.tags?.length - 1)) ? ",  " : ""}</span>)}
                 {renderWordCount && <span>{" "}<span className={classes.wordCount}>({wordCount} words)</span></span>}
               </span>}
               { !postsList && <>

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -42,7 +42,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
+export function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
   return _.sortBy(list, item=>toTag(item).core);
 }
 


### PR DESCRIPTION
This re-orders the tags on a PostsPreviewTooltip to match the ordering in FooterTagList