### PR TITLE
Fix bookmarking posts un-bookmarking posts that were bookmarked in another tab

### DIFF
--- a/packages/lesswrong/server.js
+++ b/packages/lesswrong/server.js
@@ -61,6 +61,7 @@ import './server/analyticsWriter';
 import './server/debouncer';
 import './server/logging';
 import './server/markAsUnread';
+import './server/bookmarkMutation';
 import './server/rss';
 import './server/akismet';
 import './server/votingCron';

--- a/packages/lesswrong/server/bookmarkMutation.ts
+++ b/packages/lesswrong/server/bookmarkMutation.ts
@@ -1,0 +1,34 @@
+import { addGraphQLMutation, addGraphQLResolvers } from './vulcan-lib';
+import Users from '../lib/collections/users/collection';
+import { updateMutator } from './vulcan-lib/mutators';
+import * as _ from 'underscore';
+
+addGraphQLMutation('setIsBookmarked(postId: String!, isBookmarked: Boolean!): User!');
+addGraphQLResolvers({
+  Mutation: {
+    async setIsBookmarked(root: void, {postId,isBookmarked}: {postId: string, isBookmarked: boolean}, context: ResolverContext) {
+      const {currentUser} = context;
+      if (!currentUser)
+        throw new Error("Log in to use bookmarks");
+      
+      const oldBookmarksList = currentUser.bookmarkedPostsMetadata;
+      const alreadyBookmarked = _.some(oldBookmarksList, bookmark=>bookmark.postId===postId);
+      const newBookmarksList = (isBookmarked
+        ? (alreadyBookmarked ? oldBookmarksList : [...oldBookmarksList, {postId}])
+        : _.reject(oldBookmarksList, bookmark=>bookmark.postId===postId)
+      );
+      
+      await updateMutator({
+        collection: Users,
+        documentId: currentUser._id,
+        set: {bookmarkedPostsMetadata: newBookmarksList},
+        currentUser, context,
+        validate: false,
+      });
+      
+      const updatedUser = Users.findOne(currentUser._id);
+      return updatedUser;
+    }
+  }
+});
+


### PR DESCRIPTION
The `BookMarkButton` component updates the current user's list of bookmarks. Unfortunately, it was doing this by taking the list of bookmarks client-side from the currentUser object, applying the update there, and then setting the whole list of bookmarks to the resulting object. This means that if you open a bunch of posts in new tabs, then bookmark each of them from its own tab, they will overwrite each others' changes, resulting in only the last post being bookmarked at the end.

Fix this by creating a `setIsBookmarked` mutation, which runs server-side so it is at less risk of using a stale user object. It's still theoretically possible to get bookmarking operations to overwrite each other, since this isn't using atomic mongodb operations, but you'd probably have to send the mutation http requests within a few milliseconds of each other.