### PR TITLE
Fix bug that occasionally broke ToC generation

### DIFF
--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -108,7 +108,7 @@ export function extractTableOfContents(postHTML: string)
 
 function elementToToCText(cheerioTag: CheerioElement) {
   const tagHtml = cheerio(cheerioTag).html();
-  if (!tagHtml) throw Error("Tag does not exist");
+  if (!tagHtml) return null;
   const tagClone = cheerio.load(tagHtml);
   tagClone("style").remove();
   return tagClone.root().text();


### PR DESCRIPTION
Some posts failed to generate tables of contents; these failures were showing up in Sentry. The symptom was that the post wouldn't have a ToC, but would otherwise render fine. Here's an example of a post which had its ToC missing: https://www.lesswrong.com/posts/bZ2w99pEAeAbKnKqo/optimal-exercise . This was caused by incorrect handling of blocks which would be eligible for being treated as headings, but which are empty.