### PR TITLE
New Tags on TagActivity

### DIFF
--- a/packages/lesswrong/components/tagging/NewTagsList.tsx
+++ b/packages/lesswrong/components/tagging/NewTagsList.tsx
@@ -11,7 +11,7 @@ const styles = theme => ({
     marginBottom: 24,
     background: "white",
     padding: 12,
-    paddingTop: 4,
+    paddingTop: 0,
     boxShadow: theme.boxShadow
   },
   date: {

--- a/packages/lesswrong/components/tagging/NewTagsList.tsx
+++ b/packages/lesswrong/components/tagging/NewTagsList.tsx
@@ -11,7 +11,7 @@ const styles = theme => ({
     marginBottom: 24,
     background: "white",
     padding: 12,
-    paddingTop: 0,
+    paddingTop: 2,
     boxShadow: theme.boxShadow
   },
   date: {

--- a/packages/lesswrong/components/tagging/NewTagsList.tsx
+++ b/packages/lesswrong/components/tagging/NewTagsList.tsx
@@ -18,9 +18,13 @@ const styles = theme => ({
     width: 30,
     marginRight: 8
   },
+  user: {
+    marginRight: 12,
+  },
+  postCount: {
+    marginRight: 12,
+  },
   loadMore: {
-    color: theme.palette.primary.main,
-    fontSize: "1.1rem",
     marginLeft: 2,
     marginTop: 6
   }
@@ -29,14 +33,15 @@ const styles = theme => ({
 const NewTagsList = ({classes}:{
   classes: ClassesType
 }) => {
-  const { LoadMore, FooterTag, FormatDate, MetaInfo, UsersNameDisplay } = Components
+  const { LoadMore, TagsListItem, FormatDate, MetaInfo, UsersNameDisplay } = Components
 
   const { results, loadMoreProps } = useMulti({
-    terms: {view:"newTags", limit: 5 },
+    terms: {view:"newTags", limit: 8 },
     collection: Tags,
     fragmentName: "SunshineTagFragment",
     enableTotal: true,
     ssr: true,
+    itemsPerPage: 20,
   });
 
   return <div className={classes.root}>
@@ -50,12 +55,9 @@ const NewTagsList = ({classes}:{
             </MetaInfo>
           </Link>
           <td className={classes.tag}>
-            <FooterTag tag={tag} hideScore smallText/>
+            <TagsListItem tag={tag}/>
           </td>
-          <td className={classes.postCount}>
-            <MetaInfo>{tag.postCount} posts</MetaInfo>
-          </td>
-          <td className={classes.date}>
+          <td>
             <MetaInfo>
               <FormatDate date={tag.createdAt}/>
             </MetaInfo>

--- a/packages/lesswrong/components/tagging/NewTagsList.tsx
+++ b/packages/lesswrong/components/tagging/NewTagsList.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useMulti } from '../../lib/crud/withMulti';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import Tags from '../../lib/collections/tags/collection';
+import { Link } from '../../lib/reactRouterWrapper'
+import Users from '../../lib/collections/users/collection';
+
+const styles = theme => ({
+  root: {
+    ...theme.typography.commentStyle,
+    marginBottom: 24,
+    background: "white",
+    padding: 12,
+    paddingTop: 4,
+    boxShadow: theme.boxShadow
+  },
+  date: {
+    width: 30,
+    marginRight: 8
+  },
+  loadMore: {
+    color: theme.palette.primary.main,
+    fontSize: "1.1rem",
+    marginLeft: 2,
+    marginTop: 6
+  }
+})
+
+const NewTagsList = ({classes}:{
+  classes: ClassesType
+}) => {
+  const { LoadMore, FooterTag, FormatDate, MetaInfo, UsersNameDisplay } = Components
+
+  const { results, loadMoreProps } = useMulti({
+    terms: {view:"newTags", limit: 5 },
+    collection: Tags,
+    fragmentName: "SunshineTagFragment",
+    enableTotal: true,
+    ssr: true,
+  });
+
+  return <div className={classes.root}>
+    <h2>New Tags</h2>
+    <table>
+      <tbody>
+        {results?.map(tag => <tr key={tag._id}>
+          <Link to={Users.getProfileUrl(tag.user)} className={classes.user}>
+            <MetaInfo>
+              <UsersNameDisplay user={tag.user}/>
+            </MetaInfo>
+          </Link>
+          <td className={classes.tag}>
+            <FooterTag tag={tag} hideScore smallText/>
+          </td>
+          <td className={classes.postCount}>
+            <MetaInfo>{tag.postCount} posts</MetaInfo>
+          </td>
+          <td className={classes.date}>
+            <MetaInfo>
+              <FormatDate date={tag.createdAt}/>
+            </MetaInfo>
+          </td>
+        </tr>)}
+      </tbody>
+    </table>
+    <div className={classes.loadMore}>
+      <LoadMore {...loadMoreProps}/>
+    </div>
+  </div>
+}
+
+const NewTagsListComponent = registerComponent("NewTagsList", NewTagsList, {styles});
+
+declare global {
+  interface ComponentTypes {
+    NewTagsList: typeof NewTagsListComponent
+  }
+}
+

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -41,7 +41,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   tagVotingTable: {
     background: "white",
     padding: 12,
-    paddingTop: 0,
+    paddingTop: 2,
     ...theme.typography.commentStyle,
     boxShadow: theme.boxShadow
   }

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -41,7 +41,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   tagVotingTable: {
     background: "white",
     padding: 12,
-    paddingTop: 4,
+    paddingTop: 0,
     ...theme.typography.commentStyle,
     boxShadow: theme.boxShadow
   }

--- a/packages/lesswrong/components/tagging/TagVoteActivity.tsx
+++ b/packages/lesswrong/components/tagging/TagVoteActivity.tsx
@@ -7,14 +7,12 @@ import { useVote } from '../votes/withVote';
 const styles = (theme: ThemeType): JssStyles => ({
   voteRow: {
     ...theme.typography.body2,
-    ...theme.typography.commentStyle,
     ...theme.typography.smallText,
     color: theme.palette.grey[600]
   },
   headerCell: {
     fontWeight: 700,
     ...theme.typography.body2,
-    ...theme.typography.commentStyle,
   },
   votingCell: {
     textAlign: "center",
@@ -39,6 +37,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   smallCell: {
     textAlign: "center"
+  },
+  tagVotingTable: {
+    background: "white",
+    padding: 12,
+    paddingTop: 4,
+    ...theme.typography.commentStyle,
+    boxShadow: theme.boxShadow
   }
 })
 
@@ -83,7 +88,7 @@ const TagVoteActivityRow = ({vote, classes}: {
 const TagVoteActivity = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { SingleColumnSection, LoadMore } = Components
+  const { SingleColumnSection, LoadMore, NewTagsList } = Components
   const { results: votes, loadMoreProps } = useMulti({
     terms: {view:"tagVotes"},
     collection: Votes,
@@ -94,20 +99,24 @@ const TagVoteActivity = ({classes}: {
   })
 
   return <SingleColumnSection>
-    <table>
-      <tbody>
-        <tr className={classes.headerRow}>
-          <td className={classes.headerCell}> User </td>
-          <td className={classes.headerCell}> Post Title </td>
-          <td className={classes.headerCell}> Tag </td>
-          <td className={classes.headerCell}> Pow </td>
-          <td className={classes.headerCell}> When </td>
-          <td className={classes.headerCell}> Vote </td>
-        </tr>
-        {votes?.map(vote => <TagVoteActivityRow key={vote._id} vote={vote} classes={classes}/>)}
-      </tbody>
-    </table>
-    <LoadMore {...loadMoreProps} />
+    <NewTagsList />
+    <div className={classes.tagVotingTable}>
+      <h2>Tag Voting</h2>
+      <table>
+        <tbody>
+          <tr className={classes.headerRow}>
+            <td className={classes.headerCell}> User </td>
+            <td className={classes.headerCell}> Post Title </td>
+            <td className={classes.headerCell}> Tag </td>
+            <td className={classes.headerCell}> Pow </td>
+            <td className={classes.headerCell}> When </td>
+            <td className={classes.headerCell}> Vote </td>
+          </tr>
+          {votes?.map(vote => <TagVoteActivityRow key={vote._id} vote={vote} classes={classes}/>)}
+        </tbody>
+      </table>
+      <LoadMore {...loadMoreProps} />
+    </div>
   </SingleColumnSection>
 }
 

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -16,6 +16,7 @@ registerFragment(`
     reviewedByUserId
     descriptionTruncationCount
     wikiGrade
+    createdAt
   }
 `);
 

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -58,9 +58,6 @@ ensureIndex(Tags, {deleted: 1, core:1, name: 1});
 
 Tags.addView('newTags', terms => {
   return {
-    selector: {
-      deleted: false
-    },
     options: {
       sort: {
         createdAt: -1
@@ -68,7 +65,7 @@ Tags.addView('newTags', terms => {
     }
   }
 })
-ensureIndex(Tags, {createdAt: 1});
+ensureIndex(Tags, {deleted: 1, createdAt: 1});
 
 Tags.addView('unreviewedTags', terms => {
   return {

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -56,6 +56,20 @@ Tags.addView('coreTags', terms => {
 ensureIndex(Tags, {deleted: 1, core:1, name: 1});
 
 
+Tags.addView('newTags', terms => {
+  return {
+    selector: {
+      deleted: false
+    },
+    options: {
+      sort: {
+        createdAt: -1
+      }
+    }
+  }
+})
+ensureIndex(Tags, {createdAt: 1});
+
 Tags.addView('unreviewedTags', terms => {
   return {
     selector: {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -361,6 +361,7 @@ importComponent("SunshineListCount", () => require('../components/sunshineDashbo
 importComponent(["EmailHistory", "EmailHistoryPage"], () => require('../components/sunshineDashboard/EmailHistory'));
 
 importComponent("AddTag", () => require('../components/tagging/AddTag'));
+importComponent("NewTagsList", () => require('../components/tagging/NewTagsList'));
 importComponent("AddTagButton", () => require('../components/tagging/AddTagButton'));
 importComponent("CoreTagsChecklist", () => require('../components/tagging/CoreTagsChecklist'));
 importComponent("TagPage", () => require('../components/tagging/TagPage'));

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1448,6 +1448,7 @@ interface TagBasicInfo { // fragment on Tags
   readonly reviewedByUserId: string,
   readonly descriptionTruncationCount: number,
   readonly wikiGrade: number,
+  readonly createdAt: Date,
 }
 
 interface TagFragment extends TagBasicInfo { // fragment on Tags

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -240,6 +240,11 @@ addRoute(
   {
     name: 'tagVoting',
     path: '/tagVoting',
+    redirect: () => `/tags/all`,
+  },
+  {
+    name: 'tagActivity',
+    path: '/tagActivity',
     componentName: 'TagVoteActivity',
     title: 'Tag Voting Activity'
   },

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -240,7 +240,7 @@ addRoute(
   {
     name: 'tagVoting',
     path: '/tagVoting',
-    redirect: () => `/tags/all`,
+    redirect: () => `/tagActivity`,
   },
   {
     name: 'tagActivity',


### PR DESCRIPTION
In response to some user feedback during the Tagging Session, I've added a list of newly created tags to the tagVoting page. I've also made it so "/tagVoting" and "/tagActivity" both link to the same place (since some people including myself found myself reaching more naturally for the word "tag activity".

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3246710/90706337-c3947d80-e249-11ea-8613-75301a020c95.png">
