### PR TITLE
Allow rel="nofollow" links to work right

### DIFF
--- a/packages/lesswrong/components/common/ContentItemBody.tsx
+++ b/packages/lesswrong/components/common/ContentItemBody.tsx
@@ -256,7 +256,8 @@ class ContentItemBody extends Component<ContentItemBodyProps,ContentItemBodyStat
         const tagContentsHTML = linkTag.innerHTML;
         const href = linkTag.getAttribute("href");
         const id = linkTag.getAttribute("id");
-        const replacementElement = <Components.HoverPreviewLink href={href} innerHTML={tagContentsHTML} contentSourceDescription={this.props.description} id={id}/>
+        const rel = linkTag.getAttribute("rel")
+        const replacementElement = <Components.HoverPreviewLink href={href} innerHTML={tagContentsHTML} contentSourceDescription={this.props.description} id={id} rel={rel}/>
         this.replaceElement(linkTag, replacementElement);
       }
       this.setState({updatedElements: true})

--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -38,23 +38,24 @@ const linkIsExcludedFromPreview = (url: string): boolean => {
 //   contentSourceDescription: (Optional) A human-readabe string describing
 //     where this content came from. Used in error logging only, not displayed
 //     to users.
-const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }: {
+const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id, rel }: {
   innerHTML: string,
   href: string,
   contentSourceDescription?: string,
-  id?: string
+  id?: string,
+  rel?: string
 }) => {
   const URLClass = getUrlClass()
   const location = useLocation();
 
   // Invalid link with no href? Don't transform it.
   if (!href) {
-    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel}/>
   }
 
   // Within-page relative link?
   if (href.startsWith("#")) {
-    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />
+    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel} />
   }
 
   try {
@@ -74,7 +75,7 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }: {
             <PreviewComponent href={destinationUrl} targetLocation={parsedUrl} innerHTML={innerHTML} id={id}/>
           </AnalyticsContext>
         } else {
-          return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} />
+          return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} rel={rel} />
         }
       }
     } else {
@@ -84,13 +85,13 @@ const HoverPreviewLink = ({ innerHTML, href, contentSourceDescription, id }: {
       if (linkTargetAbsolute.host === "metaculus.com" || linkTargetAbsolute.host === "www.metaculus.com") {
         return <Components.MetaculusPreview href={href} innerHTML={innerHTML} id={id} />
       }
-      return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} />
+      return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} rel={rel} />
     }
-    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} />
+    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel} />
   } catch (err) {
     console.error(err) // eslint-disable-line
     console.error(href, innerHTML) // eslint-disable-line
-    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+    return <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel}/>
   }
 
 }

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -284,12 +284,13 @@ const defaultPreviewStyles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-const DefaultPreview = ({classes, href, innerHTML, onsite=false, id}: {
+const DefaultPreview = ({classes, href, innerHTML, onsite=false, id, rel}: {
   classes: ClassesType,
   href: string,
   innerHTML: string,
   onsite?: boolean,
   id?: string,
+  rel?: string
 }) => {
   const { LWPopper } = Components
   const { eventHandlers, hover, anchorEl, stopHover } = useHover({
@@ -309,9 +310,9 @@ const DefaultPreview = ({classes, href, innerHTML, onsite=false, id}: {
       </LWPopper>
 
       {onsite
-        ? <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+        ? <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel}/>
         : <Components.AnalyticsTracker eventType="link" eventProps={{to: href}}>
-            <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id}/>
+            <a href={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} rel={rel}/>
           </Components.AnalyticsTracker>}
     </span>
   );

--- a/packages/lesswrong/server/vulcan-lib/utils.ts
+++ b/packages/lesswrong/server/vulcan-lib/utils.ts
@@ -23,7 +23,8 @@ export const sanitize = function(s: string): string {
       td: ['rowspan', 'colspan', 'style'],
       th: ['rowspan', 'colspan', 'style'],
       span: ['style'],
-      div: ['class']
+      div: ['class'],
+      a: ['href', 'name', 'target', 'rel']
     },
     allowedClasses: {
       div: [ 'spoilers' ],


### PR DESCRIPTION
From Jeff Kauffman on Intercom: 

> I noticed that when my posts are copied over rel=nofollow is removed from links? For example, my RSS feed has "&lt;a rel=&quot;nofollow&quot; href=&quot;https://www.consumerreports.org/car-seats/how-to-fit-child-car-seats-three-across/&quot;&gt;on&lt;/a&gt;"

> This isn't critical, but I put rel=nofollow on these links because while I wanted to link them to demonstrate that the topic has been widely discussed I didn't want to endorse them specifically (they're kind of spammy).

This fixes this.