### PR TITLE
Sanitizer allows the start,reversed,type attributes on <ol> tags

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/utils.ts
+++ b/packages/lesswrong/server/vulcan-lib/utils.ts
@@ -22,6 +22,7 @@ export const sanitize = function(s: string): string {
       tr: ['style'],
       td: ['rowspan', 'colspan', 'style'],
       th: ['rowspan', 'colspan', 'style'],
+      ol: ['start', 'reversed', 'type'],
       span: ['style'],
       div: ['class', 'data-oembed-url', 'data-elicit-id', 'data-metaculus-id'],
       a: ['href', 'name', 'target', 'rel'],


### PR DESCRIPTION
The `<ol>` tag is allowed to have `start`, `reversed` and `type` attributes. Stripping `start` caused an issue (misnumbered lists) in the RSS crosspost of https://www.lessestwrong.com/posts/n8PEMJNrns4d3FjY5/covid-12-31-meet-the-new-year .
