### PR TITLE
Fix fetch policy for new comments wrapper

### DIFF
--- a/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
+++ b/packages/lesswrong/components/posts/PostsItemNewCommentsWrapper.tsx
@@ -28,7 +28,7 @@ const PostsItemNewCommentsWrapper = ({ terms, classes, title, highlightDate, pos
     terms,
     collection: Comments,
     fragmentName: 'CommentsList',
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'cache-first',
     limit: 5,
   });
   const { Loading, CommentsList, NoContent } = Components


### PR DESCRIPTION
This makes it so that when you expand the comments in a PostsItem, it doesn't refresh, causing all the comments to be collapsed. I really don't know why it had this fetch-policy in the first place, and couldn't break it after playing around for a bit, so I am pretty sure this is fine.