### PR TITLE
Fix indexing issue with comments.hideAuthorIsUnreviewed

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -42,8 +42,8 @@ export function augmentForDefaultView(indexFields)
 {
   return combineIndexWithDefaultViewIndex({
     viewFields: indexFields,
-    prefix: {authorIsUnreviewed: 1},
-    suffix: {deleted:1, deletedPublic:1, hideAuthor:1, userId:1, af:1},
+    prefix: {},
+    suffix: {authorIsUnreviewed: 1, deleted:1, deletedPublic:1, hideAuthor:1, userId:1, af:1},
   });
 }
 


### PR DESCRIPTION
In https://github.com/LessWrong2/Lesswrong2/pull/1996, the `authorIsUnreviewed` field is added to the index-prefix for comments; whether that field is part of the default query depends on a config setting, which is on for EA Forum and off for LW. Because MongoDB is super brittle, putting a field which is not part of a query into an index-prefix breaks indexing. However, this change didn't break anything immediately, because the existing indexes were all still there, and would only be removed if we did so manually (which we didn't). However, it broke the *new* index for comments-on-tag, causing some significant performance problems..