### PR TITLE
EA Recommendations rework + slight refactor

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -9,8 +9,7 @@ const eaHomeSequenceIdSetting = new PublicInstanceSetting<string | null>('eaHome
 const EAHome = () => {
   const currentUser = useCurrentUser();
   const {
-    RecentDiscussionThreadsList, HomeLatestPosts, ConfigurableRecommendationsList,
-    EAHomeHandbook, RecommendationsAndCurated
+    RecentDiscussionThreadsList, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -10,7 +10,7 @@ const EAHome = () => {
   const currentUser = useCurrentUser();
   const {
     RecentDiscussionThreadsList, HomeLatestPosts, ConfigurableRecommendationsList,
-    EAHomeHandbook
+    EAHomeHandbook, RecommendationsAndCurated
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
@@ -22,7 +22,7 @@ const EAHome = () => {
 
       <HomeLatestPosts />
 
-      <ConfigurableRecommendationsList configName="frontpageEA" />
+      <RecommendationsAndCurated configName="frontpageEA" />
 
       <RecentDiscussionThreadsList
         terms={{view: 'recentDiscussionThreadsList', limit:20}}

--- a/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper'
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const recommendedName = forumTypeSetting.get() === 'EAForum' ? 'Forum Favorites' : 'Recommended'
+const recommendedName = forumTypeSetting.get() === 'EAForum' ? 'Forum Favorites' : 'Archive Recommendations'
 
 interface ExternalProps {
   configName: string,
@@ -77,4 +77,3 @@ declare global {
     ConfigurableRecommendationsList: typeof ConfigurableRecommendationsListComponent
   }
 }
-

--- a/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/ConfigurableRecommendationsList.tsx
@@ -5,7 +5,7 @@ import { Link } from '../../lib/reactRouterWrapper'
 import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
-const recommendedName = forumTypeSetting.get() === 'EAForum' ? 'Forum Favorites' : 'Archive Recommendations'
+export const archiveRecommendationsName = forumTypeSetting.get() === 'EAForum' ? 'Forum Favorites' : 'Archive Recommendations'
 
 interface ExternalProps {
   configName: string,
@@ -47,7 +47,7 @@ class ConfigurableRecommendationsList extends PureComponent<ConfigurableRecommen
           title={`A weighted, randomized sample of the highest karma posts${settings.onlyUnread ? " that you haven't read yet" : ""}.`}
         >
           <Link to={'/recommendations'}>
-            {recommendedName}
+            {archiveRecommendationsName}
           </Link>
         </LWTooltip>}
       >

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -86,7 +86,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
         ...currentUser.recommendationSettings,
         [configName]: newSettings
       };
-    
+
       void updateUser({
         selector: { _id: currentUser._id },
         data: {
@@ -99,7 +99,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
   return <div className={classes.root}>
     <span className={classes.settingGroup}>
       <span className={classes.setting}>
-        {(configName === "frontpage") &&
+        {(['frontpage', 'frontpageEA'].includes(configName)) &&
           <SectionFooterCheckbox
             value={!settings.hideContinueReading}
             onClick={(ev, checked) => applyChange({ ...settings, hideContinueReading: !settings.hideContinueReading })}
@@ -109,7 +109,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
         }
       </span>
       <span className={classes.setting}>
-        {(configName === "frontpage") && 
+        {(['frontpage', 'frontpageEA'].includes(configName)) &&
           <SectionFooterCheckbox
             value={!settings.hideBookmarks}
             onClick={(ev, checked) => applyChange({ ...settings, hideBookmarks: !settings.hideBookmarks })}
@@ -121,14 +121,14 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
     </span>
 
     {/* disabled except during review */}
-    {/* {(configName === "frontpage") && <div> 
+    {/* {(configName === "frontpage") && <div>
       <Checkbox
         checked={!settings.hideReview}
         onChange={(ev, checked) => applyChange({ ...settings, hideReview: !checked })}
       /> Show 'The LessWrong 2018 Review'
     </div>} */}
 
-    {/* <div> 
+    {/* <div>
       <Checkbox
         checked={!settings.hideCoronavirus}
         onChange={(ev, checked) => applyChange({ ...settings, hideCoronavirus: !checked })}
@@ -137,7 +137,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
 
     {/* disabled during 2018 Review [and coronavirus]*/}
     <span className={classes.settingGroup}>
-      {(configName === "frontpage") && 
+      {(configName === "frontpage") &&
         <span className={classes.setting}>
           <SectionFooterCheckbox
             value={!settings.hideFrontpage}
@@ -147,7 +147,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           />
         </span>
       }
-    
+      {/* TODO; Remove 'Archive' from tooltip  */}
       <span className={classes.setting}>
         <SectionFooterCheckbox
           disabled={!currentUser}

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -5,7 +5,7 @@ import Input from '@material-ui/core/Input';
 import Checkbox from '@material-ui/core/Checkbox';
 import deepmerge from 'deepmerge';
 import { useCurrentUser } from '../common/withUser';
-import { slotSpecificRecommendationSettingDefaults, defaultAlgorithmSettings } from '../../lib/collections/users/recommendationSettings';
+import { defaultAlgorithmSettings } from '../../lib/collections/users/recommendationSettings';
 import Users from '../../lib/collections/users/collection';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 
@@ -39,23 +39,15 @@ const recommendationAlgorithms = [
   }
 ];
 
-function getDefaultSettings(configName) {
-  if (configName in slotSpecificRecommendationSettingDefaults) {
-    return deepmerge(defaultAlgorithmSettings, slotSpecificRecommendationSettingDefaults[configName]);
-  } else {
-    return defaultAlgorithmSettings;
-  }
-}
-
 export function getRecommendationSettings({settings, currentUser, configName})
 {
   if (settings)
    return settings;
 
   if (currentUser?.recommendationSettings && configName in currentUser.recommendationSettings) {
-    return deepmerge(getDefaultSettings(configName), currentUser.recommendationSettings[configName]||{});
+    return deepmerge(defaultAlgorithmSettings, currentUser.recommendationSettings[configName]||{});
   } else {
-    return getDefaultSettings(configName);
+    return defaultAlgorithmSettings;
   }
 }
 

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -8,6 +8,7 @@ import { useCurrentUser } from '../common/withUser';
 import { defaultAlgorithmSettings } from '../../lib/collections/users/recommendationSettings';
 import Users from '../../lib/collections/users/collection';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { archiveRecommendationsName } from './ConfigurableRecommendationsList';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -59,13 +60,6 @@ const forumIncludeExtra = {
   EAForum: {humanName: 'Community', machineName: 'includeMeta'},
 }
 const includeExtra = forumIncludeExtra[forumTypeSetting.get()]
-
-const forumArchivesName = {
-  LessWrong: 'Archive Recommendations',
-  AlignmentForum: 'Archive Recommendations',
-  EAForum: 'Forum Favorites',
-}
-const archiveName = forumArchivesName[forumTypeSetting.get()]
 
 const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAdvanced=false, classes }: {
   settings: any,
@@ -149,7 +143,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           value={settings.onlyUnread && !!currentUser}
           onClick={(ev, checked) => applyChange({ ...settings, onlyUnread: !settings.onlyUnread })}
           label={`Unread ${!currentUser ? "(Requires login)" : ""}`}
-          tooltip={`'${archiveName}' will only show unread posts`}
+          tooltip={`'${archiveRecommendationsName}' will only show unread posts`}
         />
       </span>
 
@@ -160,7 +154,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           value={settings[includeExtra.machineName]}
           onClick={(ev, checked) => applyChange({ ...settings, [includeExtra.machineName]: !settings[includeExtra.machineName] })}
           label={includeExtra.humanName}
-          tooltip={`'${archiveName}' will include ${includeExtra.humanName}`}
+          tooltip={`'${archiveRecommendationsName}' will include ${includeExtra.humanName}`}
         />
       </span>
     </span>

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -63,7 +63,7 @@ const includeExtra = forumIncludeExtra[forumTypeSetting.get()]
 const forumArchivesName = {
   LessWrong: 'Archive Recommendations',
   AlignmentForum: 'Archive Recommendations',
-  EAForum: 'Community Favorites',
+  EAForum: 'Forum Favorites',
 }
 const archiveName = forumArchivesName[forumTypeSetting.get()]
 

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -52,8 +52,7 @@ export function getRecommendationSettings({settings, currentUser, configName})
   }
 }
 
-// TODO: Soon to be removed when Community becomes a tag. At that point, we'll
-// move this into forumLanguage
+// TODO: Probably to be removed when Community becomes a tag
 const forumIncludeExtra = {
   LessWrong: {humanName: 'Personal Blogposts', machineName: 'includePersonal'},
   AlignmentForum: {humanName: 'Personal Blogposts', machineName: 'includePersonal'},
@@ -227,4 +226,3 @@ declare global {
     RecommendationsAlgorithmPicker: typeof RecommendationsAlgorithmPickerComponent
   }
 }
-

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -60,31 +60,12 @@ const forumIncludeExtra = {
 }
 const includeExtra = forumIncludeExtra[forumTypeSetting.get()]
 
-interface RecommendationsForumLanguage {
-  archivesShortName: string,
-  archivesTooltip: string,
-  archivesLongName: string
+const forumArchivesName = {
+  LessWrong: 'Archive Recommendations',
+  AlignmentForum: 'Archive Recommendations',
+  EAForum: 'Community Favorites',
 }
-const getForumLanguage = (): RecommendationsForumLanguage => {
-  switch (forumTypeSetting.get()) {
-    case 'EAForum':
-      return {
-        archivesShortName: 'Favorites',
-        archivesTooltip: 'Show a randomized sample of past community favorites',
-        archivesLongName: 'Community Favorites',
-      }
-      break;
-    case 'LessWrong':
-    case 'AlignmentForum':
-    default:
-      return {
-        archivesShortName: 'Archives',
-        archivesTooltip: 'Show randomized posts from the archives',
-        archivesLongName: 'Archive Recommendations',
-      }
-  }
-}
-const forumLanguage = getForumLanguage()
+const archiveName = forumArchivesName[forumTypeSetting.get()]
 
 const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAdvanced=false, classes }: {
   settings: any,
@@ -152,13 +133,13 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
 
     {/* disabled during 2018 Review [and coronavirus]*/}
     <span className={classes.settingGroup}>
-      {(["frontpage", "frontpageEA"].includes(configName)) &&
+      {configName === "frontpage" &&
         <span className={classes.setting}>
           <SectionFooterCheckbox
             value={!settings.hideFrontpage}
             onClick={(ev, checked) => applyChange({ ...settings, hideFrontpage: !settings.hideFrontpage })}
-            label={forumLanguage.archivesShortName}
-            tooltip={forumLanguage.archivesTooltip}
+            label="Archives"
+            tooltip="Show randomized posts from the archives"
           />
         </span>
       }
@@ -168,7 +149,7 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           value={settings.onlyUnread && !!currentUser}
           onClick={(ev, checked) => applyChange({ ...settings, onlyUnread: !settings.onlyUnread })}
           label={`Unread ${!currentUser ? "(Requires login)" : ""}`}
-          tooltip={`'${forumLanguage.archivesLongName}' will only show unread posts`}
+          tooltip={`'${archiveName}' will only show unread posts`}
         />
       </span>
 
@@ -179,11 +160,10 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           value={settings[includeExtra.machineName]}
           onClick={(ev, checked) => applyChange({ ...settings, [includeExtra.machineName]: !settings[includeExtra.machineName] })}
           label={includeExtra.humanName}
-          tooltip={`'${forumLanguage.archivesLongName}' will include ${includeExtra.humanName}`}
+          tooltip={`'${archiveName}' will include ${includeExtra.humanName}`}
         />
       </span>
     </span>
-    {/* TODO; ea-forum look here */}
     {showAdvanced && <div>
       <div>{"Algorithm "}
         <select

--- a/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAlgorithmPicker.tsx
@@ -59,13 +59,40 @@ export function getRecommendationSettings({settings, currentUser, configName})
   }
 }
 
+// TODO: Soon to be removed when Community becomes a tag. At that point, we'll
+// move this into forumLanguage
 const forumIncludeExtra = {
   LessWrong: {humanName: 'Personal Blogposts', machineName: 'includePersonal'},
   AlignmentForum: {humanName: 'Personal Blogposts', machineName: 'includePersonal'},
   EAForum: {humanName: 'Community', machineName: 'includeMeta'},
 }
-
 const includeExtra = forumIncludeExtra[forumTypeSetting.get()]
+
+interface RecommendationsForumLanguage {
+  archivesShortName: string,
+  archivesTooltip: string,
+  archivesLongName: string
+}
+const getForumLanguage = (): RecommendationsForumLanguage => {
+  switch (forumTypeSetting.get()) {
+    case 'EAForum':
+      return {
+        archivesShortName: 'Favorites',
+        archivesTooltip: 'Show a randomized sample of past community favorites',
+        archivesLongName: 'Community Favorites',
+      }
+      break;
+    case 'LessWrong':
+    case 'AlignmentForum':
+    default:
+      return {
+        archivesShortName: 'Archives',
+        archivesTooltip: 'Show randomized posts from the archives',
+        archivesLongName: 'Archive Recommendations',
+      }
+  }
+}
+const forumLanguage = getForumLanguage()
 
 const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAdvanced=false, classes }: {
   settings: any,
@@ -97,28 +124,24 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
     onChange(newSettings);
   }
   return <div className={classes.root}>
-    <span className={classes.settingGroup}>
+    {['frontpage', 'frontpageEA'].includes(configName) && <span className={classes.settingGroup}>
       <span className={classes.setting}>
-        {(['frontpage', 'frontpageEA'].includes(configName)) &&
-          <SectionFooterCheckbox
-            value={!settings.hideContinueReading}
-            onClick={(ev, checked) => applyChange({ ...settings, hideContinueReading: !settings.hideContinueReading })}
-            label="Continue Reading"
-            tooltip="If you start reading a sequence, the next unread post will appear in Recommendations"
-          />
-        }
+        <SectionFooterCheckbox
+          value={!settings.hideContinueReading}
+          onClick={(ev, checked) => applyChange({ ...settings, hideContinueReading: !settings.hideContinueReading })}
+          label="Continue Reading"
+          tooltip="If you start reading a sequence, the next unread post will appear in Recommendations"
+        />
       </span>
       <span className={classes.setting}>
-        {(['frontpage', 'frontpageEA'].includes(configName)) &&
-          <SectionFooterCheckbox
-            value={!settings.hideBookmarks}
-            onClick={(ev, checked) => applyChange({ ...settings, hideBookmarks: !settings.hideBookmarks })}
-            label="Bookmarks"
-            tooltip="Posts that you have bookmarked will appear in Recommendations."
-          />
-        }
+        <SectionFooterCheckbox
+          value={!settings.hideBookmarks}
+          onClick={(ev, checked) => applyChange({ ...settings, hideBookmarks: !settings.hideBookmarks })}
+          label="Bookmarks"
+          tooltip="Posts that you have bookmarked will appear in Recommendations."
+        />
       </span>
-    </span>
+    </span>}
 
     {/* disabled except during review */}
     {/* {(configName === "frontpage") && <div>
@@ -137,24 +160,23 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
 
     {/* disabled during 2018 Review [and coronavirus]*/}
     <span className={classes.settingGroup}>
-      {(configName === "frontpage") &&
+      {(["frontpage", "frontpageEA"].includes(configName)) &&
         <span className={classes.setting}>
           <SectionFooterCheckbox
             value={!settings.hideFrontpage}
             onClick={(ev, checked) => applyChange({ ...settings, hideFrontpage: !settings.hideFrontpage })}
-            label="Archives"
-            tooltip="Show randomized posts from the archives"
+            label={forumLanguage.archivesShortName}
+            tooltip={forumLanguage.archivesTooltip}
           />
         </span>
       }
-      {/* TODO; Remove 'Archive' from tooltip  */}
       <span className={classes.setting}>
         <SectionFooterCheckbox
           disabled={!currentUser}
           value={settings.onlyUnread && !!currentUser}
           onClick={(ev, checked) => applyChange({ ...settings, onlyUnread: !settings.onlyUnread })}
           label={`Unread ${!currentUser ? "(Requires login)" : ""}`}
-          tooltip="'Archive Recommendations' will only show unread posts"
+          tooltip={`'${forumLanguage.archivesLongName}' will only show unread posts`}
         />
       </span>
 
@@ -165,11 +187,11 @@ const RecommendationsAlgorithmPicker = ({ settings, configName, onChange, showAd
           value={settings[includeExtra.machineName]}
           onClick={(ev, checked) => applyChange({ ...settings, [includeExtra.machineName]: !settings[includeExtra.machineName] })}
           label={includeExtra.humanName}
-          tooltip={`'Archive Recommendations' will include ${includeExtra.humanName}`}
+          tooltip={`'${forumLanguage.archivesLongName}' will include ${includeExtra.humanName}`}
         />
       </span>
     </span>
-    {/* ea-forum look here */}
+    {/* TODO; ea-forum look here */}
     {showAdvanced && <div>
       <div>{"Algorithm "}
         <select

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -7,6 +7,7 @@ import { getRecommendationSettings } from './RecommendationsAlgorithmPicker'
 import { useContinueReading } from './withContinueReading';
 import {AnalyticsContext} from "../../lib/analyticsEvents";
 import Hidden from '@material-ui/core/Hidden';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -95,8 +96,10 @@ const RecommendationsAndCurated = ({
     // Disabled during 2018 Review [and coronavirus]
     const recommendationsTooltip = <div>
       <div>
-        {/* TODO; Text change */}
-        Recently curated posts, as well as a random sampling of top-rated posts of all time
+        {forumTypeSetting.get() === 'EAForum' ?
+          'Assorted suggested reading, including ' :
+          'Recently curated posts, as well as a '}
+        random sampling of top-rated posts of all time
         {settings.onlyUnread && " that you haven't read yet"}.
       </div>
       <div><em>(Click to see more recommendations)</em></div>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -95,6 +95,7 @@ const RecommendationsAndCurated = ({
     // Disabled during 2018 Review [and coronavirus]
     const recommendationsTooltip = <div>
       <div>
+        {/* TODO; Text change */}
         Recently curated posts, as well as a random sampling of top-rated posts of all time
         {settings.onlyUnread && " that you haven't read yet"}.
       </div>
@@ -213,4 +214,3 @@ declare global {
     RecommendationsAndCurated: typeof RecommendationsAndCuratedComponent
   }
 }
-

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -62,7 +62,7 @@ const getFrontPageOverwrites = (haveCurrentUser: boolean) => {
   }
   return {
     method: 'sample',
-    coutn: haveCurrentUser ? 3 : 2
+    count: haveCurrentUser ? 3 : 2
   }
 }
 

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -112,12 +112,12 @@ const RecommendationsAndCurated = ({
 
     const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
     const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
- 
+
     return <SingleColumnSection className={classes.section}>
       <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
         <Link to={"/recommendations"}>Recommendations</Link>
       </LWTooltip>}>
-        {currentUser && 
+        {currentUser &&
           <LWTooltip title="Customize your recommendations">
             <SettingsButton showIcon={false} onClick={toggleSettings} label="Customize"/>
           </LWTooltip>

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -53,16 +53,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
-const defaultFrontpageSettings = {
-  method: "sample",
-  count: 3,
-  scoreOffset: 0,
-  scoreExponent: 3,
-  personalBlogpostModifier: 0,
-  frontpageModifier: 10,
-  curatedModifier: 50,
-}
-
 const RecommendationsAndCurated = ({
   configName,
   classes,
@@ -83,6 +73,11 @@ const RecommendationsAndCurated = ({
     const { SequencesGridWrapper, RecommendationsAlgorithmPicker, SingleColumnSection, SettingsButton, ContinueReadingList, PostsList2, RecommendationsList, SectionTitle, SectionSubtitle, BookmarksList, LWTooltip, TagProgressBar } = Components;
 
     const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
+    const frontpageRecommendationSettings = {
+      ...settings,
+      method: !currentUser && forumTypeSetting.get() ? 'top' : 'sample',
+      count: currentUser ? 3 : 2,
+    }
 
     const continueReadingTooltip = <div>
       <div>The next posts in sequences you've started reading, but not finished.</div>
@@ -104,14 +99,6 @@ const RecommendationsAndCurated = ({
       </div>
       <div><em>(Click to see more recommendations)</em></div>
     </div>
-
-    // defaultFrontpageSettings does not contain anything that overrides a user
-    // editable setting, so the reverse ordering here is fine
-    const frontpageRecommendationSettings = {
-      ...settings,
-      ...defaultFrontpageSettings,
-      count: currentUser ? 3 : 2,
-    }
 
     const renderBookmarks = ((currentUser?.bookmarkedPostsMetadata?.length || 0) > 0) && !settings.hideBookmarks
     const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -133,9 +133,8 @@ const RecommendationsAndCurated = ({
           onChange={(newSettings) => setSettings(newSettings)}
         /> }
 
-      {!currentUser && <div>
+      {!currentUser && forumTypeSetting.get() !== 'EAForum' && <div>
           <Hidden smDown implementation="css">
-            {/* TODO; comment out */}
             <div className={classes.sequenceGrid}>
               <SequencesGridWrapper
                 terms={{'view':'curatedSequences', limit:3}}

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -57,7 +57,7 @@ const getFrontPageOverwrites = (haveCurrentUser: boolean) => {
   if (forumTypeSetting.get() === 'EAForum') {
     return {
       method: haveCurrentUser ? 'sample' : 'top',
-      count: 5
+      count: haveCurrentUser ? 3 : 5
     }
   }
   return {
@@ -104,9 +104,9 @@ const RecommendationsAndCurated = ({
     const recommendationsTooltip = <div>
       <div>
         {forumTypeSetting.get() === 'EAForum' ?
-          'Assorted suggested reading, including ' :
-          'Recently curated posts, as well as a '}
-        random sampling of top-rated posts of all time
+          'Assorted suggested reading, including some of the ' :
+          'Recently curated posts, as well as a random sampling of '}
+        top-rated posts of all time
         {settings.onlyUnread && " that you haven't read yet"}.
       </div>
       <div><em>(Click to see more recommendations)</em></div>
@@ -135,6 +135,7 @@ const RecommendationsAndCurated = ({
 
       {!currentUser && <div>
           <Hidden smDown implementation="css">
+            {/* TODO; comment out */}
             <div className={classes.sequenceGrid}>
               <SequencesGridWrapper
                 terms={{'view':'curatedSequences', limit:3}}

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -53,6 +53,19 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
+const getFrontPageOverwrites = (haveCurrentUser: boolean) => {
+  if (forumTypeSetting.get() === 'EAForum') {
+    return {
+      method: haveCurrentUser ? 'sample' : 'top',
+      count: 5
+    }
+  }
+  return {
+    method: 'sample',
+    coutn: haveCurrentUser ? 3 : 2
+  }
+}
+
 const RecommendationsAndCurated = ({
   configName,
   classes,
@@ -75,8 +88,7 @@ const RecommendationsAndCurated = ({
     const settings = getRecommendationSettings({settings: settingsState, currentUser, configName})
     const frontpageRecommendationSettings = {
       ...settings,
-      method: !currentUser && forumTypeSetting.get() ? 'top' : 'sample',
-      count: currentUser ? 3 : 2,
+      ...getFrontPageOverwrites(!!currentUser)
     }
 
     const continueReadingTooltip = <div>

--- a/packages/lesswrong/components/recommendations/RecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { withRecommendations } from './withRecommendations';
+import { Typography } from '@material-ui/core'
 
 interface ExternalProps {
   algorithm: any,
@@ -20,7 +21,7 @@ const RecommendationsList = ({ recommendations, recommendationsLoading }: Recomm
     {recommendations.map(post =>
       <PostsItem2 post={post} key={post._id}/>)}
     {recommendations.length===0 &&
-      <span>There are no more recommendations left.</span>}
+      <Typography><small>There are no more recommendations left.</small></Typography>}
   </div>
 }
 
@@ -33,4 +34,3 @@ declare global {
     RecommendationsList: typeof RecommendationsListComponent
   }
 }
-

--- a/packages/lesswrong/lib/collections/users/recommendationSettings.ts
+++ b/packages/lesswrong/lib/collections/users/recommendationSettings.ts
@@ -20,15 +20,6 @@ export const defaultAlgorithmSettings = forumTypeSetting.get() === 'EAForum' ?
   {...baseDefaultAlgorithmSettings, metaModifier: 0} :
   baseDefaultAlgorithmSettings
 
-export const slotSpecificRecommendationSettingDefaults = {
-  frontpage: {
-    count: 4
-  },
-  frontpageEA: {
-    count: 5
-  }
-};
-
 const recommendationAlgorithmSettingsSchema = new SimpleSchema({
   method: String,
   count: SimpleSchema.Integer,

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -593,6 +593,11 @@ switch (forumTypeSetting.get()) {
         componentName: 'EASequencesHome'
       },
       {
+        name: 'eaSequencesRedirect',
+        path: '/library',
+        redirect: () => '/sequences'
+      },
+      {
         name: "TagsAll",
         path:'/tags',
         redirect: () => `/tags/all`,

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -148,14 +148,18 @@ const allRecommendablePosts = async ({currentUser, algorithm}): Promise<Array<Db
 const topPosts = async ({count, currentUser, algorithm, scoreFn}) => {
   const recommendablePostsMetadata  = await allRecommendablePosts({currentUser, algorithm});
 
-  const unreadTopPosts = _.first(
-    _.sortBy(recommendablePostsMetadata, post => -scoreFn(post)),
-    count);
-  const unreadTopPostIds = _.map(unreadTopPosts, p=>p._id);
+  const defaultRecommendations = algorithm.excludeDefaultRecommendations ? [] : recommendablePostsMetadata.filter(p=> !!p.defaultRecommendation)
+
+  const sortedTopRecommendations = _.sortBy(recommendablePostsMetadata, post => -scoreFn(post))
+  const unreadTopPosts = _.first([
+    ...defaultRecommendations,
+    ...sortedTopRecommendations
+  ], count)
+  const unreadTopPostIds = _.map(unreadTopPosts, p=>p._id)
 
   return await Posts.find(
     { _id: {$in: unreadTopPostIds} },
-    { sort: {baseScore: -1} }
+    { sort: {defaultRecommendation: -1, baseScore: -1} }
   ).fetch();
 }
 


### PR DESCRIPTION
Move the EA Forum to use RecommendationsAndCurated. This allows us to get Continue Reading and Bookmarks. Also change it such that we sample posts on the frontpage for logged in users.

While we're at it, I noticed that we had functionality to apply default settings to different recommendationsSettings based on the settings name. Unfortunately, we were overwriting the result of those defaults. Given that they hadn't been used in a year and were now serving just to confuse, I removed said functionality. I could also imagine moving the logic away from being set in the RecommendationsAndCurated component. However, I wasn't sure what legacy settings users would have in their user.recommendationSettings.frontpage settings, which would no longer be overruled. So I went with the simple refactor, see again "not having been used in a year."

One change I thought would be nice for LessWrong, but obviously am fine with reverting: Currently you can click on the recommendations section on the homepage, and will be directed to a page called "Recommendations". Unfortunately, this page has different functionality than the homepage, missing the continue reading and curated sections. A quick rename to "Archive Recommendations" matches the text on the frontpage and serves to distinguish it.

One small effect on LW is that previously the "top" recommendation algorithm did not return default recommendations. I added this. It will cause users who haven't read the "Welcome to LessWrong" post to see it on the Archive Recommendations page, which is the only place sorted by top. I expect most of your users have read it, and expect you not to mind the inclusion. But if you do, happy to remove it.