### PR TITLE
Tweaks for the 2019 review

### DIFF
--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -72,6 +72,7 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
     collectionName: "Posts",
     fragmentName: 'PostsList',
     enableTotal: true,
+    itemsPerPage: 50,
   });
 
   useEffect(() => {

--- a/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
@@ -136,7 +136,7 @@ const FrontpageReviewPhase = ({classes}) => {
         </LWTooltip>}
       >
         <LWTooltip title="All Posts written in 2019 are eligible to participate in the review. Click here to see all posts written in 2019.">
-          <Link to={"/allPosts?timeframe=yearly&after=2019-01-01&before=2020-01-01&limit=100"}><SettingsButton showIcon={false} label="See All 2019 Posts"/></Link>
+          <Link to={"/allPosts?timeframe=yearly&after=2019-01-01&before=2020-01-01&limit=100&sortedBy=top"}><SettingsButton showIcon={false} label="See All 2019 Posts"/></Link>
         </LWTooltip>
       </SectionTitle>
       <div className={classes.reviewTimeline}>

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -30,6 +30,7 @@ const ShortformTimeBlock  = ({reportEmpty, terms, classes}: {
     fetchPolicy: 'cache-and-network',
     enableTotal: true,
     limit: 5,
+    itemsPerPage: 50,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Make the link to the all-of-2019 list default to sort by top, not magic. Make Load More load more at a time.