### PR TITLE
Walled Garden Improvements Dec 2020

### DIFF
--- a/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
@@ -105,7 +105,7 @@ export const GardenCodesItem = ({classes, gardenCode}:{
       </LWTooltip>}
       {gardenCode.contents?.htmlHighlight ? <span><LWTooltip title={<span className={classes.highlight}>
           <ContentItemBody
-            dangerouslySetInnerHTML={{__html: truncate(gardenCode.contents.htmlHighlight, 400, "characters", "...(click to open event page)") }}
+            dangerouslySetInnerHTML={{__html: truncate(gardenCode.contents.htmlHighlight, 1000, "characters", "...(click to open event page)") }}
             description={`garden-code-${gardenCode._id}`}
           />
         </span>}>

--- a/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
@@ -10,7 +10,6 @@ import LinkIcon from '@material-ui/icons/Link';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import {useMessages} from "../common/withMessages";
 import { FacebookIcon } from "../localGroups/GroupLinks";
-import { Link } from '../../lib/reactRouterWrapper';
 import { truncate } from '../../lib/editor/ellipsize';
 
 const iconStyling = {
@@ -40,8 +39,6 @@ const styles = theme => ({
     ...eventName(theme)
   },
   eventNameLink: {
-    // color: `${theme.palette.grey[800]} !important`,
-    // color: "rgba(0,0,0,0.3) !important",
     color: "rgba(0,0,0,0.55) !important",
   },
   eventTime: {
@@ -94,9 +91,7 @@ export const GardenCodesItem = ({classes, gardenCode}:{
   if (editing) {
     return <GardenCodesEditForm gardenCodeId={gardenCode._id} cancelCallback={()=> setEditing(false)}   />
   }
-  // const title = <span cla>{gardenCode.title}</span>
-  // const inviteLink = `http://garden.lesswrong.com?code=${gardenCode.code}&event=${gardenCode.slug}`
-  const inviteLink = `localhost:3000/walledGardenPortal?code=${gardenCode.code}&event=${gardenCode.slug}` //TOD-DO: put back correct one
+  const inviteLink = `http://garden.lesswrong.com?code=${gardenCode.code}&event=${gardenCode.slug}`
   
   return <div className={classes.root}>
     <span className={classes.eventName}>

--- a/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesItem.tsx
@@ -10,9 +10,11 @@ import LinkIcon from '@material-ui/icons/Link';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import {useMessages} from "../common/withMessages";
 import { FacebookIcon } from "../localGroups/GroupLinks";
+import { Link } from '../../lib/reactRouterWrapper';
+import { truncate } from '../../lib/editor/ellipsize';
 
 const iconStyling = {
-  marginLeft: 1,
+  marginLeft: 2,
   height: 16,
   width: 16,
   cursor: "pointer",
@@ -26,7 +28,7 @@ const iconStyling = {
 const styles = theme => ({
   root: {
     ...eventRoot(theme),
-    width: "420px",
+    width: 420,
     '&:hover $icon': {
       opacity: 1
     },
@@ -37,12 +39,18 @@ const styles = theme => ({
   eventName: {
     ...eventName(theme)
   },
+  eventNameLink: {
+    // color: `${theme.palette.grey[800]} !important`,
+    // color: "rgba(0,0,0,0.3) !important",
+    color: "rgba(0,0,0,0.55) !important",
+  },
   eventTime: {
     ...eventTime(theme)
   },
   personalIcon: {
     ...iconStyling,
-    marginRight: "3px",
+    marginLeft: 0,
+    marginRight: 3,
     opacity: .75,
   },
   trailingIcons: {
@@ -50,20 +58,23 @@ const styles = theme => ({
     width: 48,
     marginLeft: 8,
     display: "flex",
-    justifyContent: "space-between"
+    justifyContent: "flex-start"
   },
   linkIcon: {
     ...iconStyling,
+    marginLeft: 0,
     opacity: .5,
     transform: 'rotate(-45deg)',
   },
-  fbIcon: {
+  fbIconContainer: {
     ...iconStyling,
+  },
+  fbIcon: {
     color: theme.palette.grey[700],
     height: 12,
     width: 12,
     opacity: .5,
-    marginBottom: 2
+    marginBottom: 1
   },
   editIcon: {
     ...iconStyling,
@@ -84,7 +95,8 @@ export const GardenCodesItem = ({classes, gardenCode}:{
     return <GardenCodesEditForm gardenCodeId={gardenCode._id} cancelCallback={()=> setEditing(false)}   />
   }
   // const title = <span cla>{gardenCode.title}</span>
-  const inviteLink = `http://garden.lesswrong.com?code=${gardenCode.code}&event=${gardenCode.slug}`
+  // const inviteLink = `http://garden.lesswrong.com?code=${gardenCode.code}&event=${gardenCode.slug}`
+  const inviteLink = `localhost:3000/walledGardenPortal?code=${gardenCode.code}&event=${gardenCode.slug}` //TOD-DO: put back correct one
   
   return <div className={classes.root}>
     <span className={classes.eventName}>
@@ -93,16 +105,20 @@ export const GardenCodesItem = ({classes, gardenCode}:{
       </LWTooltip>}
       {gardenCode.contents?.htmlHighlight ? <span><LWTooltip title={<span className={classes.highlight}>
           <ContentItemBody
-            dangerouslySetInnerHTML={{__html: gardenCode.contents.htmlHighlight }}
+            dangerouslySetInnerHTML={{__html: truncate(gardenCode.contents.htmlHighlight, 400, "characters", "...(click to open event page)") }}
             description={`garden-code-${gardenCode._id}`}
           />
         </span>}>
-          {gardenCode.title}
+          <a className={classes.eventNameLink} href={inviteLink} target="_blank" rel="noopener noreferrer">
+            {gardenCode.title}
+          </a>
         </LWTooltip>
       </span>
-        : gardenCode.title
-      }
-    </span>
+        : <a className={classes.eventNameLink} href={inviteLink} target="_blank" rel="noopener noreferrer">
+          {gardenCode.title}
+        </a>
+        }
+        </span>
     <div className={classes.eventTime}>
       {eventFormat(gardenCode.startTime)}
     </div>
@@ -112,12 +128,14 @@ export const GardenCodesItem = ({classes, gardenCode}:{
           <LinkIcon className={classes.linkIcon}/>
         </CopyToClipboard>
       </LWTooltip>
-      {gardenCode.fbLink && (gardenCode.type=="public" || currentUser?.walledGardenInvite) &&
-      <LWTooltip title="Link to the FB version of this event" placement="right">
-        <a href={gardenCode.fbLink} target="_blank" rel="noopener noreferrer">
-          <FacebookIcon className={classes.fbIcon}/>
-        </a>
-      </LWTooltip>}
+      <div className={classes.fbIconContainer}> {/*container for fb icon to maintain spacing*/} 
+        {gardenCode.fbLink && (gardenCode.type=="public" || currentUser?.walledGardenInvite) &&
+        <LWTooltip title="Link to the FB version of this event" placement="right">
+          <a href={gardenCode.fbLink} target="_blank" rel="noopener noreferrer">
+            <FacebookIcon className={classes.fbIcon}/>
+          </a>
+        </LWTooltip>}
+      </div>
       {(userCanDo(currentUser, "gardencodes.edit.all") || userOwns(currentUser, gardenCode)) &&
       <LWTooltip title="Click to edit event invite" placement="right">
         <CreateIcon className={classes.editIcon} onClick={() => setEditing(true)}/>

--- a/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
@@ -3,7 +3,6 @@ import { GardenCodes } from '../../lib/collections/gardencodes/collection';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
-import {commentBodyStyles} from "../../themes/stylePiping";
 
 const styles = (theme: ThemeType): JssStyles => ({
   loadMore: {

--- a/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
@@ -3,42 +3,49 @@ import { GardenCodes } from '../../lib/collections/gardencodes/collection';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
+import {commentBodyStyles} from "../../themes/stylePiping";
 
-export const GardenCodesList = ({classes, limit, personal=false}:{
-  classes:ClassesType,
-  limit?: number,
-  personal?: boolean}) => {
-  const { GardenCodesItem } = Components
+const styles = (theme: ThemeType): JssStyles => ({
+  loadMore: {
+    fontSize: "1rem"
+  }
+})
+  
+export const GardenCodesList = ({classes, terms, limit}: {classes:ClassesType, terms: any, limit?: number}) => {
+  
+  const { GardenCodesItem, Loading, LoadMore } = Components
   const currentUser = useCurrentUser()
   
-  const terms = personal ?
-    {view:"userGardenCodes"} : 
-    {view:"semipublicGardenCodes", types: ['public', 'semi-public']}
+  // const terms = personal ?
+  //   {view:"userGardenCodes"} : 
+  //   {view:"semipublicGardenCodes", types: ['public', 'semi-public']}
   
-  const { results } = useMulti({
+  const { results, loading, loadMoreProps } = useMulti({
     terms: {
       userId: currentUser?._id,
       ...terms
     },
-    enableTotal: false,
+    enableTotal: true,
     fetchPolicy: 'cache-and-network',
     collection: GardenCodes,
     fragmentName: 'GardenCodeFragment',
-    limit: limit || 8
+    limit: limit || 5,
+    itemsPerPage: 10
   });
   
+  console.log({terms, loadMoreProps})
+  
+  // const resultsFiltered = results?.filter(code => personal ? 
+  //   code.type=='private' : 
+  //   (currentUser?.walledGardenInvite || code.type=='public')) //for personal list, only show private events; for public list, show all public/semipublic events depending on membership
   
   return <div>
-    {results
-      ?.filter(code => personal ?
-        code.type=='private' : 
-        (currentUser?.walledGardenInvite || code.type=='public')
-      ) //for personal list, only show private events; for public list, show all public/semipublic events depending on membership
-      .map(code=><GardenCodesItem key={code._id} gardenCode={code}/>)}
+    {results?.map(code=><GardenCodesItem key={code._id} gardenCode={code}/>)}
+    {loading ? <Loading/> : <LoadMore className={classes.loadMore} {...loadMoreProps}/>}
   </div>
 }
 
-const GardenCodesListComponent = registerComponent('GardenCodesList', GardenCodesList);
+const GardenCodesListComponent = registerComponent('GardenCodesList', GardenCodesList, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
@@ -16,10 +16,6 @@ export const GardenCodesList = ({classes, terms, limit}: {classes:ClassesType, t
   const { GardenCodesItem, Loading, LoadMore } = Components
   const currentUser = useCurrentUser()
   
-  // const terms = personal ?
-  //   {view:"userGardenCodes"} : 
-  //   {view:"semipublicGardenCodes", types: ['public', 'semi-public']}
-  
   const { results, loading, loadMoreProps } = useMulti({
     terms: {
       userId: currentUser?._id,
@@ -33,11 +29,6 @@ export const GardenCodesList = ({classes, terms, limit}: {classes:ClassesType, t
     itemsPerPage: 10
   });
   
-  console.log({terms, loadMoreProps})
-  
-  // const resultsFiltered = results?.filter(code => personal ? 
-  //   code.type=='private' : 
-  //   (currentUser?.walledGardenInvite || code.type=='public')) //for personal list, only show private events; for public list, show all public/semipublic events depending on membership
   
   return <div>
     {results?.map(code=><GardenCodesItem key={code._id} gardenCode={code}/>)}

--- a/packages/lesswrong/components/walledGarden/GardenEventDetails.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenEventDetails.tsx
@@ -2,23 +2,10 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Typography from "@material-ui/core/Typography";
-import { FacebookIcon } from "../localGroups/GroupLinks";
-import LinkIcon from "@material-ui/icons/Link";
 import { useMessages } from "../common/withMessages";
 import moment from "../../lib/moment-timezone";
 import {useTimezone} from "../common/withTimezone";
 
-const iconStyling = {
-  marginLeft: 1,
-  height: 20,
-  width: 20,
-  cursor: "pointer",
-  position: "relative",
-  top: 1,
-  '&:hover': {
-    opacity: 0.5
-  }
-}
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -39,6 +26,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontVariant: "small-caps",
     fontSize: "1.6rem",
     marginBottom: 30
+  },
+  description: {
+    marginBottom: 20
   }
 })
 
@@ -59,14 +49,19 @@ export const GardenEventDetails = ({gardenCode, classes}: {gardenCode: GardenCod
         </CopyToClipboard>
       </LWTooltip>
     <div className={classes.startTime}>
-      <div>{moment(gardenCode?.startTime).tz(timezone).format("dddd, MMMM Do, YYYY")}</div>
-      <div>{moment(gardenCode?.startTime).tz(timezone).format("h:mma z")}</div>
+      <div>{moment(gardenCode.startTime).tz(timezone).format("dddd, MMMM Do, YYYY")}</div>
+      <div>{moment(gardenCode.startTime).tz(timezone).format("h:mma z")}</div>
     </div>
     <ContentItemBody
       dangerouslySetInnerHTML={{__html: gardenCode.contents?.html||""}}
       description={`gardenCode ${gardenCode.code}`}
       className={classes.description}
     />
+    {gardenCode.fbLink  && <LWTooltip title="Link to the FB version of this event" placement="right">
+      <a href={gardenCode.fbLink} target="_blank" rel="noopener noreferrer">
+        <em>Facebook Event</em>
+      </a>
+    </LWTooltip>}
   </div>
 }
 

--- a/packages/lesswrong/components/walledGarden/GardenEventDetails.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenEventDetails.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import Typography from "@material-ui/core/Typography";
+import { FacebookIcon } from "../localGroups/GroupLinks";
+import LinkIcon from "@material-ui/icons/Link";
+import { useMessages } from "../common/withMessages";
+import moment from "../../lib/moment-timezone";
+import {useTimezone} from "../common/withTimezone";
+
+const iconStyling = {
+  marginLeft: 1,
+  height: 20,
+  width: 20,
+  cursor: "pointer",
+  position: "relative",
+  top: 1,
+  '&:hover': {
+    opacity: 0.5
+  }
+}
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    padding: 30,
+    background: "white"
+  },
+  title: {
+    ...theme.typography.display3,
+    marginTop: 0,
+    fontWeight: 600,
+    cursor: "pointer",
+    '&:hover': {
+      opacity: 1
+    }
+  },
+  startTime: {
+    color: theme.palette.grey[700],
+    fontVariant: "small-caps",
+    fontSize: "1.6rem",
+    marginBottom: 30
+  }
+})
+
+export const GardenEventDetails = ({gardenCode, classes}: {gardenCode: GardenCodeFragment, classes:ClassesType}) => {
+  
+  const { timezone } = useTimezone();
+  
+  const { flash } = useMessages();
+  const { ContentItemBody, LWTooltip } = Components
+  const inviteLink = `http://garden.lesswrong.com?code=${gardenCode.code}&event=${gardenCode.slug}`
+  
+  return <div className={classes.root}>
+      <LWTooltip title="Click to copy invite link" placement="right">
+        <CopyToClipboard text={inviteLink} onCopy={()=>flash({messageString:"Invite link copied!"})}>
+          <Typography variant="display3" className={classes.title}>
+            {gardenCode.title}
+          </Typography>
+        </CopyToClipboard>
+      </LWTooltip>
+    <div className={classes.startTime}>
+      <div>{moment(gardenCode?.startTime).tz(timezone).format("dddd, MMMM Do, YYYY")}</div>
+      <div>{moment(gardenCode?.startTime).tz(timezone).format("h:mma z")}</div>
+    </div>
+    <ContentItemBody
+      dangerouslySetInnerHTML={{__html: gardenCode.contents?.html||""}}
+      description={`gardenCode ${gardenCode.code}`}
+      className={classes.description}
+    />
+  </div>
+}
+
+const GardenEventDetailsComponent = registerComponent('GardenEventDetails', GardenEventDetails, {styles});
+
+declare global {
+  interface ComponentTypes {
+    GardenEventDetails: typeof GardenEventDetailsComponent
+  }
+}

--- a/packages/lesswrong/components/walledGarden/GatherTown.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTown.tsx
@@ -181,7 +181,7 @@ const GatherTown = ({classes}: {
           {tooltip}
         </div>}
         <div className={classes.gardenCodesList}>
-          <GardenCodesList limit={2}/>
+          <GardenCodesList terms={{view: "semipublicGardenCodes", types:  currentUser.walledGardenInvite ? ['public', 'semi-public'] : ['public']}} limit={2}/>
         </div>
       </div>
     </div>

--- a/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTownIframeWrapper.tsx
@@ -22,7 +22,7 @@ const GatherTownIframeWrapper = ({iframeRef, classes}: {
     iframeRef?.current?.focus && iframeRef.current.focus()
   }, [iframeRef])
 
-  return <iframe className={classes.iframePositioning} ref={iframeRef} src={gatherTownURL} allow={`camera ${gatherTownURL}; microphone ${gatherTownURL}; display-capture ${gatherTownURL}`}></iframe>
+  return <iframe className={classes.iframePositioning} ref={iframeRef} src={gatherTownURL} allow={`camera ${gatherTownURL}; microphone ${gatherTownURL}; display-capture ${gatherTownURL}; transparency ${gatherTownURL}; encrypted-media ${gatherTownURL}`}></iframe>
 }
 
 const GatherTownIframeWrapperComponent = registerComponent('GatherTownIframeWrapper', GatherTownIframeWrapper, {styles});

--- a/packages/lesswrong/components/walledGarden/WalledGardenMessage.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenMessage.tsx
@@ -5,7 +5,8 @@ import {postBodyStyles} from "../../themes/stylePiping";
 const styles = (theme: ThemeType): JssStyles => ({
   messageStyling: {
     ...postBodyStyles(theme),
-    marginTop: "100px"
+    marginTop: "100px",
+    maxWidth: 620
   },
 })
 

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -86,8 +86,8 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
 
   const { query, url, currentRoute, location } = useLocation();
   const { history } = useNavigation();
-  const { code: inviteCodeQuery, entered: enteredQuery } = query;
-  console.log({query, url, currentRoute, location})
+  const { code: inviteCodeQuery, entered } = query;
+  const enteredQuery = entered === "true"
 
   const [ hideBar, setHideBar ] = useState(false);
 
@@ -164,14 +164,17 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
     </SingleColumnSection>
   }
 
-  if ((!!gardenCode && !enteredQuery) || !onboarded){
+  
+  if ((!!gardenCode && !enteredQuery) || (!!currentUser && !onboarded)){
     return <SingleColumnSection className={classes.root}>
       <h2><strong>Welcome to the Walled Garden, a curated space for truthseekers!</strong></h2>
       {!!gardenCode && <div>
         {codeIsValid ?
           <p>Your invite code to <strong>{gardenCode.title}</strong> is valid (and will be for next many hours).</p> :
-          <p>You have reached the Garden via an invite code that is not currently valid. However, as a full Garden Member you may enter anyway. :) </p>
+          <p>You have reached the Garden via an invite code that is not currently valid.</p>
         }
+        {currentUser?.walledGardenInvite && <p>Of course, as a Walled Garden member, you may enter anytime. :)</p>}
+        {!currentUser?.walledGardenInvite && isOpenToPublic && <p>However, the Garden is currently to the public, so you may enter anyway! :)</p>}
       </div>
       }
       <p><strong>IMPORTANT TECHNICAL INFORMATION</strong>

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -12,7 +12,6 @@ import { isMobile } from "../../lib/utils/isMobile";
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import qs from 'qs'
-import Button from '@material-ui/core/Button';
 
 const toggleEventsOffset = "330px"
 
@@ -84,7 +83,7 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
   })
   const isOpenToPublic = gardenOpenToPublic.get()
 
-  const { query, url, currentRoute, location } = useLocation();
+  const { query } = useLocation();
   const { history } = useNavigation();
   const { code: inviteCodeQuery, entered } = query;
   const enteredQuery = entered === "true"
@@ -177,40 +176,38 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
         {!currentUser?.walledGardenInvite && isOpenToPublic && <p>However, the Garden is currently to the public, so you may enter anyway! :)</p>}
       </div>
       }
-      <p><strong>IMPORTANT TECHNICAL INFORMATION</strong>
-        <ul>
-          <li>Please wear headphones! Try to be in a low-background noise environment.</li>
-          <li>Make sure you grant the page access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click an icon within your URL bar.</li>
-          <li>The Garden will not load from an incognito window or if 3rd-party cookies are blocked.</li>
-          <li>Technical Problems once you're in the Garden? Refresh the tab.</li>
-          <li>Lost or stuck? Message a host using chat (left sidebar)</li>
-          <li>Interactions are voluntary. It's okay to leave conversations.</li>
-          <li>Please report any issues, both technical and social, to the LessWrong team via Intercom (bottom right on most pages) or
-            email (team@lesswrong.com).</li>
-        </ul>
-      </p>
+      <p><strong>IMPORTANT TECHNICAL INFORMATION</strong></p>
+      <ul>
+        <li>Please wear headphones! Try to be in a low-background noise environment.</li>
+        <li>Make sure you grant the page access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click an icon within your URL bar.</li>
+        <li>The Garden will not load from an incognito window or if 3rd-party cookies are blocked.</li>
+        <li>Technical Problems once you're in the Garden? Refresh the tab.</li>
+        <li>Lost or stuck? Message a host using chat (left sidebar)</li>
+        <li>Interactions are voluntary. It's okay to leave conversations.</li>
+        <li>Please report any issues, both technical and social, to the LessWrong team via Intercom (bottom right on most pages) or
+          email (team@lesswrong.com).</li>
+      </ul>
       <AnalyticsTracker eventType="walledGardenEnter" captureOnMount eventProps={{ isOpenToPublic, inviteCodeQuery, isMember: currentUser?.walledGardenInvite }}>
         <div className={classes.enterButton}>
           <a className={classes.buttonStyling} onClick={ async () => {
             setOnboarded(true)
             history.push({pathname: "/walledGardenPortal", search: `?${qs.stringify({...query, entered: true})}`})
             if (currentUser && !currentUser.walledGardenPortalOnboarded) {
-            void updateUser({
-              selector: {_id: currentUser._id},
-              data: {
-                walledGardenPortalOnboarded: true
-              }
-            })
-          }
-          }
-          }>
+              void updateUser({
+                selector: {_id: currentUser._id},
+                data: {
+                  walledGardenPortalOnboarded: true
+                }
+              })
+            }
+          }}>
             <b>Enter the Garden</b>
           </a>
         </div>
       </AnalyticsTracker>
       {!!gardenCode && <div className={classes.eventDetails}>
         <p><strong>EVENT DETAILS</strong> <em>May contain important instructions</em></p>
-        {!!gardenCode && <GardenEventDetails gardenCode={gardenCode}/>}
+        <GardenEventDetails gardenCode={gardenCode}/>
       </div>
       }
     </SingleColumnSection>

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -47,18 +47,21 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   closeIcon: {
     height: 48,
-    width:48,
+    width: 48,
   },
   iframeWrapper: {
     flex: 7,
     position: "relative",
+  },
+  eventDetails: {
+    marginTop: 20
   }
 })
 
 
 const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
 
-  const { SingleColumnSection, LoginPopupButton, AnalyticsTracker, WalledGardenMessage, GatherTownIframeWrapper, WalledGardenPortalBar } = Components
+  const { SingleColumnSection, LoginPopupButton, AnalyticsTracker, WalledGardenMessage, GatherTownIframeWrapper, WalledGardenPortalBar, GardenEventDetails } = Components
   const currentUser = useCurrentUser();
   const { mutate: updateUser } = useUpdate({
     collectionName: "Users",
@@ -122,7 +125,8 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
     </WalledGardenMessage>
 
     if (codeNotYetValid) return <WalledGardenMessage>
-      <p>Your invite code is for an event that has yet started! Please come back at <strong>{moment(gardenCode?.startTime).format("dddd, MMMM Do, h:mma")}</strong></p>
+      <p>Your invite code is for an event that has not yet started! Please come back at the start time.</p>
+      {!!gardenCode && <GardenEventDetails gardenCode={gardenCode}/>}
     </WalledGardenMessage>
 
     if (codeExpiredBeforeSession) return <WalledGardenMessage>
@@ -145,22 +149,21 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
 
   if (!onboarded) {
     return <SingleColumnSection className={classes.messageStyling}>
+      <h2><strong>Welcome to the Walled Garden, a curated space for truthseekers!</strong></h2>
       {!!gardenCode && <div>
         <p>
-          Congratulations! Your invite code to <strong>{gardenCode.title}</strong> is valid (and will be for next many hours).
+          Your invite code to <strong>{gardenCode.title}</strong> is valid (and will be for next many hours).
           Please take a look at our guidelines below, then join the party!
         </p>
-        <hr />
       </div>
       }
-      <p><strong>Welcome to the Walled Garden, a curated space for truthseekers!</strong></p>
-      <p>Here you can socialize, co-work, play games, and attend events. The Garden is open to everyone on Sundays from 12pm to 4pm PT. Otherwise, it is open by invite only.</p>
+      <p><strong>IMPORTANT TECHNICAL INFORMATION</strong></p>
       <ul>
-        <li>Please wear headphones, preferably with a microphone! Try to be in a low-background noise environment.</li>
-        <li>Ensure you grant the page access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click an icon within your URL bar.</li>
+        <li>Please wear headphones! Try to be in a low-background noise environment.</li>
+        <li>Make sure you grant the page access to your camera and microphone. Usually, there are pop-ups but sometimes you have to click an icon within your URL bar.</li>
         <li>The Garden will not load from an incognito window or if 3rd-party cookies are blocked. (It is built on a 3rd-party platform.)</li>
         <li>Technical Problems once you're in the Garden? Refresh the tab.</li>
-        <li>Lost or stuck? Respawn (<i>gear icon</i> &gt; <i>respawn</i>)</li>
+        <li>Lost or stuck? Respawn (<i>click username</i> &gt; <i>reset position</i>) or message a host using chat (left sidebar)</li>
         <li>Interactions are voluntary. It's okay to leave conversations.</li>
         <li>Please report any issues, both technical and social, to the LessWrong team via Intercom (bottom right) or
           email (team@lesswrong.com).</li>
@@ -181,6 +184,11 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
           <b>Enter the Garden</b>
         </a>
       </AnalyticsTracker>
+      {!!gardenCode && <div className={classes.eventDetails}>
+        <p><strong>EVENT DETAILS.</strong>May contain important instructions.</p>
+        {!!gardenCode && <GardenEventDetails gardenCode={gardenCode}/>}
+      </div>
+      }
     </SingleColumnSection>
   }
 

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
@@ -89,10 +89,10 @@ export const WalledGardenPortalBar = ({iframeRef, classes}:{iframeRef:React.RefO
           <div><GardenCodeWidget type="event"/></div>
         </div>
       </div>}
-      {currentUser.walledGardenInvite && <div className={classes.eventWidget}>
+      <div className={classes.eventWidget}>
         <GardenCodesList terms={{view: "semipublicGardenCodes", types:  currentUser.walledGardenInvite ? ['public', 'semi-public'] : ['public']}}/>
-        <GardenCodesList terms={{view: "usersPrivateGardenCodes"}}/>
-      </div>}
+        {currentUser.walledGardenInvite &&   <GardenCodesList terms={{view: "usersPrivateGardenCodes"}}/>}
+      </div>
       {currentUser.walledGardenInvite && <div className={classes.calendars}>
         <div className={classes.textButton}>
           <a href={"https://www.facebook.com/groups/356586692361618/events"} target="_blank" rel="noopener noreferrer">

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
@@ -90,8 +90,8 @@ export const WalledGardenPortalBar = ({iframeRef, classes}:{iframeRef:React.RefO
         </div>
       </div>}
       {currentUser.walledGardenInvite && <div className={classes.eventWidget}>
-        <GardenCodesList/>
-        <GardenCodesList personal/>
+        <GardenCodesList terms={{view: "semipublicGardenCodes", types:  currentUser.walledGardenInvite ? ['public', 'semi-public'] : ['public']}}/>
+        <GardenCodesList terms={{view: "usersPrivateGardenCodes"}}/>
       </div>}
       {currentUser.walledGardenInvite && <div className={classes.calendars}>
         <div className={classes.textButton}>

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
@@ -77,12 +77,11 @@ export const WalledGardenPortalBar = ({iframeRef, classes}:{iframeRef:React.RefO
 
   const currentUser =  useCurrentUser()
 
-  if (!currentUser) return null
   const refocusOnIframe = () => iframeRef?.current && iframeRef.current.focus()
 
   return <div className={classes.root}>
     <div className={classes.widgetsContainer}>
-      {currentUser.walledGardenInvite && <div className={classes.events}>
+      {currentUser?.walledGardenInvite && <div className={classes.events}>
         <Typography variant="title">Garden Events</Typography>
         <div className={classes.calendarLinks}>
           <div><GardenCodeWidget type="friend"/></div>
@@ -90,10 +89,10 @@ export const WalledGardenPortalBar = ({iframeRef, classes}:{iframeRef:React.RefO
         </div>
       </div>}
       <div className={classes.eventWidget}>
-        <GardenCodesList terms={{view: "semipublicGardenCodes", types:  currentUser.walledGardenInvite ? ['public', 'semi-public'] : ['public']}}/>
-        {currentUser.walledGardenInvite &&   <GardenCodesList terms={{view: "usersPrivateGardenCodes"}}/>}
+        <GardenCodesList terms={{view: "semipublicGardenCodes", types:  currentUser?.walledGardenInvite ? ['public', 'semi-public'] : ['public']}}/>
+        {currentUser?.walledGardenInvite &&   <GardenCodesList terms={{view: "usersPrivateGardenCodes"}}/>}
       </div>
-      {currentUser.walledGardenInvite && <div className={classes.calendars}>
+      {currentUser?.walledGardenInvite && <div className={classes.calendars}>
         <div className={classes.textButton}>
           <a href={"https://www.facebook.com/groups/356586692361618/events"} target="_blank" rel="noopener noreferrer">
             Facebook Group

--- a/packages/lesswrong/lib/collections/gardencodes/views.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/views.ts
@@ -40,11 +40,13 @@ GardenCodes.addDefaultView(terms => {
 ensureIndex(GardenCodes, {code:1, deleted: 1});
 ensureIndex(GardenCodes, {userId:1, deleted: 1});
 
-GardenCodes.addView("userGardenCodes", function (terms) {
+GardenCodes.addView("usersPrivateGardenCodes", function (terms) {
   const twoHoursAgo = new Date(new Date().getTime()-(2*60*60*1000));
   return {
-    selector: { 
-      startTime: {$gt: twoHoursAgo }
+    selector: {
+      // userId: terms.userId,
+      type: 'private',
+      $or: [{startTime: {$gt: twoHoursAgo }}, {endTime: {$gt: new Date()}}]
     }
   }
 })
@@ -55,7 +57,7 @@ GardenCodes.addView("semipublicGardenCodes", function (terms) {
   const twoHoursAgo = new Date(new Date().getTime()-(2*60*60*1000));
   return {
     selector: { 
-      startTime: {$gt: twoHoursAgo }
+      $or: [{startTime: {$gt: twoHoursAgo }}, {endTime: {$gt: new Date()}}]
     }
   }
 })

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -268,6 +268,7 @@ importComponent("GroupFormDialog", () => require('../components/localGroups/Grou
 
 importComponent("WalledGardenHome", () => require('../components/walledGarden/WalledGardenHome'));
 importComponent("WalledGardenPortal", () => require('../components/walledGarden/WalledGardenPortal'));
+importComponent("GardenEventDetails", () => require('../components/walledGarden/GardenEventDetails'));
 importComponent("GardenCodesList", () => require('../components/walledGarden/GardenCodesList'));
 importComponent("GardenCodesEditForm", () => require('../components/walledGarden/GardenCodesEditForm'));
 importComponent("GardenCodesItem", () => require('../components/walledGarden/GardenCodesItem'));


### PR DESCRIPTION
- clicking an invite code shows you the full text of event (~event page) plus message about whether you can enter (because it's valid, you're a member, or open to public). If you do enter, `&entered=true` gets appended to url and refreshing won't show you the text again
- event items in the calendar are links, hover-over text is truncated
- Calendar of Public events shows to guests/non-members in the garden
- calendar of events now has a load more button on the frontpage and in the garden.

![image](https://user-images.githubusercontent.com/7250541/102668130-0440cc80-4140-11eb-9253-a7e978478fb0.png)

![image](https://user-images.githubusercontent.com/7250541/102668156-16bb0600-4140-11eb-94ff-c7f04a9b2103.png)

![image](https://user-images.githubusercontent.com/7250541/102668185-26d2e580-4140-11eb-90d6-dfe730380d17.png)
