### PR TITLE
Fix reviews button [hotfix]

### DIFF
--- a/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
+++ b/packages/lesswrong/components/review/FrontpageReviewPhase.tsx
@@ -211,7 +211,7 @@ const FrontpageReviewPhase = ({classes}) => {
         <LWTooltip title={<div>
           <div>Review posts with at least two nominations</div>
           </div>}>
-          <Link to={all2019Url} className={classes.actionButtonCTA}>
+          <Link to={"/reviews"} className={classes.actionButtonCTA}>
             Review 2019 Posts
           </Link>
         </LWTooltip>


### PR DESCRIPTION
It now properly links to /reviews, which AFAICT properly displays posts with 2+ nominations from the 2019 review