### PR TITLE
Upgrade Typescript to 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "speakingurl": "^9.0.0",
     "tlds": "^1.203.1",
     "turndown": "^4.0.2",
-    "typescript": "^3.7.3",
+    "typescript": "^3.8.3",
     "underscore": "^1.9.1",
     "universal-cookie": "^4.0.2",
     "universal-cookie-express": "^2.2.0",

--- a/packages/lesswrong/client/logging.ts
+++ b/packages/lesswrong/client/logging.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import * as SentryIntegrations from '@sentry/integrations';
 import { addCallback } from '../lib/vulcan-lib';
-import { RouterLocation } from '../lib/vulcan-lib/routes';
+import type { RouterLocation } from '../lib/vulcan-lib/routes';
 import { captureEvent, AnalyticsUtil } from '../lib/analyticsEvents';
 import { browserProperties } from '../lib/utils/browserProperties';
 import { sentryUrlSetting, sentryReleaseSetting, sentryEnvironmentSetting } from '../lib/instanceSettings';

--- a/packages/lesswrong/components/collections/BigCollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/BigCollectionsCard.tsx
@@ -2,7 +2,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { Link } from '../../lib/reactRouterWrapper';
 import Typography from '@material-ui/core/Typography';
-import { CoreReadingCollection } from '../sequences/CoreReading';
+import type { CoreReadingCollection } from '../sequences/CoreReading';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/collections/CollectionsCard.tsx
+++ b/packages/lesswrong/components/collections/CollectionsCard.tsx
@@ -4,7 +4,7 @@ import { Link } from '../../lib/reactRouterWrapper';
 import Typography from '@material-ui/core/Typography';
 import Hidden from '@material-ui/core/Hidden';
 import classNames from 'classnames';
-import { CoreReadingCollection } from '../sequences/CoreReading';
+import type { CoreReadingCollection } from '../sequences/CoreReading';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/comments/CommentsList.tsx
+++ b/packages/lesswrong/components/comments/CommentsList.tsx
@@ -6,7 +6,7 @@ import withGlobalKeydown from '../common/withGlobalKeydown';
 import { Link } from '../../lib/reactRouterWrapper';
 import { TRUNCATION_KARMA_THRESHOLD } from '../../lib/editor/ellipsize'
 import withUser from '../common/withUser';
