### PR TITLE
Temporarily remove tagging progress bar for Petrov day

### DIFF
--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -192,9 +192,9 @@ const RecommendationsAndCurated = ({
         </AnalyticsContext>
       </div>}
 
-      {!currentUser?.hideTaggingProgressBar && <AnalyticsContext pageSectionContext="Tag Progress Bar: LW Wiki Import">
+      {/* {!currentUser?.hideTaggingProgressBar && <AnalyticsContext pageSectionContext="Tag Progress Bar: LW Wiki Import">
         <TagProgressBar/>
-      </AnalyticsContext>}
+      </AnalyticsContext>} */}
 
       {/* disabled except during review */}
       {/* <AnalyticsContext pageSectionContext="LessWrong 2018 Review">


### PR DESCRIPTION
I think the progress bar might be causing some performance problems, and also I think it clutters up the frontpage too much during Petrov Day, so I vote to remove it.