### PR TITLE
Activate advanced search on all Algolia indexes

### DIFF
--- a/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
+++ b/packages/lesswrong/server/scripts/algoliaConfigureIndexes.ts
@@ -34,6 +34,7 @@ export const algoliaConfigureIndexes = async () => {
     attributesToHighlight: ['authorDisplayName'],
     attributesToSnippet: ['body:20'],
     unretrievableAttributes: ['authorUserName'],
+    advancedSyntax: true
   });
   await algoliaSetIndexSettingsAndWait(postsIndex, {
     searchableAttributes: [
@@ -77,6 +78,7 @@ export const algoliaConfigureIndexes = async () => {
     attributesForFaceting: [
       'filterOnly(af)',
     ],
+    advancedSyntax: true
   });
   await algoliaSetIndexSettingsAndWait(sequencesIndex, {
     searchableAttributes: [
@@ -88,6 +90,7 @@ export const algoliaConfigureIndexes = async () => {
     attributesForFaceting: [
       'filterOnly(af)',
     ],
+    advancedSyntax: true
   });
   await algoliaSetIndexSettingsAndWait(tagsIndex, {
     searchableAttributes: [
@@ -102,6 +105,7 @@ export const algoliaConfigureIndexes = async () => {
     ],
     distinct: false,
     attributesToSnippet: ['description:10'],
+    advancedSyntax: true
   });
   
   console.log("Done"); //eslint-disable-line no-console


### PR DESCRIPTION
This activates support for the verbatim search syntax, which sure seems important