### PR TITLE
Specify character set in RSS feed and static stylesheet

### DIFF
--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -111,7 +111,7 @@ export const serveCommentRSS = async (terms, url?: string) => {
 
 
 addStaticRoute('/feed.xml', async function(params, req, res, next) {
-  res.setHeader('Content-Type', 'application/rss+xml')
+  res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8')
   if (typeof params.query.view === 'undefined') {
     params.query.view = 'rss';
   }

--- a/packages/lesswrong/server/styleGeneration.tsx
+++ b/packages/lesswrong/server/styleGeneration.tsx
@@ -50,7 +50,7 @@ addStaticRoute("/allStyles", ({query}, req, res, next) => {
   if (!expectedHash || expectedHash === stylesheetHash) {
     res.writeHead(200, {
       "Cache-Control": "public, max-age=604800, immutable",
-      "Content-Type": "text/css"
+      "Content-Type": "text/css; charset=utf-8"
     });
     res.end(css);
   } else {


### PR DESCRIPTION
This might fix an issue where, under rare circumstances on Oli's machine, the static stylesheet is interpreted as ISO-8559-1, causing the degree-symbol used to mark hoverable links to be render as mojibake.