### PR TITLE
Garden event description formatting

### DIFF
--- a/packages/lesswrong/components/walledGarden/FrontpageGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/FrontpageGcalEventItem.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import moment from 'moment';
 import { registerComponent } from '../../lib/vulcan-lib';
+import { getAddToCalendarLink } from './PortalBarGcalEventItem'
 
 const styles = (theme) => ({
-  secondaryInfo: {
+  root: {
     ...theme.typography.commentStyle,
     fontSize: '1rem',
     color: 'rgba(0,0,0,0.55)'
@@ -14,11 +15,10 @@ const styles = (theme) => ({
   },
 })
 
-const FrontpageGcalEventItem = ({classes, gcalEvent}) => {
-  return <div className={classes.secondaryInfo}>
-    <span>
-          {gcalEvent.summary}{" "}
-          <span className={classes.eventTime}>{moment(new Date(gcalEvent.start.dateTime)).calendar()}</span>
+const FrontpageGcalEventItem = ({classes, gcalEvent}) => {  
+  return <div className={classes.root}>
+    {getAddToCalendarLink(gcalEvent)} <span className={classes.eventTime}>
+      {moment(new Date(gcalEvent.start.dateTime)).calendar()}
     </span>
   </div>
 }

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import moment from 'moment';
 import {registerComponent, Components } from '../../lib/vulcan-lib';
 import { getUrlClass } from '../../lib/routeUtil';
+import { sanitize } from '../vulcan-lib/utils';
 
 const styles = (theme) => ({
   root: {
@@ -32,8 +33,10 @@ export const getAddToCalendarLink = (gcalEvent) => {
     {gcalEvent.summary}
   </a>
 
+  const sanitizedDescription = sanitize(gcalEvent.description)
+
   if (gcalEvent.description) {
-    return <LWTooltip title={<div dangerouslySetInnerHTML={{__html:gcalEvent.description}}/>}>
+    return <LWTooltip title={<div dangerouslySetInnerHTML={{__html: sanitizedDescription}}/>}>
       {link}
     </LWTooltip>
   } else {

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -17,17 +17,14 @@ const styles = (theme) => ({
     width: 120,
     textAlign: "right",
     display: "inline-block"
-  },
-  tooltip: {
-    whiteSpace: "pre-wrap"
   }
 })
 
-const UrlClass = getUrlClass()
 
-const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
+export const getAddToCalendarLink = (gcalEvent) => {
   const { LWTooltip } = Components
-
+  
+  const UrlClass = getUrlClass()
   const url = new UrlClass(gcalEvent.htmlLink)
   const eid = url.searchParams.get("eid")
   const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${gcalEvent.organizer.email}`
@@ -35,12 +32,19 @@ const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
     {gcalEvent.summary}
   </a>
 
+  if (gcalEvent.description) {
+    return <LWTooltip title={<div dangerouslySetInnerHTML={{__html:gcalEvent.description}}/>}>
+      {link}
+    </LWTooltip>
+  } else {
+    return link
+  }
+}
+
+const PortalBarGcalEventItem = ({classes, gcalEvent}) => {
+
   return <div className={classes.root}>
-      {gcalEvent.description ?
-        <LWTooltip title={<div className={classes.tooltip}>{gcalEvent.description}</div>}>
-          {link}
-        </LWTooltip>
-      : link}
+      {getAddToCalendarLink(gcalEvent)}
       <span className={classes.eventTime}>
         {moment(new Date(gcalEvent.start.dateTime)).format("ddd h:mma, M/D")}
       </span>

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import moment from 'moment';
 import {registerComponent, Components } from '../../lib/vulcan-lib';
 import { getUrlClass } from '../../lib/routeUtil';
-import { sanitize } from '../../lib/vulcan-lib/utils';
 
 const styles = (theme) => ({
   root: {
@@ -27,16 +26,16 @@ export const getAddToCalendarLink = (gcalEvent) => {
   
   const UrlClass = getUrlClass()
   const url = new UrlClass(gcalEvent.htmlLink)
-  const eid = sanitize(url.searchParams.get("eid"))
-  const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${sanitize(gcalEvent.organizer.email)}`
+  const eid = url.searchParams.get("eid")
+  const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${gcalEvent.organizer.email}`
   const link = <a href={addToCalendarLink} target="_blank" rel="noopener noreferrer">
     {gcalEvent.summary}
   </a>
 
-  const sanitizedDescription = sanitize(gcalEvent.description)
+  const noHtmlDescription = gcalEvent.description ? gcalEvent.description.replace(/<[^>]*>?/gm, '') : ""
 
   if (gcalEvent.description) {
-    return <LWTooltip title={<div dangerouslySetInnerHTML={{__html: sanitizedDescription}}/>}>
+    return <LWTooltip title={<div style={{whiteSpace: "pre-wrap"}}>{noHtmlDescription}</div>}>
       {link}
     </LWTooltip>
   } else {

--- a/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
+++ b/packages/lesswrong/components/walledGarden/PortalBarGcalEventItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import moment from 'moment';
 import {registerComponent, Components } from '../../lib/vulcan-lib';
 import { getUrlClass } from '../../lib/routeUtil';
-import { sanitize } from '../vulcan-lib/utils';
+import { sanitize } from '../../lib/vulcan-lib/utils';
 
 const styles = (theme) => ({
   root: {
@@ -27,8 +27,8 @@ export const getAddToCalendarLink = (gcalEvent) => {
   
   const UrlClass = getUrlClass()
   const url = new UrlClass(gcalEvent.htmlLink)
-  const eid = url.searchParams.get("eid")
-  const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${gcalEvent.organizer.email}`
+  const eid = sanitize(url.searchParams.get("eid"))
+  const addToCalendarLink = `https://calendar.google.com/event?action=TEMPLATE&tmeid=${eid}&tmsrc=${sanitize(gcalEvent.organizer.email)}`
   const link = <a href={addToCalendarLink} target="_blank" rel="noopener noreferrer">
     {gcalEvent.summary}
   </a>


### PR DESCRIPTION
The google calendar event descriptions were actually HTML, not plain text, and needed to be formatted as such. This PR does that and also makes the frontpage events have hover-over-descriptions.