### PR TITLE
Wrap material-UI Dialog to avoid breaking CkEditor link toolbar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
       { name: "@material-ui", message: "Don't import all of material-ui/icons" },
       { name: "@material-ui/icons", message: "Don't import all of material-ui/icons" },
       { name: "@material-ui/core/Hidden", message: "Don't use material-UI's Hidden component, it's subtly broken; use breapoints and JSS styles instead" },
+      { name: "@material-ui/core/Dialog", message: "Don't use material-UI's Dialog component directly, use LWDialog instead" },
       { name: "react-router", message: "Don't import react-router, use lib/reactRouterWrapper" },
       { name: "react-router-dom", message: "Don't import react-router-dom, use lib/reactRouterWrapper" },
     ]}],

--- a/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
+++ b/packages/lesswrong/components/alignment-forum/AFApplicationForm.tsx
@@ -1,10 +1,9 @@
 import React, { PureComponent } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
 import { withMessages } from '../common/withMessages';
 import withUser from '../common/withUser'
 import Users from '../../lib/collections/users/collection';
-import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -44,8 +43,9 @@ class AFApplicationForm extends PureComponent<AFApplicationFormProps,AFApplicati
 
   render() {
     const { onClose, classes } = this.props
+    const { LWDialog } = Components;
     return (
-      <Dialog open={true} onClose={onClose}>
+      <LWDialog open={true} onClose={onClose}>
         <DialogTitle>
           AI Alignment Forum Membership Application
         </DialogTitle>
@@ -80,7 +80,7 @@ class AFApplicationForm extends PureComponent<AFApplicationFormProps,AFApplicati
             Submit Application
           </Button>
         </DialogActions>
-      </Dialog>
+      </LWDialog>
     )
   }
 }

--- a/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/comments/CommentActions/DeleteCommentDialog.tsx
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
-import { registerComponent } from '../../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import { withMessages } from '../../common/withMessages';
 import withModerateComment from './withModerateComment'
