### PR TITLE
Update EA Forum links 

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/TabNavigationItem.tsx
@@ -69,11 +69,18 @@ const TabNavigationItem = ({tab, onClick, classes}) => {
   // but its material-ui-provided type signature does not include this feature.
   // Case to any to work around it, to be able to pass a "to" parameter.
   const MenuItemUntyped = MenuItem as any;
+  
+  // React router links don't handle external URLs, so use a
+  // normal HTML a tag if the URL is external
+  const externalLink = /https?:\/\//.test(tab.link);
+  const Element = externalLink ? 
+    ({to, ...rest}) => <a href={to} target="_blank" rel="noopener noreferrer" {...rest} />
+    : Link;
 
   return <LWTooltip placement='right-start' title={tab.tooltip || ''} clickable={false}>
     <MenuItemUntyped
       onClick={onClick}
-      component={Link} to={tab.link}
+      component={Element} to={tab.link}
       disableGutters
       classes={{root: classNames({
         [classes.navButton]: !tab.subItem,

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -246,14 +246,6 @@ export default {
       showOnMobileStandalone: true,
       showOnCompressed: true,
     }, {
-      id: 'community',
-      title: 'Community',
-      link: '/tag/community',
-      iconComponent: Group,
-      tooltip: 'Read posts about EA philosophy, the EA community, and the Forum itself.',
-      showOnMobileStandalone: true,
-      showOnCompressed: true,
-    }, {
       id: 'allPosts',
       title: 'All Posts',
       link: '/allPosts',

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -13,7 +13,8 @@ import Home from '@material-ui/icons/Home'
 import Group from '@material-ui/icons/Group'
 import LocalOffer from '@material-ui/icons/LocalOffer';
 import Sort from '@material-ui/icons/Sort'
-import Info from '@material-ui/icons/Info'
+import Info from '@material-ui/icons/Info';
+import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
 
 const EventsList = ({currentUser, onClick}) => {
@@ -269,6 +270,15 @@ export default {
       tooltip: 'See posts tagged by their subject matter',
       showOnMobileStandalone: true,
       showOnCompressed: true,
+    }, {
+      id: 'groups',
+      title: 'EA Groups',
+      mobileTitle: 'EA Groups',
+      link: 'https://www.eahub.org/groups',
+      iconComponent: SupervisedUserCircleIcon,
+      tooltip: 'See EA groups in your area',
+      showOnMobileStandalone: true,
+      showOnCompressed: true
     }, {
       id: 'divider',
       divider: true,

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -10,7 +10,6 @@ import { allPostsIcon } from '../../icons/allPostsIcon';
 
 
 import Home from '@material-ui/icons/Home'
-import Group from '@material-ui/icons/Group'
 import LocalOffer from '@material-ui/icons/LocalOffer';
 import Sort from '@material-ui/icons/Sort'
 import Info from '@material-ui/icons/Info';


### PR DESCRIPTION
The only UX change is on the EA Forum side, but this adds an ability for `HashLink`s to be external, which is shared functionality.