### PR TITLE
Fix apollo update query

### DIFF
--- a/packages/lesswrong/client/vulcan-lib/apollo-client/updates.ts
+++ b/packages/lesswrong/client/vulcan-lib/apollo-client/updates.ts
@@ -51,8 +51,13 @@ export const updateInSet = (queryData, document) => {
   const oldDocument = queryData.results.find(item => item._id === document._id);
   const newDocument = { ...oldDocument, ...document };
   const index = queryData.results.findIndex(item => item._id === document._id);
-  const newData = { ...queryData }; // clone
-  newData.results[index] = newDocument;
+  const newData = { 
+    ...queryData,
+    results: {
+      ...queryData.results,
+      [index]: newDocument
+    }
+  }; // clone
   return newData;
 };
 

--- a/packages/lesswrong/client/vulcan-lib/apollo-client/updates.ts
+++ b/packages/lesswrong/client/vulcan-lib/apollo-client/updates.ts
@@ -51,12 +51,11 @@ export const updateInSet = (queryData, document) => {
   const oldDocument = queryData.results.find(item => item._id === document._id);
   const newDocument = { ...oldDocument, ...document };
   const index = queryData.results.findIndex(item => item._id === document._id);
-  const newData = { 
+  const newResults = [...queryData.results];
+  newResults[index] = newDocument;
+  const newData = {
     ...queryData,
-    results: {
-      ...queryData.results,
-      [index]: newDocument
-    }
+    results: newResults
   }; // clone
   return newData;
 };

--- a/packages/lesswrong/lib/crud/cacheUpdates.ts
+++ b/packages/lesswrong/lib/crud/cacheUpdates.ts
@@ -31,9 +31,11 @@ export const updateEachQueryResultOfType = ({ store, typeName, func, document })
     const results = data[multiResolverName]
 
     const updatedResults = func({document, results, parameters, typeName})
-
-    data[multiResolverName] = updatedResults
-    store.writeQuery({query, data, variables})
+    const newData = {
+      ...data,
+      [multiResolverName]: updatedResults
+    }
+    store.writeQuery({query, data: newData, variables})
   })
 }
 
@@ -72,6 +74,9 @@ export const handleCreateMutation = ({ document, results, parameters: { selector
 // Theoretically works for upserts
 export const handleUpdateMutation = ({ document, results, parameters: { selector, options }, typeName }) => {
   if (!document) return results;
+  console.log(selector, document?.title)
+  console.log(selector, document?.title)
+  console.log(Utils.mingoBelongsToSet(document, selector))
   if (Utils.mingoBelongsToSet(document, selector)) {
     // edited document belongs to the list
     if (!Utils.mingoIsInSet(results, document)) {
@@ -84,6 +89,11 @@ export const handleUpdateMutation = ({ document, results, parameters: { selector
     results = Utils.mingoReorderSet(results, options.sort, selector);
   } else {
     // if edited doesn't belong to current list anymore (based on view selector), remove it
+    if (!!selector?.reviewedByUserId) {
+      console.log("Removing document from set:", results)
+      console.log("New set: ", Utils.mingoRemoveFromSet(results, document))
+    }
+    
     results = Utils.mingoRemoveFromSet(results, document);
   }
   return {

--- a/packages/lesswrong/lib/crud/cacheUpdates.ts
+++ b/packages/lesswrong/lib/crud/cacheUpdates.ts
@@ -74,9 +74,6 @@ export const handleCreateMutation = ({ document, results, parameters: { selector
 // Theoretically works for upserts
 export const handleUpdateMutation = ({ document, results, parameters: { selector, options }, typeName }) => {
   if (!document) return results;
-  console.log(selector, document?.title)
-  console.log(selector, document?.title)
-  console.log(Utils.mingoBelongsToSet(document, selector))
   if (Utils.mingoBelongsToSet(document, selector)) {
     // edited document belongs to the list
     if (!Utils.mingoIsInSet(results, document)) {
@@ -89,11 +86,6 @@ export const handleUpdateMutation = ({ document, results, parameters: { selector
     results = Utils.mingoReorderSet(results, options.sort, selector);
   } else {
     // if edited doesn't belong to current list anymore (based on view selector), remove it
-    if (!!selector?.reviewedByUserId) {
-      console.log("Removing document from set:", results)
-      console.log("New set: ", Utils.mingoRemoveFromSet(results, document))
-    }
-    
     results = Utils.mingoRemoveFromSet(results, document);
   }
   return {


### PR DESCRIPTION
Looks like Apollo, in the shift from 2 to 3, made the data object in the cache immutable, which is an eminently sensible choice, though I wish javascript had some kind of runtime warning about trying to modify frozen objects. This makes it so that we copy the relevant data array. Since we are only doing one level of copying, I think we shouldn't run into any reference stability issues, but might be worth double-checking.