-import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -62,8 +61,9 @@ class DeleteCommentDialog extends PureComponent<DeleteCommentDialogProps,DeleteC
 
   render() {
     const { onClose, classes } = this.props
+    const { LWDialog } = Components;
     return (
-      <Dialog open={true} onClose={onClose}>
+      <LWDialog open={true} onClose={onClose}>
         <DialogTitle>
           What is your reason for deleting this comment?
         </DialogTitle>
@@ -91,7 +91,7 @@ class DeleteCommentDialog extends PureComponent<DeleteCommentDialogProps,DeleteC
             Delete
           </Button>
         </DialogActions>
-      </Dialog>
+      </LWDialog>
     )
   }
 }

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesEditForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent, getFragment } from '../../../lib/vulcan-lib';
 import { Posts } from '../../../lib/collections/posts'
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
@@ -39,10 +38,9 @@ const ModerationGuidelinesEditForm = ({ postId, onClose, classes }: {
     </div>
   }
   return (
-    <Dialog
+    <Components.LWDialog
       open={true}
       onClose={onClose}
-      disableEnforceFocus
     >
       <DialogTitle>
         Moderation Guidelines Edit Form
@@ -65,7 +63,7 @@ const ModerationGuidelinesEditForm = ({ postId, onClose, classes }: {
           }}
         />
       </DialogContent>
-    </Dialog>
+    </Components.LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/common/DialogGroup.tsx
+++ b/packages/lesswrong/components/common/DialogGroup.tsx
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogActions from '@material-ui/core/DialogActions';
 import Button from '@material-ui/core/Button';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 
 interface DialogGroupProps {
   title?: string,
@@ -36,6 +35,8 @@ class DialogGroup extends Component<DialogGroupProps,DialogGroupState> {
   };
 
   render() {
+    const { LWDialog } = Components;
+    
     //eslint-disable-next-line react/jsx-key
     const actions = this.props.actions.map(action =>
       <span key={action} onClick={this.handleClose}>{action}</span>
@@ -44,14 +45,14 @@ class DialogGroup extends Component<DialogGroupProps,DialogGroupState> {
     return (
       <span className="dialog-trigger-group">
         <span className="dialog-trigger" onClick={this.handleOpen}>{ this.props.trigger }</span>
-        <Dialog
+        <LWDialog
           open={this.state.open}
           onClose={this.handleClose}
         >
           {this.props.title && <DialogTitle>{this.props.title}</DialogTitle>}
           {this.props.children}
           <DialogActions>{actions}</DialogActions>
-        </Dialog>
+        </LWDialog>
       </span>
     );
   }

--- a/packages/lesswrong/components/common/LWDialog.tsx
+++ b/packages/lesswrong/components/common/LWDialog.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { registerComponent } from '../../lib/vulcan-lib/components';
+// eslint-disable-next-line no-restricted-imports
+import Dialog, { DialogProps,DialogClassKey } from '@material-ui/core/Dialog';
+
+// Wrapped to ensure the disableEnforceFocus prop is provided, since not
+// providing that breaks the toolbar in CkEditor and DraftJS. Also provides a
+// centralized place to fix it if we discover other issues with MUI Dialog, or
+// want to write it ourselves.
+const LWDialog = ({children, dialogClasses, ...dialogProps}: {
+  children: React.ReactNode,
+  dialogClasses?: Partial<Record<DialogClassKey,string>>,
+} & DialogProps) => {
+  return (
+    <Dialog
+      disableEnforceFocus
+      classes={dialogClasses}
+      {...dialogProps}
+    >
+      {children}
+    </Dialog>
+  );
+}
+
+const LWDialogComponent = registerComponent('LWDialog', LWDialog);
+
+declare global {
+  interface ComponentTypes {
+    LWDialog: typeof LWDialogComponent
+  }
+}

--- a/packages/lesswrong/components/common/SubscribeDialog.tsx
+++ b/packages/lesswrong/components/common/SubscribeDialog.tsx
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
-import { registerComponent } from '../../lib/vulcan-lib';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
 import { userEmailAddressIsVerified } from '../../lib/collections/users/helpers';
 import { rssTermsToUrl } from "../../lib/rss_urls";
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
@@ -203,6 +202,7 @@ class SubscribeDialog extends Component<SubscribeDialogProps,SubscribeDialogStat
   render() {
     const { classes, fullScreen, onClose, open, currentUser } = this.props;
     const { view, threshold, method, copiedRSSLink, subscribedByEmail } = this.state;
+    const { LWDialog } = Components;
 
     const viewSelector = <FormControl key="viewSelector" className={classes.viewSelector}>
       <InputLabel htmlFor="subscribe-dialog-view">Feed</InputLabel>
@@ -220,7 +220,7 @@ class SubscribeDialog extends Component<SubscribeDialogProps,SubscribeDialogStat
     </FormControl>
 
     return (
-      <Dialog
+      <LWDialog
         fullScreen={fullScreen}
         open={open}
         onClose={onClose}
@@ -315,7 +315,7 @@ class SubscribeDialog extends Component<SubscribeDialogProps,SubscribeDialogStat
           }
           <Button onClick={onClose}>Close</Button>
         </DialogActions>
-      </Dialog>
+      </LWDialog>
     );
   }
 }

--- a/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
+++ b/packages/lesswrong/components/localGroups/EventNotificationsDialog.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { useCurrentUser } from '../common/withUser';
-import Dialog from '@material-ui/core/Dialog';
 import Geosuggest from 'react-geosuggest';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -110,7 +109,7 @@ const EventNotificationsDialog = ({ onClose, classes }: {
   classes: ClassesType,
 }) => {
   const currentUser = useCurrentUser();
-  const { Loading } = Components
+  const { Loading, LWDialog } = Components
   const { nearbyEventsNotificationsLocation, mapLocation, googleLocation, nearbyEventsNotificationsRadius, nearbyPeopleNotificationThreshold } = currentUser || {}
 
   const [ mapsLoaded ] = useGoogleMaps("EventNotificationsDialog")
@@ -133,7 +132,7 @@ const EventNotificationsDialog = ({ onClose, classes }: {
   />
 
   return (
-    <Dialog
+    <LWDialog
       open={true}
       onClose={onClose}
     >
@@ -221,7 +220,7 @@ const EventNotificationsDialog = ({ onClose, classes }: {
           </a>
         </DialogActions>
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
+++ b/packages/lesswrong/components/localGroups/GroupFormDialog.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Localgroups } from '../../lib/index';
 import { useNavigation } from '../../lib/routeUtil'
 import { useCurrentUser } from '../common/withUser';
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
@@ -70,15 +69,14 @@ const GroupFormDialog =  ({ onClose, classes, documentId }: {
   classes: ClassesType,
   documentId: string,
 }) => {
-  const { WrappedSmartForm } = Components
+  const { WrappedSmartForm, LWDialog } = Components
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
   const { history } = useNavigation();
   
-  return <Dialog
+  return <LWDialog
     open={true}
     onClose={onClose}
-    disableEnforceFocus
   >
     <DialogContent className="local-group-form">
       <WrappedSmartForm
@@ -101,7 +99,7 @@ const GroupFormDialog =  ({ onClose, classes, documentId }: {
         }}
       />
     </DialogContent>
-  </Dialog>
+  </LWDialog>
 }
 
 const GroupFormDialogComponent = registerComponent('GroupFormDialog', GroupFormDialog);

--- a/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
+++ b/packages/lesswrong/components/localGroups/SetPersonalMapLocationDialog.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
 import { useCurrentUser } from '../common/withUser';
-import Dialog from '@material-ui/core/Dialog';
 import Geosuggest from 'react-geosuggest';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -26,7 +25,7 @@ const SetPersonalMapLocationDialog = ({ onClose, classes }: {
 }) => {
   const currentUser = useCurrentUser();
   const { mapLocation, googleLocation, mapMarkerText, bio } = currentUser || {}
-  const { Loading } = Components
+  const { Loading, LWDialog } = Components
   
   const [ mapsLoaded ] = useGoogleMaps("SetPersonalMapLocationDialog")
   const [ location, setLocation ] = useState(mapLocation || googleLocation)
@@ -42,7 +41,7 @@ const SetPersonalMapLocationDialog = ({ onClose, classes }: {
     return null;
 
   return (
-    <Dialog
+    <LWDialog
       open={true}
       onClose={onClose}
     >
@@ -88,7 +87,7 @@ const SetPersonalMapLocationDialog = ({ onClose, classes }: {
           </a>
         </DialogActions>
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
+++ b/packages/lesswrong/components/messaging/ConversationTitleEditForm.tsx
@@ -7,7 +7,6 @@ A component to configure the "Edit Title" form.
 import React from 'react';
 import { Components, registerComponent, getFragment } from "../../lib/vulcan-lib";
 import Conversations from '../../lib/collections/conversations/collection';
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
@@ -15,7 +14,7 @@ const ConversationTitleEditForm = ({onClose, documentId}: {
   onClose: ()=>void,
   documentId: string,
 }) =>{
-  return <Dialog open onClose={onClose}>
+  return <Components.LWDialog open onClose={onClose}>
       <DialogTitle>Conversation Options</DialogTitle>
       <DialogContent>
         <Components.WrappedSmartForm
@@ -29,7 +28,7 @@ const ConversationTitleEditForm = ({onClose, documentId}: {
           }}
         />
       </DialogContent>
-    </Dialog>
+    </Components.LWDialog>
 }
 
 const ConversationTitleEditFormComponent = registerComponent('ConversationTitleEditForm', ConversationTitleEditForm);

--- a/packages/lesswrong/components/questions/NewQuestionDialog.tsx
+++ b/packages/lesswrong/components/questions/NewQuestionDialog.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
 import { useMessages } from '../common/withMessages';
 
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 
 import { Posts } from '../../lib/collections/posts/collection'
@@ -27,7 +26,7 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
   const currentUser = useCurrentUser();
   const { flash } = useMessages();
   const { history } = useNavigation();
-  const { PostSubmit, SubmitToFrontpageCheckbox } = Components
+  const { PostSubmit, SubmitToFrontpageCheckbox, LWDialog } = Components
   
   const QuestionSubmit = (props) => {
     return <div className={classes.formSubmit}>
@@ -38,12 +37,11 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
   const af = forumTypeSetting.get() === 'AlignmentForum'
 
   return (
-    <Dialog
+    <LWDialog
       open={true}
       maxWidth={false}
       onClose={onClose}
       fullScreen={fullScreen}
-      disableEnforceFocus
     >
       <DialogContent>
         <Components.WrappedSmartForm
@@ -66,7 +64,7 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
           }}
         />
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/review/NominatePostDialog.tsx
+++ b/packages/lesswrong/components/review/NominatePostDialog.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Typography from '@material-ui/core/Typography';
@@ -40,7 +39,7 @@ const NominatePostDialog = ({classes, post, onClose}: {
   post: PostsBase,
   onClose: ()=>void,
 }) => {
-  const { CommentsNewForm } = Components;
+  const { CommentsNewForm, LWDialog } = Components;
 
   const hintText = <div className={classes.hintText}>
     <p>How has this post been useful to you over the past year or two?</p> 
@@ -49,7 +48,7 @@ const NominatePostDialog = ({classes, post, onClose}: {
   </div>
 
   return (
-    <Dialog open={true}
+    <LWDialog open={true}
       onClose={onClose}
       fullWidth maxWidth="sm"
     >
@@ -83,7 +82,7 @@ const NominatePostDialog = ({classes, post, onClose}: {
           </Link>
         </Typography>
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   );
 }
 

--- a/packages/lesswrong/components/shortform/NewShortformDialog.tsx
+++ b/packages/lesswrong/components/shortform/NewShortformDialog.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useNavigation } from '../../lib/routeUtil';
@@ -8,13 +7,12 @@ import { useNavigation } from '../../lib/routeUtil';
 const NewShortformDialog = ({onClose}: {
   onClose: any,
 }) => {
-  const { ShortformSubmitForm } = Components;
+  const { ShortformSubmitForm, LWDialog } = Components;
   const { history } = useNavigation();
   return (
-    <Dialog open={true}
+    <LWDialog open={true}
       onClose={onClose}
       fullWidth maxWidth="sm"
-      disableEnforceFocus
     >
       <DialogContent>
         <ShortformSubmitForm
@@ -24,7 +22,7 @@ const NewShortformDialog = ({onClose}: {
           }}
         />
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   );
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ReportForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Components, registerComponent, getFragment } from '../../lib/vulcan-lib';
 import Reports from '../../lib/collections/reports/collection'
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 
 const ReportForm = ({ userId, postId, commentId, onClose, title, link }: {
@@ -13,7 +12,7 @@ const ReportForm = ({ userId, postId, commentId, onClose, title, link }: {
   link: string,
 }) => {
   return (
-    <Dialog
+    <Components.LWDialog
       title={title}
       open={true}
       onClose={onClose}
@@ -31,7 +30,7 @@ const ReportForm = ({ userId, postId, commentId, onClose, title, link }: {
           successCallback={onClose}
         />
       </DialogContent>
-    </Dialog>
+    </Components.LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/tagging/EditTagsDialog.tsx
+++ b/packages/lesswrong/components/tagging/EditTagsDialog.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
@@ -9,15 +8,15 @@ const EditTagsDialog = ({post, onClose }: {
   post: PostsList,
   onClose: ()=>void
 }) => {
-  const { FooterTagList } = Components
-  return <Dialog open={true} onClose={onClose} fullWidth maxWidth="sm" disableEnforceFocus>
+  const { FooterTagList, LWDialog } = Components
+  return <LWDialog open={true} onClose={onClose} fullWidth maxWidth="sm">
     <AnalyticsContext pageSectionContext="editTagsDialog">
       <DialogTitle>{post.title}</DialogTitle>
       <DialogContent>
         <FooterTagList post={post}/>
       </DialogContent>
     </AnalyticsContext>
-  </Dialog>
+  </LWDialog>
 }
 
 const EditTagsDialogComponent = registerComponent('EditTagsDialog', EditTagsDialog);

--- a/packages/lesswrong/components/tagging/TagCTAPopup.tsx
+++ b/packages/lesswrong/components/tagging/TagCTAPopup.tsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
 import Card from "@material-ui/core/Card";
 import { useTagBySlug } from './useTag';
 import { commentBodyStyles } from '../../themes/stylePiping';
@@ -22,15 +21,15 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Makes its child a link (wrapping it in an <a> tag) which opens a login
 // dialog.
 const TagCTAPopup = ({onClose, classes}) => {
-  const { ContentItemBody } = Components
+  const { ContentItemBody, LWDialog } = Components
   const { tag } = useTagBySlug("tag-cta-popup", "TagFragment")
   
   return (
-    <Dialog
+    <LWDialog
       open={true}
       onClose={onClose}
       className={classes.dialog}
-      classes={{
+      dialogClasses={{
         paper: classes.paper
       }}
     >
@@ -41,7 +40,7 @@ const TagCTAPopup = ({onClose, classes}) => {
           description={`tag ${tag?.name}`}
         />
       </Card>
-    </Dialog>
+    </LWDialog>
   );
 }
 

--- a/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
+++ b/packages/lesswrong/components/tagging/TagFlagEditAndNewForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { Components, getFragment, registerComponent } from '../../lib/vulcan-lib';
@@ -10,11 +9,11 @@ const TagFlagEditAndNewForm = ({ tagFlagId, onClose, classes }: {
   onClose: () => void,
   classes: ClassesType,
 }) => {
+  const { LWDialog } = Components;
   return (
-    <Dialog
+    <LWDialog
       open={true}
       onClose={onClose}
-      disableEnforceFocus
     >
       <DialogTitle>
         {tagFlagId ? "Edit Tag Flag" : "Create Tag Flag"}
@@ -28,7 +27,7 @@ const TagFlagEditAndNewForm = ({ tagFlagId, onClose, classes }: {
           successCallback={onClose}
         />
       </DialogContent>
-    </Dialog>
+    </LWDialog>
   )
 }
 

--- a/packages/lesswrong/components/users/LoginPopup.tsx
+++ b/packages/lesswrong/components/users/LoginPopup.tsx
@@ -1,6 +1,5 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
 
 const styles = (theme: ThemeType): JssStyles => ({
   dialog: {
@@ -18,12 +17,13 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Makes its child a link (wrapping it in an <a> tag) which opens a login
 // dialog.
 const LoginPopup = ({onClose, classes}) => {
+  const { LWDialog } = Components;
   return (
-    <Dialog
+    <LWDialog
       open={true}
       onClose={onClose}
       className={classes.dialog}
-      classes={{
+      dialogClasses={{
         paper: classes.paper
       }}
     >
@@ -31,7 +31,7 @@ const LoginPopup = ({onClose, classes}) => {
         onSignedInHook={() => onClose()}
         onPostSignUpHook={() => onClose()}
       />
-    </Dialog>
+    </LWDialog>
   );
 }
 

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -98,6 +98,7 @@ importComponent("LoadMore", () => require('../components/common/LoadMore'));
 importComponent("ReCaptcha", () => require('../components/common/ReCaptcha'));
 importComponent("DefaultStyleFormGroup", () => require('../components/common/DefaultStyleFormGroup'))
 importComponent("LinkCard", () => require('../components/common/LinkCard'));
+importComponent("LWDialog", () => require('../components/common/LWDialog'));
 importComponent("Error404", () => require('../components/common/Error404'));
 importComponent("PermanentRedirect", () => require('../components/common/PermanentRedirect'));
 importComponent("SeparatorBullet", () => require('../components/common/SeparatorBullet'));


### PR DESCRIPTION
Fixes an issue where you couldn't create links in the popup comment editor when nominating posts, and in several other places.

The material-UI `Dialog` component tries to enforce the input focus being inside itself. This breaks when CkEditor pops up a toolbar, and attaches the toolbar to the root rather than making it a child of the editor component. The solution is to pass the `disableEnforceFocus` prop. But needing to always pass this prop makes using the `Dialog` component directly a footgun. So wrap it in an `LWDialog` component, and add a lint rule against using `Dialog` directly.