### PR TITLE
[HOTFIX] Add technical guidance to Portal Onboarding Page + Slight Code Clean of Link Parsing

### DIFF
--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -23,9 +23,10 @@ const styles = (theme) => ({
   }
 })
 
+const UrlClass = getUrlClass()
+
 const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
   const { LWTooltip } = Components
-  const UrlClass = getUrlClass()
 
   const url = new UrlClass(gcalEvent.htmlLink)
   const eid = url.searchParams.get("eid")

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import moment from 'moment';
-import {registerComponent, Components, Utils} from '../../lib/vulcan-lib';
-import { getUrlClass, withNavigation } from '../../lib/routeUtil';
+import {registerComponent, Components } from '../../lib/vulcan-lib';
+import { getUrlClass } from '../../lib/routeUtil';
 
 const styles = (theme) => ({
   root: {

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import moment from 'moment';
-import { registerComponent, Components } from '../../lib/vulcan-lib';
+import {registerComponent, Components, Utils} from '../../lib/vulcan-lib';
+import { getUrlClass, withNavigation } from '../../lib/routeUtil';
 
 const styles = (theme) => ({
   root: {
@@ -24,8 +25,10 @@ const styles = (theme) => ({
 
 const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
   const { LWTooltip } = Components
+  const UrlClass = getUrlClass()
 
-  const urlParams = new URLSearchParams(gcalEvent.htmlLink.split('?')[1])
+  const url = new UrlClass(gcalEvent.htmlLink)
+  const urlParams = new URLSearchParams(url.search)
   const eid = urlParams.get("eid")
   const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${gcalEvent.organizer.email}`
   const link = <a href={addToCalendarLink} target="_blank" rel="noopener noreferrer">

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -28,8 +28,7 @@ const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
   const UrlClass = getUrlClass()
 
   const url = new UrlClass(gcalEvent.htmlLink)
-  const urlParams = new URLSearchParams(url.search)
-  const eid = urlParams.get("eid")
+  const eid = url.searchParams.get("eid")
   const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${gcalEvent.organizer.email}`
   const link = <a href={addToCalendarLink} target="_blank" rel="noopener noreferrer">
     {gcalEvent.summary}

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -155,7 +155,9 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
       <p>Here you can socialize, co-work, play games, and attend events. The Garden is open to everyone on Sundays from 12pm to 4pm PT. Otherwise, it is open by invite only.</p>
       <ul>
         <li>Please wear headphones, preferably with a microphone! Try to be in a low-background noise environment.</li>
-        <li>Technical Problems? Refresh the tab.</li>
+        <li>Ensure you grant access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click within your URL bar.</li>
+        <li>The Garden will not load from an incognito window or if 3rd-party cookies are blocked. (It is built on a 3rd-party platform.)</li>
+        <li>Technical Problems once you're in the Garden? Refresh the tab.</li>
         <li>Lost or stuck? Respawn (<i>gear icon</i> &gt; <i>respawn</i>)</li>
         <li>Interactions are voluntary. It's okay to leave conversations.</li>
         <li>Please report any issues, both technical and social, to the LessWrong team via Intercom (bottom right) or
@@ -183,7 +185,7 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
 
   return <div className={classes.innerPortalPositioning}>
     <div className={classes.iframeWrapper}>
-      {hideBar ? 
+      {hideBar ?
         <div className={classes.toggleEvents} onClick={() => setHideBar(false)}>
           <ExpandLessIcon className={classes.closeIcon}/>
           Show Footer

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -155,7 +155,7 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
       <p>Here you can socialize, co-work, play games, and attend events. The Garden is open to everyone on Sundays from 12pm to 4pm PT. Otherwise, it is open by invite only.</p>
       <ul>
         <li>Please wear headphones, preferably with a microphone! Try to be in a low-background noise environment.</li>
-        <li>Ensure you grant access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click within your URL bar.</li>
+        <li>Ensure you grant the page access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click an icon within your URL bar.</li>
         <li>The Garden will not load from an incognito window or if 3rd-party cookies are blocked. (It is built on a 3rd-party platform.)</li>
         <li>Technical Problems once you're in the Garden? Refresh the tab.</li>
         <li>Lost or stuck? Respawn (<i>gear icon</i> &gt; <i>respawn</i>)</li>


### PR DESCRIPTION
What the title says. Regarding the URL parsing. The URL object returned does not have a URLParams field (empty) so I still had to use `new URLParams`

![image](https://user-images.githubusercontent.com/7250541/98424960-5de5af80-2048-11eb-92a6-b66451554b12.png)
