### PR TITLE
Tag Filter UI improvements

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -153,7 +153,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
               </span>
             </LWTooltip>
             <LWTooltip title={filterModeToTooltip("Required")}>
-              <span className={classNames(classes.filterButton)} onClick={ev => onChangeMode("Required")}>
+              <span className={classNames(classes.filterButton, {[classes.selected]: mode==="Required"})} onClick={ev => onChangeMode("Required")}>
                 Required
               </span>
             </LWTooltip>

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -106,14 +106,15 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
         mode={tagSettings.filterMode}
         canRemove={true}
         onChangeMode={(mode: FilterMode) => {
+          const newMode = mode === tagSettings.filterMode ? 0 : mode
           const changedTagId = tagSettings.tagId;
           const replacedIndex = _.findIndex(filterSettingsWithSuggestedTags.tags, t=>t.tagId===changedTagId);
           let newTagFilters = [...filterSettingsWithSuggestedTags.tags];
           newTagFilters[replacedIndex] = {
             ...filterSettingsWithSuggestedTags.tags[replacedIndex],
-            filterMode: mode
+            filterMode: newMode
           };
-          captureEvent('tagFilterModified', {tagId: tagSettings.tagId, tagName: tagSettings.tagName, mode})
+          captureEvent('tagFilterModified', {tagId: tagSettings.tagId, tagName: tagSettings.tagName, newMode})
 
           changeFilterSettings({
             personalBlog: filterSettingsWithSuggestedTags.personalBlog,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -228,7 +228,7 @@ addFieldsDict(Users, {
     group: formGroups.default,
     control: "select",
     form: {
-      // TODO – maybe factor out??
+      // TODO - maybe factor out??
       options: function () { // options for the select form control
         let commentViews = [
           {value:'postCommentsTop', label: 'magical algorithm'},


### PR DESCRIPTION
Fixes the bug where clicking "Required" on a tag filter doesn't highlight "Required", and makes it so that clicking on a filter-button that's already been clicked reverts the filter to "0"