### PR TITLE
Remove the "2.0" from "LessWrong 2.0"

### DIFF
--- a/packages/lesswrong/components/common/HeadTags.tsx
+++ b/packages/lesswrong/components/common/HeadTags.tsx
@@ -7,7 +7,7 @@ import { PublicInstanceSetting } from '../../lib/instanceSettings';
 
 export const taglineSetting = new PublicInstanceSetting<string>('tagline', "A community blog devoted to refining the art of rationality", "warning")
 export const faviconUrlSetting = new PublicInstanceSetting<string>('faviconUrl', '/img/favicon.ico', "warning")
-const tabTitleSetting = new PublicInstanceSetting<string>('forumSettings.tabTitle', 'LessWrong 2.0', "warning")
+const tabTitleSetting = new PublicInstanceSetting<string>('forumSettings.tabTitle', 'LessWrong', "warning")
 
 
 const HeadTags = (props) => {

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -101,7 +101,7 @@ export class PublicInstanceSetting<SettingValueType> {
 */
 
 export const forumTypeSetting = new PublicInstanceSetting<string>('forumType', 'LessWrong', 'warning') // What type of Forum is being run, {LessWrong, AlignmentForum, EAForum}
-export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'LessWrong 2.0', 'warning') // Default title for URLs
+export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'LessWrong', 'warning') // Default title for URLs
 
 // Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum". Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.
 export const siteNameWithArticleSetting = new PublicInstanceSetting<string>('siteNameWithArticle', "LessWrong", "warning")

--- a/packages/lesswrong/server/scripts/invites.ts
+++ b/packages/lesswrong/server/scripts/invites.ts
@@ -3,25 +3,25 @@ import { Meteor } from 'meteor/meteor';
 import { mailUrlSetting } from '../vulcan-core/start';
 
 if (!Meteor.isPackageTest) {
-  Accounts.emailTemplates.siteName = 'LessWrong 2.0';
-  Accounts.emailTemplates.from = 'LessWrong 2.0 <no-reply@lesserwrong.com>';
+  Accounts.emailTemplates.siteName = 'LessWrong';
+  Accounts.emailTemplates.from = 'LessWrong <no-reply@lesserwrong.com>';
   Accounts.emailTemplates.enrollAccount.subject = (user) => {
-    return `Activate your Account on LessWrong 2.0`;
+    return `Activate your Account on LessWrong`;
   };
   Accounts.emailTemplates.enrollAccount.text = (user, url) => {
-    return 'You are invited to join LessWrong 2.0'
+    return 'You are invited to join LessWrong'
       + ' To register an account, simply click the link below:\n\n'
       + url;
   };
 
   Accounts.emailTemplates.resetPassword.subject = (user) => {
-    return `Reset your password on LessWrong 2.0`;
+    return `Reset your password on LessWrong`;
   };
 
   Accounts.emailTemplates.resetPassword.from = () => {
     // Overrides the value set in `Accounts.emailTemplates.from` when resetting
     // passwords.
-    return 'LessWrong 2.0 <no-reply@lesserwrong.com>';
+    return 'LessWrong <no-reply@lesserwrong.com>';
   };
 
   Accounts.emailTemplates.resetPassword.text = (user, url) => {
@@ -42,6 +42,6 @@ if (!Meteor.isPackageTest) {
     // console.log("Set Mail URL environment variable");
     process.env.MAIL_URL = mailUrlSetting.get() || undefined;
     // console.log("Set Root URL variable");
-    process.env.ROOT_URL = "http://www.lesswrong.com/";
+    process.env.ROOT_URL = "https://www.lesswrong.com/";
   }
 }

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -11,7 +11,7 @@
     "forumSettings": {
       "headerTitle": "LESSWRONG",
       "shortForumTitle": "LW",
-      "tabTitle": "LessWrong 2.0"
+      "tabTitle": "LessWrong"
     },
     "analytics": {
       "environment": "localhost"


### PR DESCRIPTION
Awhile ago, I recall a conversation where we said that at some point we should drop the "2.0" from "LessWrong 2.0", to just be "LessWrong" again, since old-LessWrong no longer exists concurrently, and it's a weird thing to have in our branding. This PR does that renaming (on the code side, in conjunction with a [second PR](https://github.com/LessWrong2/LessWrong-Credentials/pull/30) against the credentials repo, which does it on the config-gile side).