### PR TITLE
Prevent pixel-offset rendering artifacts in Elicit Blocks

### DIFF
--- a/packages/lesswrong/components/posts/ElicitBlock.tsx
+++ b/packages/lesswrong/components/posts/ElicitBlock.tsx
@@ -63,6 +63,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   histogramBucket: {
     display: 'flex',
     flexGrow: 1,
+    overflow: 'hidden',
     '&:hover $sliceColoredArea': {
       backgroundColor: "rgba(0,0,0,0.15)"
     },


### PR DESCRIPTION
Makes this: 
![image](https://user-images.githubusercontent.com/9090789/99854942-a5853480-2b3a-11eb-9449-7668e3a3af09.png)


Into this: 
![image](https://user-images.githubusercontent.com/9090789/99854904-930afb00-2b3a-11eb-81fa-e00d222b6081.png)

