### PR TITLE
Online event updates

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -32,6 +32,7 @@ const EventsList = ({currentUser, onClick}) => {
   }
   if (lat && lng) {
     eventsListTerms = {
+      onlineEvent: false,
       view: 'nearbyEvents',
       lat: lat,
       lng: lng,
@@ -40,7 +41,7 @@ const EventsList = ({currentUser, onClick}) => {
   }
   const onlineTerms = {
     view: 'onlineEvents',
-    limit: 2
+    limit: 4
   }
   return <span>
     <AnalyticsContext pageSubSectionContext="menuEventsList">

--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -36,7 +36,7 @@ const EventsList = ({currentUser, onClick}) => {
       view: 'nearbyEvents',
       lat: lat,
       lng: lng,
-      limit: 2,
+      limit: 1,
     }
   }
   const onlineTerms = {

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -62,18 +62,23 @@ class CommunityHome extends Component<CommunityHomeProps,CommunityHomeState> {
     const filters = query?.filters || [];
     const { SingleColumnSection, SectionTitle, PostsList2, SectionButton, GroupFormLink, SectionFooter } = Components
 
-    const postsListTerms = {
+    const eventsListTerms = {
       view: 'nearbyEvents',
       lat: this.state.currentUserLocation.lat,
       lng: this.state.currentUserLocation.lng,
-      limit: 7,
+      limit: 5,
       filters: filters,
+      onlineEvent: false
+    }
+    const onlineEventsListTerms = {
+      view: 'onlineEvents',
+      limit: 10
     }
     const groupsListTerms = {
       view: 'nearby',
       lat: this.state.currentUserLocation.lat,
       lng: this.state.currentUserLocation.lng,
-      limit: 7,
+      limit: 4,
       filters: filters,
     }
     const mapEventTerms = {
@@ -103,6 +108,21 @@ class CommunityHome extends Component<CommunityHomeProps,CommunityHomeState> {
                 </SectionFooter>
             </SingleColumnSection>
             <SingleColumnSection>
+              <SectionTitle title="Online Events"/>
+              <AnalyticsContext listContext={"communityEvents"}>
+                <PostsList2 terms={onlineEventsListTerms}/>
+              </AnalyticsContext>
+            </SingleColumnSection>
+            <SingleColumnSection>
+              <SectionTitle title="In-Person Events"/>
+              <AnalyticsContext listContext={"communityEvents"}>
+                <PostsList2 terms={eventsListTerms}>
+                  <Link to="/pastEvents">View Past Events</Link>
+                  <Link to="/upcomingEvents">View Upcoming Events</Link>
+                </PostsList2>
+              </AnalyticsContext>
+            </SingleColumnSection>
+            <SingleColumnSection>
               <SectionTitle title="Local Groups">
                 {this.props.currentUser && <GroupFormLink />}
               </SectionTitle>
@@ -112,22 +132,6 @@ class CommunityHome extends Component<CommunityHomeProps,CommunityHomeState> {
                       <Link to={"/allGroups"}>View All Groups</Link>
                   </Components.LocalGroupsList>
               }
-            </SingleColumnSection>
-            <SingleColumnSection>
-              <SectionTitle title="Events">
-                {this.props.currentUser && <Link to={{pathname:"/newPost", search: `?eventForm=true`}}>
-                  <SectionButton>
-                    <EventIcon />
-                    New Event
-                  </SectionButton>
-                </Link>}
-              </SectionTitle>
-              <AnalyticsContext listContext={"communityEvents"}>
-                <PostsList2 terms={postsListTerms}>
-                  <Link to="/pastEvents">View Past Events</Link>
-                  <Link to="/upcomingEvents">View Upcoming Events</Link>
-                </PostsList2>
-              </AnalyticsContext>
             </SingleColumnSection>
             <SingleColumnSection>
               <SectionTitle title="Resources"/>

--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -5,7 +5,6 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { userGetLocation } from '../../lib/collections/users/helpers';
 import withUser from '../common/withUser';
 import { createStyles } from '@material-ui/core/styles';
-import EventIcon from '@material-ui/icons/Event';
 import { withLocation } from '../../lib/routeUtil';
 import Typography from '@material-ui/core/Typography';
 import withDialog from '../common/withDialog'
@@ -60,7 +59,7 @@ class CommunityHome extends Component<CommunityHomeProps,CommunityHomeState> {
     const { classes, currentUser } = this.props;
     const { query } = this.props.location; // From withLocation
     const filters = query?.filters || [];
-    const { SingleColumnSection, SectionTitle, PostsList2, SectionButton, GroupFormLink, SectionFooter } = Components
+    const { SingleColumnSection, SectionTitle, PostsList2, GroupFormLink, SectionFooter } = Components
 
     const eventsListTerms = {
       view: 'nearbyEvents',

--- a/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
+++ b/packages/lesswrong/components/localGroups/TabNavigationEventsList.tsx
@@ -121,7 +121,9 @@ const TabNavigationEventsList = ({ terms, onClick, classes }: {
 
         const tooltip = <div>
             <div className={classes.tooltipTitle}>{event.title}</div>
-            <div className={classes.tooltipLogisticsTitle}>Location</div>
+            <div className={classes.tooltipLogisticsTitle}>
+             {event.onlineEvent ? "Onlne Event" : "Location"}
+            </div>
             <div>{event.location}</div>
             <div className={classes.tooltipLogisticsTitle}>Time</div>
             <div>

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -167,7 +167,7 @@ class PostsPage extends Component<PostsPageProps> {
               <div className={classes.content}>
                 <div className={classes.centralColumn}>
                   {/* Body */}
-                  { post.isEvent && <Components.SmallMapPreview post={post} /> }
+                  { post.isEvent && !post.onlineEvent && <Components.SmallMapPreview post={post} /> }
                   <div className={classes.postContent}>
                     <PostBodyPrefix post={post} query={query}/>
                     

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -122,14 +122,15 @@ class UsersMenu extends PureComponent<UsersMenuProps,UsersMenuState> {
                 <MenuItem>New Post</MenuItem>
               </Link>
             }
-            {showNewButtons && <Link to={`/newPost?eventForm=true`}>
-                <MenuItem>New Event</MenuItem>
-              </Link>
-            }
             {showNewButtons &&
               <MenuItem onClick={()=>openDialog({componentName:"NewShortformDialog"})}>
                 New Shortform
               </MenuItem>
+            }
+            {showNewButtons && <Divider/>}
+            {showNewButtons && <Link to={`/newPost?eventForm=true`}>
+                <MenuItem>New Event</MenuItem>
+              </Link>
             }
             {(showNewButtons && currentUser.karma >= 1000) &&
               <Link to={`/sequencesnew`}>

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -122,6 +122,10 @@ class UsersMenu extends PureComponent<UsersMenuProps,UsersMenuState> {
                 <MenuItem>New Post</MenuItem>
               </Link>
             }
+            {showNewButtons && <Link to={`/newPost?eventForm=true`}>
+                <MenuItem>New Event</MenuItem>
+              </Link>
+            }
             {showNewButtons &&
               <MenuItem onClick={()=>openDialog({componentName:"NewShortformDialog"})}>
                 New Shortform

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -742,7 +742,7 @@ Posts.addView("onlineEvents", function (terms) {
     },
     options: {
       sort: {
-        startTime: -1,
+        startTime: 1,
         createdAt: null,
         _id: null
       }


### PR DESCRIPTION
This PR fixes some issues that were getting in the way of Online Events working nicely:

1. On the community page, there are now separate lists for online and in-person events.

2. On the left navBar (where there were already two lists of online and geographic events), I updated the geographic events to exclude online events.

3. On the left navBar, I _also_ added to the total number of events. This is the boldest change, raising the total to six events. I recognize this is a pretty bold change. I think it is the right call, at least as an experiment. People have been complaining about it being impossible to find events and I think we should just spend a chunk of time erring on the side of "you can definitely find them."

4. I moved the "create event" button into the UsersMenu, so you don't have to go hunting to find it.
