### PR TITLE
Fix a function renaming that was missed because it had an @ts-ignore on it due to argument mismatch

### DIFF
--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -4,7 +4,7 @@ import {useNewEvents} from '../../../lib/events/withNewEvents';
 import { useCurrentUser } from '../../common/withUser';
 import { truncatise } from '../../../lib/truncatise';
 import Edit from '@material-ui/icons/Edit';
-import Users from '../../../lib/collections/users/collection';
+import { userCanModeratePost } from '../../../lib/collections/users/helpers';
 import { Posts } from '../../../lib/collections/posts/collection';
 import { useSingle } from '../../../lib/crud/withSingle';
 import Tooltip from '@material-ui/core/Tooltip';

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -144,7 +144,7 @@ const ModerationGuidelinesBox = ({classes, post}: {
         // reasonable to include in fragments, so on non-post pages the edit button
         // may be missing from moderation guidelines.
         // @ts-ignore
-        Users.canModeratePost(currentUser, post) &&
+        userCanModeratePost(currentUser, post) &&
         <span onClick={openEditDialog}>
           <Tooltip title="Edit moderation guidelines">
             <Edit className={classes.editButton} />


### PR DESCRIPTION
Also went through all the @ts-ignores in the codebase; no others seemed to matter in this way.
