### PR TITLE
gatherTownCron: Fix duplicate users when names change during check

### DIFF
--- a/packages/lesswrong/server/gatherTownCron.ts
+++ b/packages/lesswrong/server/gatherTownCron.ts
@@ -1,5 +1,5 @@
 import { addCronJob } from './cronUtil';
-import { createMutator, Globals } from './vulcan-lib';
+import { createMutator } from './vulcan-lib';
 import { LWEvents } from '../lib/collections/lwevents/collection';
 import fetch from 'node-fetch';
 import WebSocket from 'ws';


### PR DESCRIPTION
Tested by: adding `getGatherTownUsers` to `Globals` and calling it from a `meteor shell`, while typing in the GatherTown username box in another window.