### PR TITLE
Fix React key-duplication issue on answer pages with ToCs

### DIFF
--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -210,7 +210,7 @@ async function getTocAnswers (document) {
     return [
       {anchor: "answers", level:1, title:'Answers'}, 
       ...answerSections,
-      {divider:true, level: 0, anchor: "postHeadingsDivider"}
+      {divider:true, level: 0, anchor: "postAnswersDivider"}
     ]
   } else {
     return []


### PR DESCRIPTION
Fixes (probably) a bug which completely broke the comments section on https://www.lesswrong.com/posts/H3wdw2cLNLpcF8pXA/social-capital-paradoxes .