### PR TITLE
Move the "A/B test key" setting to the admin options section of the user profile

### DIFF
--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1387,6 +1387,7 @@ addFieldsDict(Users, {
     optional: true,
     canRead: [Users.owns, 'sunshineRegiment', 'admins'],
     canUpdate: ['admins'],
+    group: formGroups.adminOptions,
   },
   abTestOverrides: {
     type: GraphQLJSON, //Record<string,number>


### PR DESCRIPTION
Move the A/B test key override setting to the admin options section on user profile pages. It's only visible to admins, but it was defaulting to being the first field on the form, which was conspicuous and ugly.