### PR TITLE
Track clicks to external GT

### DIFF
--- a/packages/lesswrong/components/localGroups/GatherTown.tsx
+++ b/packages/lesswrong/components/localGroups/GatherTown.tsx
@@ -108,7 +108,7 @@ const GatherTown = ({classes}: {
     fragmentName: 'UsersCurrent',
   });
 
-  const { LWTooltip } = Components
+  const { LWTooltip, AnalyticsTracker } = Components
 
 
   if (!currentUser || !currentUser.walledGardenInvite) return null
@@ -133,6 +133,7 @@ const GatherTown = ({classes}: {
     })
   }
 
+  const gatherTownURL = "https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus"
   const tooltip = <LWTooltip title={
     <div>
       Click to read more about this space
@@ -147,7 +148,9 @@ const GatherTown = ({classes}: {
       <CloseIcon className={classes.hide} onClick={hideClickHandler} />
       <div className={classes.icon}>{gatherIcon} </div>
       <div>
-        <div>You're invited to the <a href="https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus">Walled Garden Beta</a></div>
+        <AnalyticsTracker eventType="link" eventProps={{to: gatherTownURL}}>
+          <div>You're invited to the <a href={gatherTownURL}>Walled Garden Beta</a></div>
+        </AnalyticsTracker>
         <div className={classes.secondaryInfo}>
           <div>
             A private, permanent virtual world. Coworking 2pm-7pm PT weekdays. Schelling Social hours at 1pm and 7pm.
@@ -157,7 +160,7 @@ const GatherTown = ({classes}: {
             {Object.keys(users).map(user => <span className={classes.userName} key={user}><FiberManualRecordIcon className={classes.onlineDot}/> {user}</span>)}
             {tooltip}
         </div>}
-        {userList && !userList.length && <div className={classNames(classes.usersOnlineList, classes.noUsers)}> 
+        {userList && !userList.length && <div className={classNames(classes.usersOnlineList, classes.noUsers)}>
           <FiberManualRecordIcon className={classNames(classes.onlineDot, classes.greyDot)}/> No users currently online. Check back later or be the first to join!
           {tooltip}
         </div>}

--- a/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsAndCurated.tsx
@@ -116,7 +116,7 @@ const RecommendationsAndCurated = ({
     const renderContinueReading = currentUser && (continueReading?.length > 0) && !settings.hideContinueReading
 
     return <SingleColumnSection className={classes.section}>
-      {<AnalyticsContext pageSectionContext="Gather Town Welcome">
+      {<AnalyticsContext pageSectionContext="gatherTownWelcome">
         <GatherTown/>
       </AnalyticsContext>}
       <SectionTitle title={<LWTooltip title={recommendationsTooltip} placement="left">
@@ -160,10 +160,10 @@ const RecommendationsAndCurated = ({
             </AnalyticsContext>
           }
           <AnalyticsContext listContext={"curatedPosts"}>
-            <PostsList2 
-              terms={{view:"curated", limit: currentUser ? 3 : 2}} 
-              showLoadMore={false} 
-              hideLastUnread={true} 
+            <PostsList2
+              terms={{view:"curated", limit: currentUser ? 3 : 2}}
+              showLoadMore={false}
+              hideLastUnread={true}
               boxShadow={false}
               curatedIconLeft={true}
             />
@@ -195,7 +195,7 @@ const RecommendationsAndCurated = ({
         </AnalyticsContext>
       </div>}
 
-      
+
 
       {!currentUser?.hideTaggingProgressBar && <AnalyticsContext pageSectionContext="Tag Progress Bar: LW Wiki Import">
         <TagProgressBar/>
@@ -214,7 +214,7 @@ const RecommendationsAndCurated = ({
       </AnalyticsContext> */}
     </SingleColumnSection>
   }
-  
+
   return render();
 }
 


### PR DESCRIPTION
Wraps the <a> tag in an AnalyticsTracker component. Very simple.

Also rename AnalyticsContext to camelCase

