### PR TITLE
Bugfix for algoliaCleanAll, add some related type improvements

### DIFF
--- a/packages/lesswrong/lib/algoliaUtil.ts
+++ b/packages/lesswrong/lib/algoliaUtil.ts
@@ -3,7 +3,9 @@ import { algoliaAppIdSetting, algoliaSearchKeySetting, algoliaPrefixSetting } fr
 
 const ALGOLIA_PREFIX = algoliaPrefixSetting.get()
 
-export const algoliaIndexNames: Record<string,string> = {
+export type AlgoliaIndexCollectionName = "Comments" | "Posts" | "Users" | "Sequences" | "Tags"
+
+export const algoliaIndexNames: Record<AlgoliaIndexCollectionName, string> = {
   Comments: ALGOLIA_PREFIX+'comments',
   Posts: ALGOLIA_PREFIX+'posts',
   Users: ALGOLIA_PREFIX+'users',

--- a/packages/lesswrong/server/scripts/algoliaExport.ts
+++ b/packages/lesswrong/server/scripts/algoliaExport.ts
@@ -9,7 +9,7 @@ import { wrapVulcanAsyncScript } from './utils'
 import { getAlgoliaAdminClient, algoliaIndexDocumentBatch, algoliaDeleteIds, subsetOfIdsAlgoliaShouldntIndex, algoliaGetAllDocuments } from '../search/utils';
 import { forEachDocumentBatchInCollection } from '../migrations/migrationUtils';
 import keyBy from 'lodash/keyBy';
-import { algoliaIndexNames } from '../../lib/algoliaUtil';
+import { algoliaIndexNames, AlgoliaIndexCollectionName } from '../../lib/algoliaUtil';
 import * as _ from 'underscore';
 
 async function algoliaExport(collection, selector?: any, updateFunction?: any) {
@@ -46,7 +46,7 @@ async function algoliaExport(collection, selector?: any, updateFunction?: any) {
   }
 }
 
-async function algoliaExportByCollectionName(collectionName) {
+async function algoliaExportByCollectionName(collectionName: AlgoliaIndexCollectionName) {
   switch (collectionName) {
     case 'Posts':
       await algoliaExport(Posts, {baseScore: {$gte: 0}, draft: {$ne: true}, status: 2})
@@ -70,7 +70,11 @@ async function algoliaExportByCollectionName(collectionName) {
 
 export async function algoliaExportAll() {
   for (let collectionName in algoliaIndexNames)
-    await algoliaExportByCollectionName(collectionName);
+    // I found it quite suprising that I'd need to type cast this. If algoliaIndexNames
+    // is of type Partial<Record<CollectionNameString, string>>, why would collectionName
+    // be a string? (It's not because we have the in / of mixed up.)
+    // Answer: https://stackoverflow.com/questions/61829651/how-can-i-iterate-over-record-keys-in-a-proper-type-safe-way
+    await algoliaExportByCollectionName(collectionName as AlgoliaIndexCollectionName);
 }
 
 
@@ -83,13 +87,13 @@ Vulcan.algoliaExportAll = algoliaExportAll
 // don't exist in mongodb or which exist but shouldn't be indexed. This plus
 // algoliaExport together should result in a fully up to date Algolia index,
 // regardless of the starting state.
-async function algoliaCleanIndex(collectionName: CollectionNameString)
+async function algoliaCleanIndex(collectionName: AlgoliaIndexCollectionName)
 {
   let client = getAlgoliaAdminClient();
   if (!client) return;
   
   const collection = getCollection(collectionName);
-  if (!collection) throw new Error("Invalid collection name");
+  if (!collection) throw new Error(`Invalid collection name '${collectionName}'`);
   
   // eslint-disable-next-line no-console
   console.log(`Deleting spurious documents from Algolia index ${algoliaIndexNames[collectionName]} for ${collectionName}`);
@@ -115,8 +119,9 @@ async function algoliaCleanIndex(collectionName: CollectionNameString)
 }
 
 export async function algoliaCleanAll() {
-  for (let collectionName in algoliaIndexNames)
-    await algoliaCleanIndex(getCollection(collectionName));
+  for (let collectionName in algoliaIndexNames) {
+    await algoliaCleanIndex(collectionName as AlgoliaIndexCollectionName);
+  }
 }
 
 Vulcan.algoliaCleanIndex = wrapVulcanAsyncScript('algoliaCleanIndex', algoliaCleanIndex);

--- a/packages/lesswrong/server/scripts/algoliaExport.ts
+++ b/packages/lesswrong/server/scripts/algoliaExport.ts
@@ -70,8 +70,8 @@ async function algoliaExportByCollectionName(collectionName: AlgoliaIndexCollect
 
 export async function algoliaExportAll() {
   for (let collectionName in algoliaIndexNames)
-    // I found it quite suprising that I'd need to type cast this. If algoliaIndexNames
-    // is of type Partial<Record<CollectionNameString, string>>, why would collectionName
+    // I found it quite surprising that I'd need to type cast this. If algoliaIndexNames
+    // is of type <Record<AlgoliaIndexCollectionName, string>>, why would collectionName
     // be a string? (It's not because we have the in / of mixed up.)
     // Answer: https://stackoverflow.com/questions/61829651/how-can-i-iterate-over-record-keys-in-a-proper-type-safe-way
     await algoliaExportByCollectionName(collectionName as AlgoliaIndexCollectionName);

--- a/packages/lesswrong/server/tagging/tagsGraphQL.ts
+++ b/packages/lesswrong/server/tagging/tagsGraphQL.ts
@@ -16,9 +16,9 @@ const addOrUpvoteTag = async ({tagId, postId, currentUser, context}: {
   const post = Posts.findOne({_id: postId});
   const tag = Tags.findOne({_id: tagId});
   if (!await accessFilterSingle(currentUser, Posts, post, context))
-    throw new Error("Invalid postId");
+    throw new Error(`Invalid postId ${postId}, either this post does not exist, or you do not have access`);
   if (!await accessFilterSingle(currentUser, Tags, tag, context))
-    throw new Error("Invalid tagId");
+    throw new Error(`Invalid tagId ${tagId}, either this tag does not exist, or you do not have access`);
   
   // Check whether this document already has this tag applied
   const existingTagRel = TagRels.findOne({ tagId, postId });


### PR DESCRIPTION
`algoliaCleanIndex` takes a collection **name**, while `algoliaCleanAll` previously passed it a full collection. Fixed, and thought it would be nice for the type checker to help with that, so I added some extra typing. Unfortunately, TypeScript didn't work like I thought it did*, so the new type is only marginally useful. Still, it seems more descriptive of the thing that the code is doing, so I left it in. Also includes some slightly more helpful logs.

* See comment, it's mildly interesting.