### PR TITLE
Vendor synced-cron

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,7 +226,6 @@ module.exports = {
       "sinon",
       "sinon-chai",
       "chai-enzyme",
-      "meteor/littledata:synced-cron",
       "meteor/meteorhacks:picker"
     ],
     "react": {

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -39,7 +39,6 @@ http@1.4.2
 id-map@1.1.0
 inter-process-messaging@0.1.1
 lesswrong@2.0.0
-littledata:synced-cron@1.5.1
 lmieulet:meteor-coverage@2.0.2
 localstorage@1.2.0
 logging@1.1.20

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "jsdom": "^13.1.0",
     "jsonwebtoken": "^8.5.1",
     "juice": "^7.0.0",
+    "later": "^1.2.0",
     "logrocket": "^1.0.0",
     "lolex": "^3.0.0",
     "lru-cache": "^5.1.1",

--- a/packages/lesswrong/lib/executionEnvironment.ts
+++ b/packages/lesswrong/lib/executionEnvironment.ts
@@ -19,6 +19,8 @@ export const getAbsoluteUrl = (maybeRelativeUrl?: string): string => {
 
 // Like setTimeout, but with fiber handling
 export const runAfterDelay = Meteor.setTimeout;
+// Like clearTimeout, but with fiber handling
+export const clearRunAfterDelay = Meteor.clearTimeout;
 
 // Like setTimeout with 0 timeout, possibly different priority, and fiber handling
 export const deferWithoutDelay = Meteor.defer;

--- a/packages/lesswrong/meteor-imports.d.ts
+++ b/packages/lesswrong/meteor-imports.d.ts
@@ -6,7 +6,6 @@ declare module 'meteor/practicalmeteor:chai';
 declare module 'meteor/webapp';
 declare module 'meteor/server-render';
 declare module 'meteor/meteorhacks:picker';
-declare module 'meteor/littledata:synced-cron';
 declare module 'meteor/mongo';
 declare module 'meteor/ejson';
 declare module 'meteor/check';

--- a/packages/lesswrong/package.js
+++ b/packages/lesswrong/package.js
@@ -35,7 +35,6 @@ Package.onUse( function(api) {
     'mongo',
     'http',
     'meteorhacks:picker@1.0.3',
-    'littledata:synced-cron@1.1.0',
   ]);
   
   // dependencies of vulcan-accounts

--- a/packages/lesswrong/server/cronUtil.ts
+++ b/packages/lesswrong/server/cronUtil.ts
@@ -8,13 +8,29 @@ SyncedCron.options = {
   collectionTTL: 172800
 };
 
-export function addCronJob(options: any)
+export function addCronJob(options: {
+  name: string,
+  interval?: string,
+  cronStyleSchedule?: string,
+  job: ()=>void,
+})
 {
   onStartup(function() {
     if (!isAnyTest) {
       // Defer starting of cronjobs until 20s after server startup
       runAfterDelay(() => {
-        SyncedCron.add(options);
+        SyncedCron.add({
+          name: options.name,
+          schedule: (parser: any) => {
+            if (options.interval)
+              return parser.text(options.interval);
+            else if (options.cronStyleSchedule)
+              return parser.cron(options.cronStyleSchedule);
+            else
+              throw new Error("addCronJob needs a schedule specified");
+          },
+          job: options.job,
+        });
       }, 20000);
     }
   });

--- a/packages/lesswrong/server/cronUtil.ts
+++ b/packages/lesswrong/server/cronUtil.ts
@@ -1,5 +1,5 @@
-import { SyncedCron } from 'meteor/littledata:synced-cron';
 import { isAnyTest, onStartup, runAfterDelay } from '../lib/executionEnvironment';
+import { SyncedCron } from './vendor/synced-cron/synced-cron-server';
 
 SyncedCron.options = {
   log: true,

--- a/packages/lesswrong/server/debouncer.ts
+++ b/packages/lesswrong/server/debouncer.ts
@@ -288,10 +288,8 @@ const testServerSetting = new PublicInstanceSetting<boolean>("testServer", false
 if (!testServerSetting.get()) {
   addCronJob({
     name: "Debounced event handler",
-    schedule(parser: any) {
-      // Once per minute, on the minute
-      return parser.cron('* * * * * *');
-    },
+    // Once per minute, on the minute
+    cronStyleSchedule: '* * * * * *',
     job() {
       void dispatchPendingEvents();
     }

--- a/packages/lesswrong/server/emails/emailCron.ts
+++ b/packages/lesswrong/server/emails/emailCron.ts
@@ -5,9 +5,7 @@ export const releaseEmailBatches = ({now}) => {
 
 addCronJob({
   name: "Hourly notification batch",
-  schedule(parser) {
-    return parser.cron('0 ? * * *');
-  },
+  cronStyleSchedule: '0 ? * * *',
   job() {
     releaseEmailBatches({ now: new Date() });
   }

--- a/packages/lesswrong/server/gatherTownCron.ts
+++ b/packages/lesswrong/server/gatherTownCron.ts
@@ -15,9 +15,7 @@ const gatherTownWebsocketServer = new DatabaseServerSetting<string>("gatherTownW
 if (isProduction) {
   addCronJob({
     name: 'gatherTownGetUsers',
-    schedule(parser) {
-      return parser.text(`every 3 minutes`);
-    },
+    interval: "every 3 minutes",
     job() {
       void pollGatherTownUsers();
     }

--- a/packages/lesswrong/server/posts/cron.ts
+++ b/packages/lesswrong/server/posts/cron.ts
@@ -5,9 +5,7 @@ import * as _ from 'underscore';
 
 addCronJob({
   name: 'checkScheduledPosts',
-  schedule(parser) {
-    return parser.text('every 10 minutes');
-  },
+  interval: 'every 10 minutes',
   job() {
     // fetch all posts tagged as future
     const scheduledPosts = Posts.find({isFuture: true}, {fields: {_id: 1, status: 1, postedAt: 1, userId: 1, title: 1}}).fetch();

--- a/packages/lesswrong/server/rss-integration/cron.ts
+++ b/packages/lesswrong/server/rss-integration/cron.ts
@@ -80,9 +80,7 @@ const runRSSImport = async () => {
 
 addCronJob({
   name: 'addNewRSSPosts',
-  schedule(parser) {
-    return parser.text('every 10 minutes');
-  },
+  interval: 'every 10 minutes',
   job: runRSSImport
 });
 

--- a/packages/lesswrong/server/search/algoliaCron.ts
+++ b/packages/lesswrong/server/search/algoliaCron.ts
@@ -8,9 +8,7 @@ const algoliaAutoSyncIndexesSetting = new DatabasePublicSetting<boolean>('algoli
 if (algoliaAutoSyncIndexesSetting.get()) {
   addCronJob({
     name: 'updateAlgoliaIndex',
-    schedule(parser) {
-      return parser.text('every 24 hours')
-    },
+    interval: 'every 24 hours',
     job: async () => {
       await algoliaExportAll();
       await algoliaCleanAll();

--- a/packages/lesswrong/server/vendor/synced-cron/LICENSE-PercolateStudioSyncedCron
+++ b/packages/lesswrong/server/vendor/synced-cron/LICENSE-PercolateStudioSyncedCron
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Percolate Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/lesswrong/server/vendor/synced-cron/README-PercolateStudioSyncedCron.md
+++ b/packages/lesswrong/server/vendor/synced-cron/README-PercolateStudioSyncedCron.md
@@ -1,0 +1,149 @@
+# littledata:synced-cron
+
+A simple cron system for [Meteor](http://meteor.com). It supports syncronizing jobs between multiple processes. In other words, if you add a job that runs every hour and your deployment consists of multiple app servers, only one of the app servers will execute the job each time (whichever tries first).
+
+## Migrated from percolate:synced-cron littledata:synced-cron
+
+Since the original creator of the project could no longer maintain it, we had to migrate the package to another organisation to allow further maintenance and updates.
+
+To migrate you can simply run
+
+``` sh
+$ meteor remove percolate:synced-cron && meteor add littledata:synced-cron
+```
+
+## Installation
+
+``` sh
+$ meteor add littledata:synced-cron
+```
+
+## API
+
+### Basics
+
+To write a cron job, give it a unique name, a schedule and a function to run like below. SyncedCron uses the fantastic [later.js](http://bunkat.github.io/later/) library behind the scenes. A Later.js `parse` object is passed into the schedule call that gives you a huge amount of flexibility for scheduling your jobs, see the [documentation](http://bunkat.github.io/later/parsers.html#overview).
+
+``` js
+SyncedCron.add({
+  name: 'Crunch some important numbers for the marketing department',
+  schedule: function(parser) {
+    // parser is a later.parse object
+    return parser.text('every 2 hours');
+  },
+  job: function() {
+    var numbersCrunched = CrushSomeNumbers();
+    return numbersCrunched;
+  }
+});
+```
+
+To start processing your jobs, somewhere in your project add:
+
+``` js
+SyncedCron.start();
+```
+
+### Advanced
+
+SyncedCron uses a collection called `cronHistory` to syncronize between processes. This also serves as a useful log of when jobs ran along with their output or error. A sample item looks like:
+
+``` js
+{ _id: 'wdYLPBZp5zzbwdfYj',
+  intendedAt: Sun Apr 13 2014 17:34:00 GMT-0700 (MST),
+  finishedAt: Sun Apr 13 2014 17:34:01 GMT-0700 (MST),
+  name: 'Crunch some important numbers for the marketing department',
+  startedAt: Sun Apr 13 2014 17:34:00 GMT-0700 (MST),
+  result: '1982 numbers crunched'
+}
+```
+
+Call `SyncedCron.nextScheduledAtDate(jobName)` to find the date that the job
+referenced by `jobName` will run next.
+
+Call `SyncedCron.remove(jobName)` to remove and stop running the job referenced by jobName.
+
+Call `SyncedCron.stop()` to remove and stop all jobs.
+
+Call `SyncedCron.pause()` to stop all jobs without removing them.  The existing jobs can be rescheduled (i.e. restarted) with `SyncedCron.start()`.
+
+To schedule a once off (i.e not recurring) event, create a job with a schedule like this `parser.recur().on(date).fullDate();`
+
+### Configuration
+
+You can configure SyncedCron with the `config` method. Defaults are:
+
+``` js
+  SyncedCron.config({
+    // Log job run details to console
+    log: true,
+
+    // Use a custom logger function (defaults to Meteor's logging package)
+    logger: null,
+
+    // Name of collection to use for synchronisation and logging
+    collectionName: 'cronHistory',
+
+    // Default to using localTime
+    utc: false,
+
+    /*
+      TTL in seconds for history records in collection to expire
+      NOTE: Unset to remove expiry but ensure you remove the index from
+      mongo by hand
+
+      ALSO: SyncedCron can't use the `_ensureIndex` command to modify
+      the TTL index. The best way to modify the default value of
+      `collectionTTL` is to remove the index by hand (in the mongo shell
+      run `db.cronHistory.dropIndex({startedAt: 1})`) and re-run your
+      project. SyncedCron will recreate the index with the updated TTL.
+    */
+    collectionTTL: 172800
+  });
+```
+
+### Logging
+
+SyncedCron uses Meteor's `logging` package by default. If you want to use your own logger (for sending to other consumers or similar) you can do so by configuring the `logger` option.
+
+SyncedCron expects a function as `logger`, and will pass arguments to it for you to take action on.
+
+```js
+var MyLogger = function(opts) {
+  console.log('Level', opts.level);
+  console.log('Message', opts.message);
+  console.log('Tag', opts.tag);
+}
+
+SyncedCron.config({
+  logger: MyLogger
+});
+
+SyncedCron.add({ name: 'Test Job', ... });
+SyncedCron.start();
+```
+
+The `opts` object passed to `MyLogger` above includes `level`, `message`, and `tag`.
+
+- `level` will be one of `info`, `warn`, `error`, `debug`.
+- `message` is something like `Scheduled "Test Job" next run @Fri Mar 13 2015 10:15:00 GMT+0100 (CET)`.
+- `tag` will always be `"SyncedCron"` (handy for filtering).
+
+
+## Caveats
+
+Beware, SyncedCron probably won't work as expected on certain shared hosting providers that shutdown app instances when they aren't receiving requests (like Heroku's free dyno tier or Meteor free galaxy).
+
+## Contributing
+
+Write some code. Write some tests. To run the tests, do:
+
+``` sh
+$ meteor test-packages ./
+```
+
+## License
+
+MIT. (c) Percolate Studio, originally designed and built by Zoltan Olah (@zol), now community maintained.
+
+Synced Cron was developed as part of the [Verso](http://versoapp.com) project.

--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.js
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.js
@@ -1,0 +1,351 @@
+// A package for running jobs synchronized across multiple processes
+SyncedCron = {
+  _entries: {},
+  running: false,
+  options: {
+    //Log job run details to console
+    log: true,
+
+    logger: null,
+
+    //Name of collection to use for synchronisation and logging
+    collectionName: 'cronHistory',
+
+    //Default to using localTime
+    utc: false,
+
+    //TTL in seconds for history records in collection to expire
+    //NOTE: Unset to remove expiry but ensure you remove the index from
+    //mongo by hand
+    collectionTTL: 172800
+  },
+  config: function(opts) {
+    this.options = _.extend({}, this.options, opts);
+  }
+}
+
+Later = Npm.require('later');
+
+/*
+  Logger factory function. Takes a prefix string and options object
+  and uses an injected `logger` if provided, else falls back to
+  Meteor's `Log` package.
+
+  Will send a log object to the injected logger, on the following form:
+
+    message: String
+    level: String (info, warn, error, debug)
+    tag: 'SyncedCron'
+*/
+function createLogger(prefix) {
+  check(prefix, String);
+
+  // Return noop if logging is disabled.
+  if(SyncedCron.options.log === false) {
+    return function() {};
+  }
+
+  return function(level, message) {
+    check(level, Match.OneOf('info', 'error', 'warn', 'debug'));
+    check(message, String);
+
+    var logger = SyncedCron.options && SyncedCron.options.logger;
+
+    if(logger && _.isFunction(logger)) {
+
+      logger({
+        level: level,
+        message: message,
+        tag: prefix
+      });
+
+    } else {
+      Log[level]({ message: prefix + ': ' + message });
+    }
+  }
+}
+
+var log;
+
+Meteor.startup(function() {
+  var options = SyncedCron.options;
+
+  log = createLogger('SyncedCron');
+
+  ['info', 'warn', 'error', 'debug'].forEach(function(level) {
+    log[level] = _.partial(log, level);
+  });
+
+  // Don't allow TTL less than 5 minutes so we don't break synchronization
+  var minTTL = 300;
+
+  // Use UTC or localtime for evaluating schedules
+  if (options.utc)
+    Later.date.UTC();
+  else
+    Later.date.localTime();
+
+  // collection holding the job history records
+  SyncedCron._collection = new Mongo.Collection(options.collectionName);
+  SyncedCron._collection._ensureIndex({intendedAt: 1, name: 1}, {unique: true});
+
+  if (options.collectionTTL) {
+    if (options.collectionTTL > minTTL)
+      SyncedCron._collection._ensureIndex({startedAt: 1 },
+        { expireAfterSeconds: options.collectionTTL } );
+    else
+      log.warn('Not going to use a TTL that is shorter than:' + minTTL);
+  }
+});
+
+var scheduleEntry = function(entry) {
+  var schedule = entry.schedule(Later.parse);
+  entry._timer =
+    SyncedCron._laterSetInterval(SyncedCron._entryWrapper(entry), schedule);
+
+  log.info('Scheduled "' + entry.name + '" next run @'
+    + Later.schedule(schedule).next(1));
+}
+
+// add a scheduled job
+// SyncedCron.add({
+//   name: String, //*required* unique name of the job
+//   schedule: function(laterParser) {},//*required* when to run the job
+//   job: function() {}, //*required* the code to run
+// });
+SyncedCron.add = function(entry) {
+  check(entry.name, String);
+  check(entry.schedule, Function);
+  check(entry.job, Function);
+  check(entry.persist, Match.Optional(Boolean));
+
+  if (entry.persist === undefined) {
+    entry.persist = true;
+  }
+
+  // check
+  if (!this._entries[entry.name]) {
+    this._entries[entry.name] = entry;
+
+    // If cron is already running, start directly.
+    if (this.running) {
+      scheduleEntry(entry);
+    }
+  }
+}
+
+// Start processing added jobs
+SyncedCron.start = function() {
+  var self = this;
+
+  Meteor.startup(function() {
+    // Schedule each job with later.js
+    _.each(self._entries, function(entry) {
+      scheduleEntry(entry);
+    });
+    self.running = true;
+  });
+}
+
+// Return the next scheduled date of the first matching entry or undefined
+SyncedCron.nextScheduledAtDate = function(jobName) {
+  var entry = this._entries[jobName];
+
+  if (entry)
+    return Later.schedule(entry.schedule(Later.parse)).next(1);
+}
+
+// Remove and stop the entry referenced by jobName
+SyncedCron.remove = function(jobName) {
+  var entry = this._entries[jobName];
+
+  if (entry) {
+    if (entry._timer)
+      entry._timer.clear();
+
+    delete this._entries[jobName];
+    log.info('Removed "' + entry.name + '"');
+  }
+}
+
+// Pause processing, but do not remove jobs so that the start method will
+// restart existing jobs
+SyncedCron.pause = function() {
+  if (this.running) {
+    _.each(this._entries, function(entry) {
+      entry._timer.clear();
+    });
+    this.running = false;
+  }
+}
+
+// Stop processing and remove ALL jobs
+SyncedCron.stop = function() {
+  _.each(this._entries, function(entry, name) {
+    SyncedCron.remove(name);
+  });
+  this.running = false;
+}
+
+// The meat of our logic. Checks if the specified has already run. If not,
+// records that it's running the job, runs it, and records the output
+SyncedCron._entryWrapper = function(entry) {
+  var self = this;
+
+  return function(intendedAt) {
+    intendedAt = new Date(intendedAt.getTime());
+    intendedAt.setMilliseconds(0);
+
+    var jobHistory;
+
+    if (entry.persist) {
+      jobHistory = {
+        intendedAt: intendedAt,
+        name: entry.name,
+        startedAt: new Date()
+      };
+
+      // If we have a dup key error, another instance has already tried to run
+      // this job.
+      try {
+        jobHistory._id = self._collection.insert(jobHistory);
+      } catch(e) {
+        // http://www.mongodb.org/about/contributors/error-codes/
+        // 11000 == duplicate key error
+        if (e.code === 11000) {
+          log.info('Not running "' + entry.name + '" again.');
+          return;
+        }
+
+        throw e;
+      };
+    }
+
+    // run and record the job
+    try {
+      log.info('Starting "' + entry.name + '".');
+      var output = entry.job(intendedAt,entry.name); // <- Run the actual job
+
+      log.info('Finished "' + entry.name + '".');
+      if(entry.persist) {
+        self._collection.update({_id: jobHistory._id}, {
+          $set: {
+            finishedAt: new Date(),
+            result: output
+          }
+        });
+      }
+    } catch(e) {
+      log.info('Exception "' + entry.name +'" ' + ((e && e.stack) ? e.stack : e));
+      if(entry.persist) {
+        self._collection.update({_id: jobHistory._id}, {
+          $set: {
+            finishedAt: new Date(),
+            error: (e && e.stack) ? e.stack : e
+          }
+        });
+      }
+    }
+  };
+}
+
+// for tests
+SyncedCron._reset = function() {
+  this._entries = {};
+  this._collection.remove({});
+  this.running = false;
+}
+
+// ---------------------------------------------------------------------------
+// The following two functions are lifted from the later.js package, however
+// I've made the following changes:
+// - Use Meteor.setTimeout and Meteor.clearTimeout
+// - Added an 'intendedAt' parameter to the callback fn that specifies the precise
+//   time the callback function *should* be run (so we can co-ordinate jobs)
+//   between multiple, potentially laggy and unsynced machines
+
+// From: https://github.com/bunkat/later/blob/master/src/core/setinterval.js
+SyncedCron._laterSetInterval = function(fn, sched) {
+
+  var t = SyncedCron._laterSetTimeout(scheduleTimeout, sched),
+      done = false;
+
+  /**
+  * Executes the specified function and then sets the timeout for the next
+  * interval.
+  */
+  function scheduleTimeout(intendedAt) {
+    if(!done) {
+      try {
+        fn(intendedAt);
+      } catch(e) {
+        log.info('Exception running scheduled job ' + ((e && e.stack) ? e.stack : e));
+      }
+
+      t = SyncedCron._laterSetTimeout(scheduleTimeout, sched);
+    }
+  }
+
+  return {
+
+    /**
+    * Clears the timeout.
+    */
+    clear: function() {
+      done = true;
+      t.clear();
+    }
+
+  };
+
+};
+
+// From: https://github.com/bunkat/later/blob/master/src/core/settimeout.js
+SyncedCron._laterSetTimeout = function(fn, sched) {
+
+  var s = Later.schedule(sched), t;
+  scheduleTimeout();
+
+  /**
+  * Schedules the timeout to occur. If the next occurrence is greater than the
+  * max supported delay (2147483647 ms) than we delay for that amount before
+  * attempting to schedule the timeout again.
+  */
+  function scheduleTimeout() {
+    var now = Date.now(),
+        next = s.next(2, now);
+
+    // don't schedlue another occurence if no more exist synced-cron#41
+    if (! next[0])
+      return;
+
+    var diff = next[0].getTime() - now,
+        intendedAt = next[0];
+
+    // minimum time to fire is one second, use next occurrence instead
+    if(diff < 1000) {
+      diff = next[1].getTime() - now;
+      intendedAt = next[1];
+    }
+
+    if(diff < 2147483647) {
+      t = Meteor.setTimeout(function() { fn(intendedAt); }, diff);
+    }
+    else {
+      t = Meteor.setTimeout(scheduleTimeout, 2147483647);
+    }
+  }
+
+  return {
+
+    /**
+    * Clears the timeout.
+    */
+    clear: function() {
+      Meteor.clearTimeout(t);
+    }
+
+  };
+
+};
+// ---------------------------------------------------------------------------

--- a/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
+++ b/packages/lesswrong/server/vendor/synced-cron/synced-cron-server.ts
@@ -1,6 +1,7 @@
 import later from 'later';
 import * as _ from 'underscore';
 import { onStartup, runAfterDelay, clearRunAfterDelay } from '../../../lib/executionEnvironment';
+import { Mongo } from 'meteor/mongo';
 
 // A package for running jobs synchronized across multiple processes
 export const SyncedCron: any = {
@@ -59,6 +60,8 @@ function createLogger(prefix: string) {
 
     } else {
       //Log[level]({ message: prefix + ': ' + message });
+      
+      // eslint-disable-next-line no-console
       console.log(prefix + ': ' + message);
     }
   }

--- a/packages/lesswrong/server/votingCron.ts
+++ b/packages/lesswrong/server/votingCron.ts
@@ -9,9 +9,7 @@ import { addCronJob } from './cronUtil';
 
 addCronJob({
   name: 'updateScoreActiveDocuments',
-  schedule(parser) {
-    return parser.text(`every 30 seconds`);
-  },
+  interval: `every 30 seconds`,
   job() {
     VoteableCollections.forEach(collection => {
       void batchUpdateScore({collection});
@@ -20,9 +18,7 @@ addCronJob({
 });
 addCronJob({
   name: 'updateScoreInactiveDocuments',
-  schedule(parser) {
-    return parser.text('every 24 hours');
-  },
+  interval: 'every 24 hours',
   job() {
     VoteableCollections.forEach(collection => {
       void batchUpdateScore({collection, inactive: true});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6275,6 +6275,11 @@ keycode@^2.1.9, keycode@^2.2.0:
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
   integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
 
+later@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/later/-/later-1.2.0.tgz#f2cf6c4dd7956dd2f520adf0329836e9876bad0f"
+  integrity sha1-8s9sTdeVbdL1IK3wMpg26YdrrQ8=
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -6689,12 +6694,7 @@ lodash.without@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-lodash@4.17.15, lodash@>=3.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.2.0:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@4.17.15, lodash@>=3.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
When we leave Meteor, we must be free of Meteor-using libraries. One such library is `synced-cron`, whose source code lives at https://github.com/percolatestudio/meteor-synced-cron and is MIT licensed. Vendored it, making it no longer an external dependency.