### PR TITLE
Don't show [deleted comment] entries in shortform section on All Posts page

### DIFF
--- a/packages/lesswrong/lib/collections/comments/views.ts
+++ b/packages/lesswrong/lib/collections/comments/views.ts
@@ -288,6 +288,7 @@ Comments.addView('topShortform', function (terms) {
     selector: {
       shortform: true,
       parentCommentId: viewFieldNullOrMissing,
+      deleted: false,
       ...timeRange
     },
     options: {sort: {baseScore: -1, postedAt: -1}}


### PR DESCRIPTION
Mostly hasn't come up before, but there was one recently, and seeing a deleted-comment entry in the All Posts page context was ugly and weird.