### PR TITLE
Filter wikiOnly tags from Algolia

### DIFF
--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -183,6 +183,7 @@ Posts.toAlgolia = async (post: DbPost): Promise<Array<AlgoliaDocument>|null> => 
 Tags.toAlgolia = async (tag: DbTag): Promise<Array<AlgoliaDocument>|null> => {
   if (tag.deleted) return null;
   if (tag.adminOnly) return null;
+  if (tag.wikiOnly) return null;
   
   let description = ""
   if (tag.description?.originalContents?.type) {
@@ -203,6 +204,7 @@ Tags.toAlgolia = async (tag: DbTag): Promise<Array<AlgoliaDocument>|null> => {
     suggestedAsFilter: tag.suggestedAsFilter,
     postCount: tag.postCount,
     description,
+    wikiOnly: tag.wikiOnly
   }];
 } 
 


### PR DESCRIPTION
For now just filters out wiki only tags from the algolia index. Later on we will probably want to instead make it so that different searchboxes use different filters.