### PR TITLE
Suggest Tags based on Pingbacks

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostFooter.tsx
@@ -48,7 +48,7 @@ const PostsPagePostFooter = ({post, sequenceId, classes}: {
   return <>
     {!post.shortform && (wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) && <AnalyticsContext pageSectionContext="tagFooter">
       <div className={classes.footerTagList}>
-        <FooterTagList post={post}/>
+        <FooterTagList post={post} suggestedTags={post.suggestedTags}/>
       </div>
     </AnalyticsContext>}
     {!post.shortform && (wordCount > HIDE_POST_BOTTOM_VOTE_WORDCOUNT_LIMIT) &&

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -173,7 +173,7 @@ const PostsPagePostHeader = ({post, classes}: {
     </div>
     
     {!post.shortform && <AnalyticsContext pageSectionContext="tagHeader">
-      <FooterTagList post={post} hideScore />
+      <FooterTagList post={post} hideScore suggestedTags={post.suggestedTags} />
     </AnalyticsContext>}
     {post.isEvent && <PostsPageEventData post={post}/>}
   </>

--- a/packages/lesswrong/components/tagging/AddTag.tsx
+++ b/packages/lesswrong/components/tagging/AddTag.tsx
@@ -55,9 +55,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const AddTag = ({onTagSelected, classes}: {
+const AddTag = ({onTagSelected, classes, suggestedTags=[]}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
   classes: ClassesType,
+  suggestedTags?: Array<TagPreviewFragment>
 }) => {
   const { TagSearchHit, WrappedSmartForm } = Components
   const currentUser = useCurrentUser()
@@ -120,7 +121,15 @@ const AddTag = ({onTagSelected, classes}: {
       {showAllTags && <a onClick={()=>setShowAllTags(!showAllTags)} className={classes.newTag}>
         Show fewer tags
       </a>}
-      <Configure hitsPerPage={showAllTags ? 500 : (searchOpen ? 12 : 6)} />
+      <Configure hitsPerPage={showAllTags ? 500 : (searchOpen ? 12 : suggestedTags.length ? 0 : 6)} />
+      {!searchOpen && suggestedTags.length > 0 && suggestedTags.map(tag => {
+        return <TagSearchHit key={tag._id} hit={tag}
+          onClick={ev => {
+            onTagSelected({tagId: tag._id, tagName: tag.name});
+            ev.stopPropagation();
+          }}
+          />
+      })}
       <Hits hitComponent={({hit}) =>
         <TagSearchHit hit={hit}
             onClick={ev => {

--- a/packages/lesswrong/components/tagging/AddTagButton.tsx
+++ b/packages/lesswrong/components/tagging/AddTagButton.tsx
@@ -18,10 +18,11 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const AddTagButton = ({onTagSelected, classes, children}: {
+const AddTagButton = ({onTagSelected, classes, children, suggestedTags=[]}: {
   onTagSelected: (props: {tagId: string, tagName: string})=>void,
   classes: ClassesType,
-  children?: any
+  children?: any,
+  suggestedTags?: Array<TagPreviewFragment>
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement|null>(null);
@@ -58,6 +59,7 @@ const AddTagButton = ({onTagSelected, classes, children}: {
       >
         <Paper>
           <AddTag
+            suggestedTags={suggestedTags}
             onTagSelected={({tagId, tagName}: {tagId: string, tagName: string}) => {
               setAnchorEl(null);
               setIsOpen(false);

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -46,14 +46,14 @@ function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo): Array<T> {
   return _.sortBy(list, item=>toTag(item).core);
 }
 
-const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFrontpage, smallText=false}: {
+const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFrontpage, smallText=false, suggestedTags=[]}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
   classes: ClassesType,
   hideScore?: boolean,
   hideAddTag?: boolean,
   hidePersonalOrFrontpage?: boolean,
-  smallText?: boolean
-
+  smallText?: boolean,
+  suggestedTags?: Array<TagPreviewFragment>
 }) => {
   const [isAwaiting, setIsAwaiting] = useState(false);
   const currentUser = useCurrentUser();
@@ -128,7 +128,7 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFron
       />
     )}
     { postType }
-    {currentUser && !hideAddTag && <AddTagButton onTagSelected={onTagSelected} />}
+    {currentUser && !hideAddTag && <AddTagButton onTagSelected={onTagSelected} suggestedTags={suggestedTags} />}
     { isAwaiting && <Loading/>}
   </span>
 };

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -244,6 +244,9 @@ registerFragment(`
       }
       order
     }
+    suggestedTags {
+      ...TagPreviewFragment
+    }
   }
 `);
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -188,6 +188,7 @@ interface PostsDetails extends PostsListBase { // fragment on Posts
   readonly feed: RSSFeedMinimumInfo,
   readonly sourcePostRelations: Array<PostsDetails_sourcePostRelations>,
   readonly targetPostRelations: Array<PostsDetails_targetPostRelations>,
+  readonly suggestedTags: TagPreviewFragment,
 }
 
 interface PostsDetails_canonicalSequence { // fragment on Sequences


### PR DESCRIPTION
This adds a resolverOnly field to posts, which currently:

1. Checks for pingbacks for that post
2. Checks for tags on those pingbacks
3. Returns those tags as "suggested tags" for the post.

Those tags are then show up instead of the core tags when you click "Add Tag" for that post. Over time I'd want to fine tune exactly how those posts are selected (potentially using other heuristics).

Issues with the current PR I could use help with:
- I couldn't figure out how to get the getWithLoader working for pingbacks
- I'm currently just passing the tags into TagSearchHit, which... magically works fine, but I'm sorta surprised, and guessing I should be doing something to properly match the types. (I can probably figure this one out more easily on my own, haven't actually tried to yet) 