### PR TITLE
Various Garden Portal Improvements

### DIFF
--- a/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
@@ -10,7 +10,8 @@ const styles = (theme) => ({
     width: `calc(100% + ${gatherTownLeftMenuWidth}px)`,
     height: "100%",
     border: "none",
-    marginLeft: -gatherTownLeftMenuWidth
+    marginLeft: -gatherTownLeftMenuWidth,
+    flex: 4
   },
 })
 
@@ -21,7 +22,7 @@ const GatherTownIframeWrapper = ({iframeRef, classes}) => {
 
   useEffect(() => {
     iframeRef.current.focus()
-  }, [iframeRef])
+  }, [iframeRef, iframeRef.current])
 
   return <iframe className={classes.iframePositioning} ref={iframeRef} src={gatherTownURL} allow={`camera ${gatherTownURL}; microphone ${gatherTownURL}`}></iframe>
 }

--- a/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
@@ -11,7 +11,7 @@ const styles = (theme) => ({
     height: "100%",
     border: "none",
     marginLeft: -gatherTownLeftMenuWidth,
-    flex: 4
+    flex: 7
   },
 })
 

--- a/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
@@ -22,7 +22,7 @@ const GatherTownIframeWrapper = ({iframeRef, classes}) => {
 
   useEffect(() => {
     iframeRef.current.focus()
-  }, [iframeRef, iframeRef.current])
+  }, [iframeRef])
 
   return <iframe className={classes.iframePositioning} ref={iframeRef} src={gatherTownURL} allow={`camera ${gatherTownURL}; microphone ${gatherTownURL}`}></iframe>
 }

