### PR TITLE
Only default filter tags are unremovable

### DIFF
--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -167,7 +167,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
 
               onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}
             />
-            {canRemove && !tag?.core &&
+            {canRemove && !tag?.suggestedAsFilter &&
               <div className={classes.removeLabel} onClick={ev => {if (onRemove) onRemove()}}>
                 <LWTooltip title={<div><div>This filter will no longer appear in Latest Posts.</div><div>You can add it back later if you want</div></div>}>
                   <a>Remove</a>


### PR DESCRIPTION
Pursuant to a [discussion](https://cea-core.slack.com/archives/CJZ7QMY5V/p1603374484065300) on slack:

Since suggestedAsFilter can diverge from core tags, just have suggestedAsFilter be the ones that aren't removable