### PR TITLE
Tag page header tweaks

### DIFF
--- a/packages/lesswrong/components/tagging/TagDiscussion.tsx
+++ b/packages/lesswrong/components/tagging/TagDiscussion.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { unflattenComments } from "../../lib/utils/unflatten";
+import { useMulti } from '../../lib/crud/withMulti';
+import { Link } from '../../lib/reactRouterWrapper';
+
+const styles = theme => ({
+  root: {
+    maxWidth: 400,
+    padding: 6
+  },
+  seeAll: {
+    ...theme.typography.body2,
+    ...theme.typography.commentStyle,
+    marginLeft: 6,
+    color: theme.palette.primary.main
+  }
+})
+
+const TagDiscussion = ({classes, tag}: {
+  classes: ClassesType,
+  tag: TagFragment
+}) => {
+  const { CommentsList, Loading } = Components;
+  
+  const { results, loading, totalCount } = useMulti({
+    skip: !tag?._id,
+    terms: {
+      view: "commentsOnTag",
+      tagId: tag?._id,
+      limit: 7,
+    },
+    collectionName: "Comments",
+    fragmentName: 'CommentsList',
+    fetchPolicy: 'cache-and-network',
+    enableTotal: true,
+    ssr: true
+  });
+
+  if (!tag) return null
+  
+  const nestedComments = results && unflattenComments(results);
+  
+  return <div className={classes.root}>
+        {!results && loading ? <Loading/> : 
+        <CommentsList
+          totalComments={totalCount}
+          comments={nestedComments}
+          tag={tag}
+          postPage
+        />}
+        <Link to={`/tag/${tag.slug}/discussion`} className={classes.seeAll}>
+          See all
+        </Link>
+
+    </div>
+}
+
+const TagDiscussionComponent = registerComponent("TagDiscussion", TagDiscussion, {styles})
+
+
+declare global {
+  interface ComponentTypes {
+    TagDiscussion: typeof TagDiscussionComponent
+  }
+}

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -7,7 +7,7 @@ import { useCurrentUser } from '../common/withUser';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import Typography from '@material-ui/core/Typography';
-import CommentIcon from '@material-ui/icons/ModeComment';
+import CommentOutlinedIcon from '@material-ui/icons/ModeCommentOutlined';
 import { truncate } from '../../lib/editor/ellipsize';
 import { Tags } from '../../lib/collections/tags/collection';
 import { subscriptionTypes } from '../../lib/collections/subscriptions/schema'
@@ -192,8 +192,8 @@ const TagPage = ({classes}: {
             </LWTooltip>
 
             <Link className={classes.discussionButton} to={`/tag/${tag.slug}/discussion`} {...eventHandlers}>
-              <CommentIcon/> Discussion
-              <PopperCard open={hover} anchorEl={anchorEl} placement="right-start">
+              <CommentOutlinedIcon/> Discussion
+              <PopperCard open={hover} anchorEl={anchorEl} placement="bottom-start" >
                 <TagDiscussion tag={tag}/>
               </PopperCard>    
             </Link>   

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -15,6 +15,7 @@ import { userCanViewRevisionHistory } from '../../lib/betas';
 import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 import HistoryIcon from '@material-ui/icons/History';
 import { useDialog } from '../common/withDialog';
+import { useHover } from '../common/withHover';
 
 // Also used in TagCompareRevisions, TagDiscussionPage
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -83,6 +84,12 @@ export const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "center",
     marginRight: 16
   },
+  discussionButton: {
+    display: "flex",
+    alignItems: "center",
+    marginRight: 16,
+    marginLeft: "auto"
+  },
   subscribeTo: {
     marginRight: 16
   }
@@ -101,7 +108,7 @@ export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { SingleColumnSection, SubscribeTo, PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, WikiGradeDisplay } = Components;
+  const { SingleColumnSection, SubscribeTo, PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, LWTooltip, PopperCard, TagDiscussion } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;
@@ -113,6 +120,8 @@ const TagPage = ({classes}: {
   const { captureEvent } =  useTracking()
   const { openDialog } = useDialog();
   
+  const { hover, anchorEl, eventHandlers} = useHover()
+
   if (loadingTag)
     return <Loading/>
   if (!tag)
@@ -171,18 +180,23 @@ const TagPage = ({classes}: {
             {userCanViewRevisionHistory(currentUser) && <Link className={classes.button} to={`/revisions/tag/${tag.slug}`}>
               <HistoryIcon /> History
             </Link>}
-            <Link className={classes.button} to={`/tag/${tag.slug}/discussion`}>
+            <LWTooltip title="Get notifications when posts are added to this tag">
+              <SubscribeTo 
+                document={tag} 
+                className={classes.subscribeTo}
+                showIcon 
+                subscribeMessage="Subscribe"
+                unsubscribeMessage="Unsubscribe"
+                subscriptionType={subscriptionTypes.newTagPosts}
+              />
+            </LWTooltip>
+
+            <Link className={classes.discussionButton} to={`/tag/${tag.slug}/discussion`} {...eventHandlers}>
               <CommentIcon/> Discussion
-            </Link>
-            <SubscribeTo 
-              document={tag} 
-              className={classes.subscribeTo}
-              showIcon 
-              subscribeMessage="Subscribe to Tag"
-              unsubscribeMessage="Unsubscribe from Tag"
-              subscriptionType={subscriptionTypes.newTagPosts}
-            />
-            <WikiGradeDisplay wikiGrade={tag.wikiGrade} />
+              <PopperCard open={hover} anchorEl={anchorEl} placement="right-start">
+                <TagDiscussion tag={tag}/>
+              </PopperCard>    
+            </Link>   
           </div>
           <div onClick={clickReadMore}>
             <ContentItemBody

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -384,6 +384,7 @@ importComponent("TagRevisionItem", () => require('../components/tagging/TagRevis
 importComponent("TagsDetailsItem", () => require('../components/tagging/TagsDetailsItem'));
 importComponent("TagCompareRevisions", () => require('../components/tagging/TagCompareRevisions'));
 importComponent("TagDiscussionPage", () => require('../components/tagging/TagDiscussionPage'));
+importComponent("TagDiscussion", () => require('../components/tagging/TagDiscussion'));
 importComponent("TagFilterSettings", () => require('../components/tagging/TagFilterSettings'));
 importComponent("FilterMode", () => require('../components/tagging/FilterMode'));
 importComponent("TagPreview", () => require('../components/tagging/TagPreview'));


### PR DESCRIPTION
This PR aims to clean up the Tag Page header, via:

1. gets rid of WikiTagGrade, because I don't think it's currently providing much value and adds a bit too much clutter
2. Moves the TagDiscussion button off to the right
3. TagDiscussion button is now a hoverover so you can see a few comments without having to click through.

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/3246710/92670804-a6435400-f2c9-11ea-88d1-c718441870e0.png">
