### PR TITLE
Detect timeouts of MathJax processing

### DIFF
--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -7,6 +7,7 @@ import Revisions from '../../lib/collections/revisions/collection'
 import { extractVersionsFromSemver } from '../../lib/editor/utils'
 import { ensureIndex } from '../../lib/collectionUtils'
 import { htmlToPingbacks } from '../pingbacks';
+import Sentry from '@sentry/node';
 import TurndownService from 'turndown';
 const turndownService = new TurndownService()
 import * as _ from 'underscore';
@@ -31,14 +32,30 @@ function mjPagePromise(html: string, beforeSerializationCallback): Promise<strin
   // Takes in HTML and replaces LaTeX with CommonHTML snippets
   // https://github.com/pkra/mathjax-node-page
   return new Promise((resolve, reject) => {
+    let finished = false;
+    
+    setTimeout(() => {
+      if (!finished) {
+        const errorMessage = `Timed out in mjpage when processing html: ${html}`;
+        Sentry.captureException(new Error(errorMessage));
+        // eslint-disable-next-line no-console
+        console.error(errorMessage);
+      }
+    }, 10000);
+    
     const errorHandler = (id, wrapperNode, sourceFormula, sourceFormat, errors) => {
       // eslint-disable-next-line no-console
       console.log("Error in Mathjax handling: ", id, wrapperNode, sourceFormula, sourceFormat, errors)
       reject(`Error in $${sourceFormula}$: ${errors}`)
     }
     
+    const callbackAndMarkFinished = (result) => {
+      finished = true;
+      return beforeSerializationCallback(result);
+    };
+    
     mjpage(html, { fragment: true, errorHandler } , {html: true, css: true}, resolve)
-      .on('beforeSerialization', beforeSerializationCallback);
+      .on('beforeSerialization', callbackAndMarkFinished);
   })
 }
 


### PR DESCRIPTION
We briefly had some code to detect if MathJax fails to return a result, which was accidentally deleted in https://github.com/LessWrong2/Lesswrong2/pull/2691 .