### PR TITLE
Fix client-side update of comments

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -248,7 +248,7 @@ export const createCollection = (options: {
         parameters.selector[key] = null;
       } else if (_.isEqual(parameters.selector[key], viewFieldAllowAny)) {
         delete parameters.selector[key];
-      } else if (parameters.selector[key] === null) {
+      } else if (parameters.selector[key] === null || parameters.selector[key] === undefined) {
         //console.log(`Warning: Null key ${key} in query of collection ${collectionName} with view ${terms.view}.`);
         delete parameters.selector[key];
       }


### PR DESCRIPTION
Turns out `Utils.deepExtend` had the accidental undocumented side-effect of deleting keys with the value `undefined`, and we were relying on this for Mingo client-side updates. %@#$%#$@%.