### PR TITLE
Properly gate the garden

### DIFF
--- a/packages/lesswrong/components/localGroups/GatherTown.tsx
+++ b/packages/lesswrong/components/localGroups/GatherTown.tsx
@@ -103,7 +103,7 @@ const GatherTown = ({classes}: {
   });
 
 
-  if (!currentUser) return null
+  if (!currentUser || !currentUser.walledGardenInvite) return null
   if (currentUser.hideWalledGardenUI) return null
 
   const hideClickHandler = async () => {


### PR DESCRIPTION
At some point the GatherTown widget was properly gated, but then either Oli or me (probably me) accidentally un-gated it. This limits it to people with the walledGardenInvite setting again.