### PR TITLE
Hide tiny green circle within spoilers.

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -4,7 +4,7 @@ import isPlainObject from 'is-plain-object';
 const hideSpoilers = {
   backgroundColor: 'black',
   color: 'black',
-  '& a, & a:hover, & a:focus': {
+  '& a, & a:hover, & a:focus, & a::after': {
     color: 'black'
   },
   '& code': {


### PR DESCRIPTION
Hide tiny green circle from `PostLinkPreviewWithPost-link` link elements within spoilers.


