### PR TITLE
Review Page updates [hotfix]

### DIFF
--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -21,6 +21,7 @@ import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
 import seedrandom from '../../lib/seedrandom';
 
 const YEAR = "2019"
+const NOMINATIONS_VIEW = "nominations2019"
 const REVIEWS_VIEW = "reviews2019" // unfortunately this can't just inhereit from YEAR. It needs to exactly match a view-type so that the type-check of the view can pass.
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -364,12 +365,12 @@ const ReviewVotingPage = ({classes}: {
                 <PostReviewsAndNominations
                   title="nomination"
                   singleLine
-                  terms={{view:`nominations${YEAR}`, postId: expandedPost._id}}
+                  terms={{view: NOMINATIONS_VIEW, postId: expandedPost._id}}
                   post={expandedPost}
                 />
                 <PostReviewsAndNominations
                   title="review"
-                  terms={{view:`reviews${YEAR}`, postId: expandedPost._id}}
+                  terms={{view: REVIEWS_VIEW, postId: expandedPost._id}}
                   post={expandedPost}
                 />
               </div>

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -20,6 +20,9 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
 import seedrandom from '../../lib/seedrandom';
 
+const YEAR = "2019"
+const REVIEWS_VIEW = "reviews2019" // unfortunately this can't just inhereit from YEAR so that the type-check of the view can pass.
+
 const styles = (theme: ThemeType): JssStyles => ({
   grid: {
     display: 'grid',
@@ -99,19 +102,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   comments: {
   },
-  reason: {
-    position: "relative",
-    border: "solid 1px rgba(0,0,0,.3)",
-    padding: theme.spacing.unit*1.5,
-    paddingLeft: theme.spacing.unit*2,
-    paddingBottom: theme.spacing.unit
-  },
-  reasonTitle: {
-    ...theme.typography.body2,
-    ...theme.typography.commentStyle,
-    fontWeight: 600,
-    marginBottom: theme.spacing.unit
-  },
   voteTotal: {
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
@@ -175,14 +165,14 @@ const ReviewVotingPage = ({classes}: {
   const currentUser = useCurrentUser()
   const { captureEvent } = useTracking({eventType: "reviewVotingEvent"})
   const { results: posts, loading: postsLoading } = useMulti({
-    terms: {view:"reviews2018", limit: 100},
+    terms: {view: REVIEWS_VIEW, limit: 200},
     collectionName: "Posts",
     fragmentName: 'PostsList',
     fetchPolicy: 'cache-and-network',
   });
   
   const { results: dbVotes, loading: dbVotesLoading } = useMulti({
-    terms: {view: "reviewVotesFromUser", limit: 100, userId: currentUser?._id},
+    terms: {view: "reviewVotesFromUser", limit: 200, userId: currentUser?._id},
     collectionName: "ReviewVotes",
     fragmentName: "reviewVoteFragment",
     fetchPolicy: 'cache-and-network',
@@ -231,13 +221,13 @@ const ReviewVotingPage = ({classes}: {
     });
   }
 
-  const dispatchQualitativeVote = async ({postId, score}: {postId: string, score: number}) => await submitVote({variables: {postId, qualitativeScore: score, year: "2018", dummy: true}})
+  const dispatchQualitativeVote = async ({postId, score}: {postId: string, score: number}) => await submitVote({variables: {postId, qualitativeScore: score, year: YEAR, dummy: true}})
 
   const quadraticVotes = dbVotes?.map(({_id, quadraticScore, postId}) => ({_id, postId, score: quadraticScore, type: "quadratic"})) as quadraticVote[]
   const dispatchQuadraticVote = async ({_id, postId, change, set}) => {
     const existingVote = _id && dbVotes.find(vote => vote._id === _id)
     await submitVote({
-      variables: {postId, quadraticChange: change, newQuadraticScore: set, year: "2018", dummy: true},
+      variables: {postId, quadraticChange: change, newQuadraticScore: set, year: YEAR, dummy: true},
       optimisticResponse: _id && {
         __typename: "Mutation",
         submitReviewVote: {
@@ -264,10 +254,10 @@ const ReviewVotingPage = ({classes}: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [!!posts, useQuadratic, !!quadraticVotes, !!votes])
 
-  if (!currentUser || currentUser.createdAt > new Date("2019-01-01")) {
+  if (!currentUser || currentUser.createdAt > new Date(`${YEAR}-01-01`)) {
     return (
       <div className={classes.message}>
-        Only users registered before 2019 can vote in the 2019 LessWrong Review
+        Only users registered before {YEAR} can vote in the {YEAR} LessWrong Review
       </div>
     )
   }
@@ -340,9 +330,9 @@ const ReviewVotingPage = ({classes}: {
         <div className={classes.rightColumn}>
           {!expandedPost && <div className={classes.expandedInfoWrapper}>
             <div className={classes.expandedInfo}>
-              <h1 className={classes.header}>Try out the vote on nominated and reviewed posts from 2018</h1>
+              <h1 className={classes.header}>Try out the vote on nominated and reviewed posts from {YEAR}</h1>
               <div className={classes.instructions}>
-                <p className={classes.warning}>For now this is just a dummy page that you can use to understand how the vote works. All submissions will be discarded, and the list of posts replaced by posts in the 2019 Review on January 12th.</p>
+                <p className={classes.warning}>For now this is just a dummy page that you can use to understand how the vote works. All submissions will be discarded, and the list of posts replaced by posts in the {YEAR} Review on January 12th.</p>
                 <p> Your vote should reflect a post’s overall level of importance (with whatever weightings seem right to you for “usefulness”, “accuracy”, “following good norms”, and other virtues).</p>
                 <p>Voting is done in two passes. First, roughly sort each post into one of the following buckets:</p>
                 <ul>
@@ -350,7 +340,7 @@ const ReviewVotingPage = ({classes}: {
                   <li><b>Neutral</b> – You wouldn't personally recommend it, but seems fine if others do. <em>(If you don’t have strong opinions about a post, leaving it ‘neutral’ is fine)</em></li>
                   <li><b>Good</b> – Useful ideas that I still think about sometimes.</li>
                   <li><b>Important</b> – A key insight or excellent distillation.</li>
-                  <li><b>Crucial</b> – One of the most significant posts of 2018, for LessWrong to discuss and build upon over the coming years.</li>
+                  <li><b>Crucial</b> – One of the most significant posts of {YEAR}, for LessWrong to discuss and build upon over the coming years.</li>
                 </ul>
                 <p>After that, click “Convert to Quadratic”, and you will then have the option to use the quadratic voting system to fine-tune your votes. (Quadratic voting gives you a limited number of “points” to spend on votes, allowing you to vote multiple times, with each additional vote on an item costing more. See <Link to="/posts/qQ7oJwnH9kkmKm2dC/feedback-request-quadratic-voting-for-the-2018-review">this post</Link> for details.)</p>
                 <p>If you’re having difficulties, please message the LessWrong Team using Intercom, the circle at the bottom right corner of the screen, or leave a comment on <Link to="/posts/zLhSjwXHnTg9QBzqH/the-final-vote-for-lw-2018-review">this post</Link>.</p>
@@ -361,7 +351,7 @@ const ReviewVotingPage = ({classes}: {
           {expandedPost && <div className={classes.expandedInfoWrapper}>
             <div className={classes.expandedInfo}>
               <div className={classes.writeAReview}>
-                <ReviewPostButton post={expandedPost} year="2018" reviewMessage={<div>
+                <ReviewPostButton post={expandedPost} year={YEAR} reviewMessage={<div>
                   <div>Write a public review for "{expandedPost.title}"</div>
                   <TextField
                     placeholder="Any thoughts about this post you want to share with other voters?"
@@ -370,24 +360,16 @@ const ReviewVotingPage = ({classes}: {
                   />
                 </div>}/>
               </div>
-              <div className={classes.reason}>
-                <div className={classes.reasonTitle}>Comment anonymously (optional)</div>
-                <CommentTextField
-                  startValue={getVoteForPost(dbVotes, expandedPost._id)?.comment}
-                  updateValue={(value) => submitVote({variables: {comment: value, postId: expandedPost._id}})}
-                  postId={expandedPost._id}
-                />
-              </div>
               <div className={classes.comments}>
                 <PostReviewsAndNominations
                   title="nomination"
                   singleLine
-                  terms={{view:"nominations2018", postId: expandedPost._id}}
+                  terms={{view:`nominations${YEAR}`, postId: expandedPost._id}}
                   post={expandedPost}
                 />
                 <PostReviewsAndNominations
                   title="review"
-                  terms={{view:"reviews2018", postId: expandedPost._id}}
+                  terms={{view:`reviews${YEAR}`, postId: expandedPost._id}}
                   post={expandedPost}
                 />
               </div>
@@ -400,40 +382,6 @@ const ReviewVotingPage = ({classes}: {
   );
 }
 
-function getVoteForPost(votes: Array<reviewVoteFragment>, postId: string) {
-  return votes.find((vote: reviewVoteFragment) => vote.postId === postId)
-}
-
-function CommentTextField({startValue, updateValue, postId}: {
-  startValue: string|undefined,
-  updateValue: (value: any)=>void,
-  postId: string,
-}) {
-  const [text, setText] = useState(startValue)
-  // Reset text when postId changes
-  useEffect(() => {
-    setText(startValue)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [postId])
-  // Spurious warning because eslint doesn't know what _.debounce does
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedUpdateValue = useCallback(_.debounce((value: any) => {
-    updateValue(value)
-  }, 500), [updateValue])
-  return <TextField
-    id="standard-multiline-static"
-    placeholder="What considerations affected your vote? These will appear anonymously in a 2018 Review roundup. The moderation team will take them as input for final decisions of what posts to include in the Best of 2018."
-    defaultValue={startValue}
-    onChange={(event) => {
-      setText(event.target.value)
-      debouncedUpdateValue(event.target.value)
-    }}
-    value={text || ""}
-    fullWidth
-    multiline
-    rows="2"
-  />
-}
 function getPostOrder(posts: Array<PostsList>, votes: Array<qualitativeVote|quadraticVote>, currentUser: UsersCurrent|null): Array<[number,number]> {
   const randomPermutation = generatePermutation(posts.length, currentUser);
   const result = posts.map(

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -21,7 +21,7 @@ import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents'
 import seedrandom from '../../lib/seedrandom';
 
 const YEAR = "2019"
-const REVIEWS_VIEW = "reviews2019" // unfortunately this can't just inhereit from YEAR so that the type-check of the view can pass.
+const REVIEWS_VIEW = "reviews2019" // unfortunately this can't just inhereit from YEAR. It needs to exactly match a view-type so that the type-check of the view can pass.
 
 const styles = (theme: ThemeType): JssStyles => ({
   grid: {

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';

--- a/packages/lesswrong/components/users/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/users/ReviewVotingPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { withStyles, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
 import sumBy from 'lodash/sumBy'
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import { useUpdate } from '../../lib/crud/withUpdate';
@@ -125,16 +124,23 @@ const styles = (theme: ThemeType): JssStyles => ({
   writeAReview: {
     paddingTop: 12,
     paddingLeft: 12,
+    paddingRight: 12,
     paddingBottom: 8,
     border: "solid 1px rgba(0,0,0,.3)",
     marginBottom: 8,
-    '& span': {
-      fontWeight: 600,
-      fontSize: "1.2rem",
-      color: "rgba(0,0,0,.87)",
-      width: "100%",
-      display: "block"
-    }
+  },
+  reviewPrompt: {
+    fontWeight: 600,
+    fontSize: "1.2rem",
+    color: "rgba(0,0,0,.87)",
+    width: "100%",
+    display: "block"
+  },
+  fakeTextfield: {
+    marginTop: 5,
+    width: "100%",
+    borderBottom: "dashed 1px rgba(0,0,0,.25)",
+    color: theme.palette.grey[400]
   },
   warning: {
     color: theme.palette.error.main
@@ -351,16 +357,13 @@ const ReviewVotingPage = ({classes}: {
           </div>}
           {expandedPost && <div className={classes.expandedInfoWrapper}>
             <div className={classes.expandedInfo}>
-              <div className={classes.writeAReview}>
                 <ReviewPostButton post={expandedPost} year={YEAR} reviewMessage={<div>
-                  <div>Write a public review for "{expandedPost.title}"</div>
-                  <TextField
-                    placeholder="Any thoughts about this post you want to share with other voters?"
-                    fullWidth
-                    disabled
-                  />
+                  <div className={classes.writeAReview}>
+                    <div className={classes.reviewPrompt}>Write a review for "{expandedPost.title}"</div>
+                    <div className={classes.fakeTextfield}>Any thoughts about this post you want to share with other voters?</div>
+                  </div>
                 </div>}/>
-              </div>
+
               <div className={classes.comments}>
                 <PostReviewsAndNominations
                   title="nomination"


### PR DESCRIPTION
This PR
– factors out year-specific strings on the reviewVoting page into a few top-level variables
– removes the anonymous comment option
– slightly improves the Review button on the reviewVoting page.
– increases the limit from 100 to 200 because not being able to see all the posts seems really annoying.

I tried to make the "reviews2019" view also just inherit from the YEAR variable, but then ran into typecheck errors where "view" doesn't accept an arbitrary string. This didn't seem important enough to figure out how to do, but if someone happens to know, that seems convenient.

This also changes the year from "2018" to "2019." I... think that might just be fine to do now, without advertising it much, but I can change it back if people disagree.

NOTE: Merging into master because I wasn't sure what our devel-cycle was going to be like this week, but could also branch this off devel if that's better.