### PR TITLE
[Hotfix] Fix broken GatherTown link in front page widget

### DIFF
--- a/packages/lesswrong/components/localGroups/GatherTown.tsx
+++ b/packages/lesswrong/components/localGroups/GatherTown.tsx
@@ -157,7 +157,7 @@ const GatherTown = ({classes}: {
       <div className={classes.icon}>{gatherIcon} </div>
       <div>
         <AnalyticsTracker eventType="link" eventProps={{to: gatherTownURL}} captureOnMount>
-          <div><Link to={gatherTownURL}>Walled Garden Beta</Link></div>
+          <div><a href={gatherTownURL}>Walled Garden Beta</a></div>
         </AnalyticsTracker>
         <div className={classes.secondaryInfo}>
           <div>


### PR DESCRIPTION
Fix the GatherTown link in the front page widget. This happens because the `Link` component only works with on-site URLs; given an absolute URL it improperly treats it as relative.