### PR TITLE
Automatically verify email address for oAuth users

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -76,6 +76,16 @@ const schema: SchemaType<DbUser> = {
   emails: {
     type: Array,
     optional: true,
+    onCreate: ({document: user}) => {
+      const oAuthEmail = getNestedProperty(user, 'services.facebook.email') |
+        getNestedProperty(user, 'services.google.email') | 
+        getNestedProperty(user, 'services.github.email') | 
+        getNestedProperty(user, 'services.linkedin.emailAddress')
+      
+      if (oAuthEmail) {
+        return [{address: oAuthEmail, verified: true}]
+      }
+    }
   },
   'emails.$': {
     type: Object,


### PR DESCRIPTION
Currently oAuth users can't receive subscription emails, because they don't have a verified email address because the `emails` field just never gets populated. This fixes that by just assuming oAuth emails are verified and adding them to the emails array