-import { CommentTreeNode } from '../../lib/utils/unflatten';
+import type { CommentTreeNode } from '../../lib/utils/unflatten';
 
 const styles = (theme: ThemeType): JssStyles => ({
   button: {

--- a/packages/lesswrong/components/comments/CommentsListSection.tsx
+++ b/packages/lesswrong/components/comments/CommentsListSection.tsx
@@ -10,7 +10,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
 import withUser from '../common/withUser';
-import { CommentTreeNode } from '../../lib/utils/unflatten';
+import type { CommentTreeNode } from '../../lib/utils/unflatten';
 import classNames from 'classnames';
 
 export const NEW_COMMENT_MARGIN_BOTTOM = "1.3em"

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -6,7 +6,7 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import withUser from '../common/withUser';
 import { shallowEqual, shallowEqualExcept } from '../../lib/utils/componentUtils';
 import { AnalyticsContext } from "../../lib/analyticsEvents"
-import { CommentTreeNode } from '../../lib/utils/unflatten';
+import type { CommentTreeNode } from '../../lib/utils/unflatten';
 
 const KARMA_COLLAPSE_THRESHOLD = -4;
 const HIGHLIGHT_DURATION = 3

--- a/packages/lesswrong/components/form-components/PostsListEditor.tsx
+++ b/packages/lesswrong/components/form-components/PostsListEditor.tsx
@@ -82,6 +82,8 @@ class PostsListEditor extends Component<any,any> {
     const disabledElements = ['input', 'textarea', 'select', 'option', 'button', 'svg', 'path'];
     if (disabledElements.includes(e.target.tagName.toLowerCase())) {
       return true; // Return true to cancel sorting
+    } else {
+      return false;
     }
   }
 

--- a/packages/lesswrong/components/form-components/SequencesListEditor.tsx
+++ b/packages/lesswrong/components/form-components/SequencesListEditor.tsx
@@ -85,6 +85,8 @@ class SequencesListEditor extends Component<any,any> {
     const disabledElements = ['input', 'textarea', 'select', 'option', 'button', 'svg'];
     if (disabledElements.indexOf(e.target.tagName.toLowerCase()) !== -1) {
       return true; // Return true to cancel sorting
+    } else {
+      return false;
     }
   }
 

--- a/packages/lesswrong/components/form-components/UsersListEditor.tsx
+++ b/packages/lesswrong/components/form-components/UsersListEditor.tsx
@@ -73,6 +73,8 @@ class UsersListEditor extends Component<any> {
     ];
     if (disabledElements.includes(e.target.tagName.toLowerCase())) {
       return true; // Return true to cancel sorting
+    } else {
+      return false;
     }
   }
 

--- a/packages/lesswrong/components/tagging/ChangeMetricsDisplay.tsx
+++ b/packages/lesswrong/components/tagging/ChangeMetricsDisplay.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { registerComponent } from '../../lib/vulcan-lib';
-import { ChangeMetrics } from '../../lib/collections/revisions/collection';
+import type { ChangeMetrics } from '../../lib/collections/revisions/collection';
 
 const styles = (theme: ThemeType): JssStyles => ({
   charsAdded: {

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { FilterMode } from '../../lib/filterSettings';
+import type { FilterMode } from '../../lib/filterSettings';
 import classNames from 'classnames';
 import { useHover } from '../common/withHover';
 import { useSingle } from '../../lib/crud/withSingle';

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { FilterSettings, FilterTag, FilterMode } from '../../lib/filterSettings';
+import type { FilterSettings, FilterTag, FilterMode } from '../../lib/filterSettings';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Tags } from '../../lib/collections/tags/collection';
 import * as _ from 'underscore';

--- a/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
+++ b/packages/lesswrong/components/users/KarmaChangeNotifierSettings.tsx
@@ -12,7 +12,7 @@ import withTimezone from '../common/withTimezone';
 import withErrorBoundary from '../common/withErrorBoundary';
 import moment from '../../lib/moment-timezone';
 import { convertTimeOfWeekTimezone } from '../../lib/utils/timeUtil';
-import { KarmaChangeSettingsType } from '../../lib/collections/users/custom_fields';
+import type { KarmaChangeSettingsType } from '../../lib/collections/users/custom_fields';
 import * as _ from 'underscore';
 
 const styles = (theme: ThemeType): JssStyles => ({

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -503,7 +503,7 @@ const computeTotalCost = (votes: vote[]) => {
   return sumBy(votes, ({score}) => sumOf1ToN(score))
 }
 
-function createPostVoteTuples<K extends any,T extends vote> (posts: K[], votes: T[]):[K, T | undefined][] {
+function createPostVoteTuples<K extends HasIdType,T extends vote> (posts: K[], votes: T[]):[K, T | undefined][] {
   return posts.map(post => {
     const voteForPost = votes.find(vote => vote.postId === post._id)
     return [post, voteForPost]

--- a/packages/lesswrong/components/vulcan-accounts/LoginFormInner.tsx
+++ b/packages/lesswrong/components/vulcan-accounts/LoginFormInner.tsx
@@ -970,7 +970,7 @@ export class AccountsLoginFormInner extends TrackerComponent {
 
   showMessage(messageId, type?: any, clearTimeout?: any, field?: any) {
     if (messageId) {
-      this.setState(({ messages = [] }) => {
+      this.setState(({messages = []}: {messages?: Array<any>}) => {
         messages.push({
           message: this.context.intl.formatMessage({id: messageId}) || messageId || "Unknown Error",
           type,

--- a/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
+++ b/packages/lesswrong/lib/collections/databaseMetadata/schema.ts
@@ -1,4 +1,4 @@
-import { SchemaType } from '../../utils/schemaUtils';
+import type { SchemaType } from '../../utils/schemaUtils';
 
 // The databaseMetadata collection is a collection of named, mostly-singleton
 // values. (Currently just databaseId, which is used for ensuring you don't

--- a/packages/lesswrong/lib/collections/legacyData/collection.ts
+++ b/packages/lesswrong/lib/collections/legacyData/collection.ts
@@ -1,6 +1,6 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields, ensureIndex } from '../../collectionUtils'
-import { SchemaType} from '../../utils/schemaUtils'
+import type { SchemaType } from '../../utils/schemaUtils'
 
 const schema: SchemaType<DbLegacyData> = {
   objectId: {

--- a/packages/lesswrong/lib/collections/migrations/collection.ts
+++ b/packages/lesswrong/lib/collections/migrations/collection.ts
@@ -1,6 +1,6 @@
 import { createCollection } from '../../vulcan-lib';
 import { addUniversalFields } from '../../collectionUtils'
-import { SchemaType } from '../../utils/schemaUtils'
+import type { SchemaType } from '../../utils/schemaUtils'
 
 // A collection which records whenever a migration is run, when it started and
 // finished, and whether it succeeded. This can be cross-checked against the

--- a/packages/lesswrong/lib/collections/notifications/schema.ts
+++ b/packages/lesswrong/lib/collections/notifications/schema.ts
@@ -1,6 +1,6 @@
 import Users from '../users/collection';
 import { schemaDefaultValue } from '../../collectionUtils';
-import { SchemaType } from '../../utils/schemaUtils';
+import type { SchemaType } from '../../utils/schemaUtils';
 
 const schema: SchemaType<DbNotification> = {
   userId: {

--- a/packages/lesswrong/lib/collections/petrovDayLaunchs/schema.ts
+++ b/packages/lesswrong/lib/collections/petrovDayLaunchs/schema.ts
@@ -1,4 +1,4 @@
-import { SchemaType } from '../../utils/schemaUtils'
+import type { SchemaType } from '../../utils/schemaUtils'
 
 const schema: SchemaType<DbPetrovDayLaunch> = {
   createdAt: {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -87,7 +87,7 @@ export const sortings = {
  * ~ $lt: before.endOf('day').
  */
 Posts.addDefaultView(terms => {
-  const validFields = _.pick(terms, 'userId', 'meta', 'groupId', 'af','question', 'authorIsUnreviewed');
+  const validFields: any = _.pick(terms, 'userId', 'meta', 'groupId', 'af','question', 'authorIsUnreviewed');
   // Also valid fields: before, after, timeField (select on postedAt), and
   // karmaThreshold (selects on baseScore).
 

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import * as _ from 'underscore';
 import { combineIndexWithDefaultViewIndex, ensureIndex } from '../../collectionUtils';
-import { FilterMode, FilterSettings } from '../../filterSettings';
+import type { FilterMode, FilterSettings } from '../../filterSettings';
 import { forumTypeSetting } from '../../instanceSettings';
 import { defaultScoreModifiers, timeDecayExpr } from '../../scoring';
 import { viewFieldAllowAny, viewFieldNullOrMissing } from '../../vulcan-lib';

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -1,6 +1,6 @@
 import { createCollection, Utils } from '../../vulcan-lib';
 import { addUniversalFields, getDefaultResolvers, getDefaultMutations, schemaDefaultValue } from '../../collectionUtils'
-import { SchemaType } from '../../utils/schemaUtils'
+import type { SchemaType } from '../../utils/schemaUtils'
 import { makeEditable } from '../../editor/make_editable';
 import './fragments'
 import Users from '../../vulcan-users';

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -512,7 +512,6 @@ addFieldsDict(Users, {
   },
 
   bookmarkedPostsMetadata: {
-    type: Array,
     canRead: [Users.owns, 'sunshineRegiment', 'admins'],
     canUpdate: [Users.owns, 'sunshineRegiment', 'admins'],
     optional: true,

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -1,7 +1,7 @@
 import SimpleSchema from 'simpl-schema';
 import { Utils, getCollection } from '../../vulcan-lib';
 import Users from "./collection";
-import { SchemaType } from '../../utils/schemaUtils';
+import type { SchemaType } from '../../utils/schemaUtils';
 import * as _ from 'underscore';
 
 ///////////////////////////////////////

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -1,5 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
-import { FilterTag } from './filterSettings';
+import type { FilterTag } from './filterSettings';
 // We initialize these public settings to make it available on both the client and the server,
 // but they get initialized via separate pathways on the client and on the server
 // Server: See databaseSettings.ts in the server directory

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -3,7 +3,7 @@ import qs from 'qs';
 import React, { useContext } from 'react';
 import { forumTypeSetting } from './instanceSettings';
 import { LocationContext, NavigationContext, ServerRequestStatusContext, SubscribeLocationContext } from './vulcan-core/appContext';
-import { RouterLocation } from './vulcan-lib/routes';
+import type { RouterLocation } from './vulcan-lib/routes';
 
 // Given the props of a component which has withRouter, return the parsed query
 // from the URL.

--- a/packages/lesswrong/lib/vulcan-forms/index.ts
+++ b/packages/lesswrong/lib/vulcan-forms/index.ts
@@ -1,4 +1,3 @@
 import './components';
 
 export * from './utils';
-export { default as FormWrapper } from '../../components/vulcan-forms/FormWrapper';

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -159,7 +159,7 @@ export const createCollection = (options: any): any => {
 
   // ------------------------------------- Parameters -------------------------------- //
 
-  collection.getParameters = (terms = {}, apolloClient, context) => {
+  collection.getParameters = (terms:any = {}, apolloClient, context) => {
     // console.log(terms);
 
     let parameters: any = {

--- a/packages/lesswrong/server/karmaChanges.ts
+++ b/packages/lesswrong/server/karmaChanges.ts
@@ -1,6 +1,6 @@
 import Votes from '../lib/collections/votes/collection';
 import { Tags } from '../lib/collections/tags/collection';
-import { KarmaChangeSettingsType } from '../lib/collections/users/custom_fields';
+import type { KarmaChangeSettingsType } from '../lib/collections/users/custom_fields';
 import moment from '../lib/moment-timezone';
 import htmlToText from 'html-to-text';
 import sumBy from 'lodash/sumBy';

--- a/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-ssr/pageCache.ts
@@ -1,7 +1,7 @@
 import LRU from 'lru-cache';
 import * as _ from 'underscore';
-import { RenderResult } from './renderPage';
-import { CompleteTestGroupAllocation, RelevantTestGroupAllocation } from '../../../lib/abTestImpl';
+import type { RenderResult } from './renderPage';
+import type { CompleteTestGroupAllocation, RelevantTestGroupAllocation } from '../../../lib/abTestImpl';
 import { Globals } from '../../../lib/vulcan-lib';
 
 // Page cache. This applies only to logged-out requests, and exists primarily

--- a/yarn.lock
+++ b/yarn.lock
@@ -9622,10 +9622,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@^3.8.3:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Upgrades Typescript from 3.7.3 to 3.8.3, bringing us in sync with the version Meteor is now using. This version tightens a few things (there's a commit fixing all the relevant type errors), and introduces the "import type ..." syntax, which we now make use of. ("import type" makes it so that importing a type declaration doesn't cause the file to actually get imported at run time, for a small performance boost and potential avoidance of circular-dependency issues.)