### PR TITLE
Shortform container posts default to sorting by newest

### DIFF
--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -67,7 +67,12 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
 }
 
 export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): string => {
-  return (post?.commentSortOrder) || (currentUser?.commentSorting) || "postCommentsTop"
+  if (post?.commentSortOrder) return post.commentSortOrder;
+  if (currentUser?.commentSorting) return currentUser.commentSorting;
+  if (post?.shortform)
+    return "postCommentsNew";
+  else
+    return "postCommentsTop"
 }
 
 export const commentGetKarma = (comment: CommentsList|DbComment): number => {


### PR DESCRIPTION
Shortform container posts default to sorting by newest, rather than by top scoring. Fixes https://github.com/LessWrong2/Lesswrong2/issues/3580 .