### PR TITLE
Determine darkening of Elicit histogram bucket based on ID rather than display name

### DIFF
--- a/packages/lesswrong/components/posts/ElicitBlock.tsx
+++ b/packages/lesswrong/components/posts/ElicitBlock.tsx
@@ -219,7 +219,7 @@ const ElicitBlock = ({ classes, questionId = "IyWNjzc5P" }: {
     <div className={classes.histogramRoot}>
       {times(10, (bucket) => <div key={bucket} 
         className={classNames(classes.histogramBucket, {
-          [classes.histogramBucketCurrentUser]: roughlyGroupedData[`${bucket*10}`]?.some(({creator}) => currentUser && creator?.displayName === currentUser.displayName)
+          [classes.histogramBucketCurrentUser]: roughlyGroupedData[`${bucket*10}`]?.some(({creator}) => currentUser && creator?.sourceUserId === currentUser._id)
         })}
         onMouseEnter={() => roughlyGroupedData[`${bucket*10}`]?.length && setHideTitle(true)}
         onMouseLeave={() => setHideTitle(false)}


### PR DESCRIPTION
Not sure how to test, but this is copying the same logic from when to darken a slice.

I'm making this PR since Ought wants people to be able to contact us to associate their Elicit account with their LW account, and in testing I discovered that the bucket darkening logic didn't work when a user's LW display name is different from their Elicit display name; the slice darkening still works.