--- a/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
@@ -1,46 +1,28 @@
-import React, { useState } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib';
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import TimerIcon from '@material-ui/icons/Timer';
 
 const styles = (theme) => ({
-  showButton: {
-    paddingTop: 12,
-    paddingBottom: 8,
-    textAlign: "right",
-    cursor: "pointer",
-    "&:hover": {
-      opacity: .5,
-      background: "none"
-    },
+  root: {
+    padding: 16,
+    display: "flex",
+    alignItems: "center"
   },
-  pomodoroTimerIframe: {
-    width: "450px",
-    height: "220px",
-    border: 'none'
-  },
-  hide: {
-    verticalAlign: "top",
-    opacity: .5,
-    padding: 10
+  icon: {
+    color: theme.palette.primary.main,
+    marginRight: 8  
   }
 })
 
 export const PomodoroWidget = ({classes}:{classes:ClassesType}) => {
+  const { LWTooltip } = Components
 
-  const [hidePomodoroTimer, setHidePomodoroTimer] = useState(true)
-
-  return <div>
-    {hidePomodoroTimer && <div>
-      <div className={classes.showButton} onClick={()=> setHidePomodoroTimer(false)}>
-        <i>Show Pomodoro Timer</i>
+  return <LWTooltip title="Open the Garden pomodoro timer in a separate window">
+      <div className={classes.root}>
+        <TimerIcon className={classes.icon} />
+        <a target="_blank" href="https://cuckoo.team/lesswrong">Open Pomodoro Timer</a>
       </div>
-    </div>}
-    { !hidePomodoroTimer && <div>
-      <span className={classes.hide} onClick={()=> setHidePomodoroTimer(true)}>
-        <i>X</i>
-      </span>
-      <iframe className={classes.pomodoroTimerIframe} src={"https://cuckoo.team/lesswrong"}/>
-    </div>}
-  </div>
+    </LWTooltip>
 }
 
 const PomodoroWidgetComponent = registerComponent('PomodoroWidget', PomodoroWidget, {styles});

--- a/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
@@ -20,7 +20,9 @@ export const PomodoroWidget = ({classes}:{classes:ClassesType}) => {
   return <LWTooltip title="Open the Garden pomodoro timer in a separate tab">
       <div className={classes.root}>
         <TimerIcon className={classes.icon} />
-        <a target="_blank" href="https://cuckoo.team/lesswrong">Open Pomodoro Timer</a>
+        <a target="_blank" rel="noopener noreferrer" href="https://cuckoo.team/lesswrong">
+          Open Pomodoro Timer
+        </a>
       </div>
     </LWTooltip>
 }

--- a/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/PomodoroWidget.tsx
@@ -17,7 +17,7 @@ const styles = (theme) => ({
 export const PomodoroWidget = ({classes}:{classes:ClassesType}) => {
   const { LWTooltip } = Components
 
-  return <LWTooltip title="Open the Garden pomodoro timer in a separate window">
+  return <LWTooltip title="Open the Garden pomodoro timer in a separate tab">
       <div className={classes.root}>
         <TimerIcon className={classes.icon} />
         <a target="_blank" href="https://cuckoo.team/lesswrong">Open Pomodoro Timer</a>

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -17,16 +17,23 @@ const styles = (theme) => ({
     textAlign: "right",
     display: "inline-block"
   },
+  tooltip: {
+    whiteSpace: "pre-wrap"
+  }
 })
 
 const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
   const { LWTooltip } = Components
+  const link = <a href={gcalEvent.htmlLink} target="_blank" rel="noopener noreferrer">
+    {gcalEvent.summary}
+  </a>
+  
   return <div className={classes.root}>
-      <LWTooltip title={gcalEvent.description}>
-        <a href={gcalEvent.htmlLink} target="_blank" rel="noopener noreferrer">
-            {gcalEvent.summary}
-        </a>
-      </LWTooltip>
+      {gcalEvent.description ? 
+        <LWTooltip title={<div className={classes.tooltip}>{gcalEvent.description}</div>}>
+          {link}
+        </LWTooltip>
+      : link}
       <span className={classes.eventTime}>
         {moment(new Date(gcalEvent.start.dateTime)).format("ddd h:mma, M/D")}
       </span>

--- a/packages/lesswrong/components/walledGarden/WalledGardenEvents.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenEvents.tsx
@@ -19,7 +19,7 @@ const WalledGardenEvents = ({frontpage=true}) => {
   }, [])
 
 
-  const limit = frontpage ? 2 : 6
+  const limit = frontpage ? 2 : 8
   if (!(events.length > 0)) return null
 
   return <div>

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -11,8 +11,6 @@ import {useUpdate} from "../../lib/crud/withUpdate";
 import Users from "../../lib/vulcan-users";
 import { isMobile } from "../../lib/utils/isMobile";
 
-const gatherTownLeftMenuWidth = 65 // We want to hide this menu, so we apply a negative margin on the iframe
-
 const styles = (theme) => ({
   messageStyling: {
     ...postBodyStyles(theme),

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -27,14 +27,9 @@ const styles = (theme) => ({
     display: 'flex',
     flexDirection: 'column',
   },
-  iframePositioning: {
-    width: `calc(100% + ${gatherTownLeftMenuWidth}px)`,
-    height: "100%",
-    border: "none",
-    marginLeft: -gatherTownLeftMenuWidth
-  },
   portalBarPositioning: {
     width: "100%",
+    flex: 1
   },
 })
 

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
@@ -1,12 +1,9 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { Button, Typography } from "@material-ui/core";
 import {commentBodyStyles } from "../../themes/stylePiping";
-import { useUpdate } from '../../lib/crud/withUpdate';
-import Users from "../../lib/vulcan-users";
 import { useCurrentUser } from '../common/withUser';
 import { CAL_ID } from "./gardenCalendar";
-import moment from "moment"
 
 const widgetStyling = {
   marginLeft: "30px",

--- a/packages/lesswrong/themes/createThemeDefaults.ts
+++ b/packages/lesswrong/themes/createThemeDefaults.ts
@@ -41,11 +41,11 @@ export const zIndexes = {
   header: 1300,
   karmaChangeNotifier: 1400,
   notificationsMenu: 1500,
+  gatherTownIframe: 9999, // 1000001 higher than everything except intercom
   lwPopper: 10000,
   lwPopperTooltip: 10001,
   loginDialog: 10002,
   searchBar: 100000,
-  gatherTownIframe: 1000001, // higher than everything except intercom
   commentBoxPopup: 10000000001, // has to be higher than Intercom,
   // ckEditorToolbar: 10000000002, // has to be higher than commentBoxPopup, (note: the css had to be applied in an scss file, "_editor.scss", but the position is listed here for ease of reference)
   petrovDayButton: 6,


### PR DESCRIPTION
Among other things, changes how the portal/iframe flexbox works so that it works on Firefox. This isn't quite optimal and isn't a strict improvement (it leaves more dead space on large monitors probably). But, I think it's better than status quo. The PortalBar still expands to take up more space when it gets bigger.

Another noteworthy thing: at Ruby's request I made this change:

``` 
 useEffect(() => {
    iframeRef.current.focus()
  }, [iframeRef])
  }, [iframeRef, iframeRef.current])
```

Which aims to fix a focusing issue. I haven't yet tested it or thought through exactly what it does.

![image](https://user-images.githubusercontent.com/3246710/97766152-6e3edd00-1ad2-11eb-9ad8-8b6027ab433a.png)
