### PR TITLE
Don't make tables full-width

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -61,7 +61,6 @@ const tableStyles = {
   borderSpacing: 0,
   border: "1px double #b3b3b3",
   margin: "auto",
-  width: "100%",
   height: "100%",
   textAlign: "left"
 }


### PR DESCRIPTION
This fixes a visual discrepancy between the WYSIWYG editor view and the rendered posts. Some historical posts might be affected, but when I checked a few randomly sampled ones, things looked fine. 