### PR TITLE
Fix font for recent-discussion-tag

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionTag.tsx
@@ -19,7 +19,8 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   title: {
     ...theme.typography.display2,
-    ...theme.typography.postStyle,
+    ...theme.typography.commentStyle,
+    fontVariant: "small-caps",
     marginTop: 0,
     marginBottom: 8,
     display: "block",


### PR DESCRIPTION
It currently uses the same font as recent-discussion-posts, which makes them hard to tell apart. I think they should probably be even more distinct than this, but this seemed like an incremental improvement.

![image](https://user-images.githubusercontent.com/3246710/100495719-2330dd80-3103-11eb-89eb-a7cfd641959e.png)
