### PR TITLE
Walled Garden Portal [WIP]

### DIFF
--- a/packages/lesswrong/components/localGroups/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/localGroups/WalledGardenPortal.tsx
@@ -1,0 +1,88 @@
+import { Typography } from '@material-ui/core';
+import React, { useState } from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { postBodyStyles } from '../../themes/stylePiping';
+import { useCurrentUser } from '../common/withUser';
+import { useLocation } from "../../lib/routeUtil";
+
+const styles = (theme) => ({
+  body: {
+    ...theme.typography.body1,
+    ...postBodyStyles(theme)
+  },
+  iframeStyling: {
+    width: "100%",
+    height: 800,
+    border: "none",
+    // maxWidth: "100vw"
+  }
+})
+
+/* TO DO LIST
+* - link parsing for shared links
+* - query whether host is in Garden
+* - Sidebar: office-hours, create new event, add calendar to own, share invite-link
+*
+* Flows:
+* 1) full member -> page renders normally
+* 2) garden set to open (for weekend): fully open message and renders for all
+* 3) has link: a) event link, event currently running ? render : "sorry, event is over"
+* b) event is personal code, host in garden? render : "sorry, host is not in the garden"
+*
+* */
+
+
+function validateInviteCode(code: string) {
+  return (code.length > 3)
+}
+
+const WalledGardenPortal = ({classes}:{classes:ClassesType}) => {
+  const { query, params: { slug } } = useLocation();
+  const { inviteCode: inviteCodeQuery } = query;
+  const currentUser = useCurrentUser();
+
+  const isSunday =  (new Date()).getDay() === 0;
+  const authorizedToEnter = (currentUser && currentUser.walledGardenInvite) || (inviteCodeQuery && validateInviteCode(inviteCodeQuery)) || isSunday ;
+
+  const [onboarded, setOnboarded] = useState(false);
+  const hasInvite = currentUser?.walledGardenInvite;
+
+  console.log({isSunday, inviteCodeQuery, authorizedToEnter, hasInvite});
+
+  if (!authorizedToEnter) {
+    return <div>The Walled Garden is a private virtual space managed by the LessWrong team. It is closed right now.
+      Please return on Sunday when it is open to everyone. If you have a non-Sunday invite, you may need to log
+      in.</div>
+  } else {
+    return <div>
+      {onboarded
+        ? (<iframe className={classes.iframeStyling} src="https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus"></iframe>)
+        : (<div>
+            <p>Welcome! The Garden is a locus for truthseeking.&nbsp;<br></br>
+              Get curious, go wherever the evidence takes you, be precise with your words, conduct experiments,
+              make bets, plan for your own fallibility, study many sciences and absorb their powers as your own.
+              Blah, blah, blah, this text is bad. Make better text!!<br></br>And, above, all in every motion,
+              figure out what is really actually true.</p>
+            < ul>
+              <li>Headphones</li>
+              <li>Interactions are voluntary</li>
+              <li>Restart to fix problems</li>
+              <li>Respawn</li>
+            </ul>
+            <a onClick={() => setOnboarded(true)}>
+              <b>Enter the Garden</b>
+            </a>
+        </div>)
+      }
+    </div>
+  }
+}
+
+
+const WalledGardenPortalComponent = registerComponent("WalledGardenPortal", WalledGardenPortal, {styles});
+
+declare global {
+  interface ComponentTypes {
+    WalledGardenPortal: typeof WalledGardenPortalComponent
+  }
+}

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -265,6 +265,7 @@ importComponent("AllGroupsPage", () => require('../components/localGroups/AllGro
 importComponent("GroupFormDialog", () => require('../components/localGroups/GroupFormDialog'));
 
 importComponent("WalledGardenHome", () => require('../components/localGroups/WalledGardenHome'));
+importComponent("WalledGardenPortal", () => require('../components/localGroups/WalledGardenPortal'));
 importComponent("GatherTown", () => require('../components/localGroups/GatherTown'));
 
 // comments

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -165,6 +165,7 @@ interface PostsList_contents { // fragment on Revisions
 }
 
 interface PostsListTag extends PostsList { // fragment on Posts
+  readonly tagRelevance: any /*{"definitions":[{}]}*/,
   readonly tagRel: WithVoteTagRel|null,
 }
 
@@ -551,6 +552,13 @@ interface lwEventsAdminPageFragment { // fragment on LWEvents
 interface emailHistoryFragment { // fragment on LWEvents
   readonly _id: string,
   readonly userId: string,
+  readonly name: string,
+  readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
+}
+
+interface gatherTownEventFragment { // fragment on LWEvents
+  readonly _id: string,
+  readonly createdAt: Date,
   readonly name: string,
   readonly properties: any /*{"definitions":[{"blackbox":true}]}*/,
 }
@@ -1170,7 +1178,6 @@ interface UsersEdit extends UsersProfile { // fragment on Users
   readonly hideFrontpageMap: boolean,
   readonly hideTaggingProgressBar: boolean,
   readonly deleted: boolean,
-  readonly hideWalledGardenUI: boolean,
 }
 
 interface unclaimedReportsList { // fragment on Reports
@@ -1426,6 +1433,17 @@ interface TagRelHistoryFragment extends TagRelBasicInfo { // fragment on TagRels
   readonly createdAt: Date,
   readonly user: UsersMinimumInfo|null,
   readonly post: PostsList|null,
+}
+
+interface TagRelCreationFragment extends TagRelBasicInfo { // fragment on TagRels
+  readonly tag: TagPreviewFragment|null,
+  readonly post: TagRelCreationFragment_post|null,
+  readonly currentUserVotes: Array<VoteFragment>,
+}
+
+interface TagRelCreationFragment_post extends PostsList { // fragment on Posts
+  readonly tagRelevance: any /*{"definitions":[{}]}*/,
+  readonly tagRel: WithVoteTagRel|null,
 }
 
 interface TagRelMinimumFragment extends TagRelBasicInfo { // fragment on TagRels
@@ -1724,6 +1742,7 @@ interface FragmentTypes {
   LWEventsDefaultFragment: LWEventsDefaultFragment
   lwEventsAdminPageFragment: lwEventsAdminPageFragment
   emailHistoryFragment: emailHistoryFragment
+  gatherTownEventFragment: gatherTownEventFragment
   TagFlagFragment: TagFlagFragment
   TagFlagEditFragment: TagFlagEditFragment
   TagFlagsDefaultFragment: TagFlagsDefaultFragment
@@ -1785,6 +1804,7 @@ interface FragmentTypes {
   TagRelBasicInfo: TagRelBasicInfo
   TagRelFragment: TagRelFragment
   TagRelHistoryFragment: TagRelHistoryFragment
+  TagRelCreationFragment: TagRelCreationFragment
   TagRelMinimumFragment: TagRelMinimumFragment
   WithVoteTagRel: WithVoteTagRel
   TagBasicInfo: TagBasicInfo

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -8,6 +8,7 @@ const rationalitySubtitle = { subtitleLink: "/rationality", subtitle: "Rationali
 const hpmorSubtitle = { subtitleLink: "/hpmor", subtitle: "HPMoR" };
 const codexSubtitle = { subtitleLink: "/codex", subtitle: "SlateStarCodex" };
 const metaSubtitle = { subtitleLink: "/meta", subtitle: "Meta" };
+const walledGardenPortalSubtitle = { subtitleLink: '/walledGardenPortal', subtitle: "Walled Garden"};
 
 const aboutPostIdSetting = new PublicInstanceSetting<string>('aboutPostId', 'bJ2haLkcGeLtTWaD5', "warning") // Post ID for the /about route
 const contactPostIdSetting = new PublicInstanceSetting<string | null>('contactPostId', null, "optional")
@@ -360,6 +361,13 @@ if (forumTypeSetting.get() === 'LessWrong') {
       path: '/walledGarden',
       componentName: 'WalledGardenHome',
       title: "Walled Garden",
+    },
+    {
+      name: 'Walled Garden Portal',
+      path: '/walledGardenPortal',
+      componentName: 'WalledGardenPortal',
+      title: "Walled Garden Portal",
+      ...walledGardenPortalSubtitle
     },
     {
       name: 'HPMOR.posts.single',


### PR DESCRIPTION
This PR introduces a new Walled Garden Portal page that embeds GT in an iframe, thereby masking the URL

- users with GardenInvite are passed through
- users with valid invite url are passed through (currently any code longer than 3 characters is valid, e.g `?inviteCode=aaaa`
- on Sundays, all users are passed through

Before the iframe renders, authorized users are shown some text and a "click to enter" button.

If unauthorized, a simple message is shown.