### PR TITLE
Hide progress bar during loading

### DIFF
--- a/packages/lesswrong/components/tagging/TagProgressBar.tsx
+++ b/packages/lesswrong/components/tagging/TagProgressBar.tsx
@@ -131,6 +131,8 @@ const TagProgressBar = ({ classes }: {
     }
   }
 
+  if (!allTagsToProcessTotal || !processedTagsTotal) return null
+
   const allPostsTooltip = processedTagsTotal < allTagsToProcessTotal ?
     `${allTagsToProcessTotal - processedTagsTotal} pages out of ${allTagsToProcessTotal} from the LW 1.0 Wiki still need processing` :
     `All tags and wiki pages from the LW Wiki import have been processed!`


### PR DESCRIPTION
Currently the progress bar shows as completed during loading. This PR just hides it during loading, which seems better.