### PR TITLE
Fix the all-posts list staying dim/loading after some settings changes

### DIFF
--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -3,7 +3,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useMulti } from '../../lib/crud/withMulti';
 import Typography from '@material-ui/core/Typography';
 import moment from '../../lib/moment-timezone';
-import { timeframeToTimeBlock } from './timeframeUtils'
+import { timeframeToTimeBlock, TimeframeType } from './timeframeUtils'
 import { useTimezone } from '../common/withTimezone';
 import { QueryLink } from '../../lib/reactRouterWrapper';
 
@@ -57,10 +57,10 @@ const postTypes = [
 
 const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, timeframe, displayShortform=true, classes }: {
   terms: any,
-  timeBlockLoadComplete: any,
+  timeBlockLoadComplete: ()=>void,
   startDate: any,
-  hideIfEmpty: any,
-  timeframe: any,
+  hideIfEmpty: boolean,
+  timeframe: TimeframeType,
   displayShortform: any,
   classes: ClassesType
 }) => {
@@ -78,8 +78,10 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
     if (!loading && timeBlockLoadComplete) {
       timeBlockLoadComplete();
     }
-  }, [loading, timeBlockLoadComplete]);
-  
+  // No dependency list because we want this to be called even when it looks
+  // like nothing has changed, to signal loading is complete
+  });
+
   // Child component needs a way to tell us about the presence of shortforms
   const reportEmptyShortform = useCallback(() => {
     setNoShortform(true);


### PR DESCRIPTION
Fixes https://github.com/LessWrong2/Lesswrong2/issues/3695 .

In `PostsTimeframeList`, `componentDidUpdate` sets a `dim` state when the requested list has changed, and expects one of its children (a `PostsTimeBlock`) to call its `timeBlockLoadComplete` callback to signal that it's done loading. But `PostsTimeBlock` only does this if it either remounted or it actually went into a loading state; if the `PostsTimeBlock` was updated in place and gets results from the cache, it skips the loading state and never invoked the callback.

Fix by removing the dependencies-list from the `useEffect`.