### PR TITLE
Hookify DialogManager and make its context referentially stable, fixing some spurious rerenders

### DIFF
--- a/packages/lesswrong/components/common/withDialog.tsx
+++ b/packages/lesswrong/components/common/withDialog.tsx
@@ -1,8 +1,8 @@
-import React, { PureComponent } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 import { Components } from '../../lib/vulcan-lib';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import { hookToHoc } from '../../lib/hocUtils';
-import { withTracking } from '../../lib/analyticsEvents';
+import { useTracking } from '../../lib/analyticsEvents';
 
 interface OpenDialogContextType {
   openDialog: ({componentName,componentProps}: {componentName: string, componentProps?: Record<string,any>}) => void,
@@ -10,61 +10,47 @@ interface OpenDialogContextType {
 }
 export const OpenDialogContext = React.createContext<OpenDialogContextType|null>(null);
 
-interface DialogManagerComponentProps {
-  captureEvent: any,
+
+export const DialogManager = ({children}: {
   children: React.ReactNode,
-}
-interface DialogManagerComponentState {
-  componentName: string|null,
-  componentProps: any,
-}
-
-class DialogManagerComponent extends PureComponent<DialogManagerComponentProps,DialogManagerComponentState> {
-  state: DialogManagerComponentState = {
-    componentName: null,
-    componentProps: null
-  };
+}) => {
+  const [componentName,setComponentName] = useState<string|null>(null);
+  const [componentProps,setComponentProps] = useState<any>(null);
+  const {captureEvent} = useTracking();
   
-  closeDialog = () => {
-    this.props.captureEvent("dialogBox", {open: false, dialogName: this.state.componentName})
-    this.setState({
-      componentName: null,
-      componentProps: null
-    });
-  }
+  const closeDialog = useCallback(() => {
+    captureEvent("dialogBox", {open: false, dialogName: componentName})
+    setComponentName(null);
+    setComponentProps(null);
+  }, [captureEvent, componentName]);
 
-  render() {
-    const { children, captureEvent } = this.props;
-    const { componentName } = this.state;
-    const ModalComponent = (componentName!==null) ? (Components[componentName as string]) : null;
+  const ModalComponent = (componentName!==null) ? (Components[componentName as string]) : null;
+  
+  const providedContext = useMemo((): OpenDialogContextType => ({
+    openDialog: ({componentName, componentProps}) => {
+      captureEvent("dialogBox", {open: true, dialogName: componentName})
+      setComponentName(componentName);
+      setComponentProps(componentProps);
+    },
+    closeDialog: closeDialog
+  }), [captureEvent, closeDialog]);
 
-    return (
-      <OpenDialogContext.Provider value={{
-        openDialog: ({componentName, componentProps}) => {
-          captureEvent("dialogBox", {open: true, dialogName: componentName})
-          this.setState({
-            componentName: componentName,
-            componentProps: componentProps
-          })
-        },
-        closeDialog: this.closeDialog
-      }}>
-        {children}
+  return (
+    <OpenDialogContext.Provider value={providedContext}>
+      {children}
 
-        {this.state.componentName &&
-          <ClickAwayListener onClickAway={() => this.closeDialog()}>
-            <ModalComponent
-              {...this.state.componentProps}
-              onClose={this.closeDialog}
-            />
-          </ClickAwayListener>
-        }
-      </OpenDialogContext.Provider>
-    );
-  }
+      {componentName &&
+        <ClickAwayListener onClickAway={closeDialog}>
+          <ModalComponent
+            {...componentProps}
+            onClose={closeDialog}
+          />
+        </ClickAwayListener>
+      }
+    </OpenDialogContext.Provider>
+  );
 }
 
-export const DialogManager = withTracking(DialogManagerComponent)
 export const useDialog = (): OpenDialogContextType => {
   const result = React.useContext(OpenDialogContext);
   if (!result) throw new Error("useDialog called but not a descendent of DialogManagerComponent");


### PR DESCRIPTION
This had a significant loading-time performance impact on posts with lots of comments


