### PR TITLE
More visibility on show personal blogposts

### DIFF
--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -49,7 +49,7 @@ const LWTooltip = ({classes, className, children, title, placement="bottom-start
       }}
       clickable={clickable}
     >
-      <div className={classes.tooltip}>{title}</div>
+      <div className={tooltip ? classes.tooltip : null}>{title}</div>
     </LWPopper>}
     
     {children}

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -11,6 +11,18 @@ import { Link } from '../../lib/reactRouterWrapper';
 import { isMobile } from '../../lib/utils/isMobile'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
+export const filteringStyles = theme => ({
+  paddingLeft: 16,
+  paddingTop: 12,
+  paddingRight: 16,
+  width: 500,
+  marginBottom: -4,
+  ...theme.typography.commentStyle,
+  [theme.breakpoints.down('xs')]: {
+    width: "calc(100% - 32px)",
+  }
+})
+
 const styles = (theme: ThemeType): JssStyles => ({
   tag: {
     ...tagStyle(theme),
@@ -29,15 +41,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginLeft: 4,
   },
   filtering: {
-    paddingLeft: 16,
-    paddingTop: 12,
-    paddingRight: 16,
-    width: 500,
-    marginBottom: -4,
-    ...theme.typography.commentStyle,
-    [theme.breakpoints.down('xs')]: {
-      width: "calc(100% - 32px)",
-    }
+    ...filteringStyles(theme)
   },
   filterRow: {
     display: "flex",

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -5,6 +5,11 @@ import { useMulti } from '../../lib/crud/withMulti';
 import * as _ from 'underscore';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useTracking } from "../../lib/analyticsEvents";
+import { useCurrentUser } from '../common/withUser';
+import { tagStyle } from './FooterTag';
+import { filteringStyles } from './FilterMode';
+import { commentBodyStyles } from '../../themes/stylePiping';
+import { Card } from '@material-ui/core';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -14,6 +19,14 @@ const styles = (theme: ThemeType): JssStyles => ({
     flexWrap: "wrap",
     alignItems: "flex-start",
     paddingBottom: 4
+  },
+  showPersonalBlogposts: {
+    ...tagStyle(theme),
+    display: "inline-block",
+    marginBottom: 4,
+    marginRight: 4,
+    border: `solid 1px rgba(0,0,0,.25)`,
+    backgroundColor: "white"
   },
   addButton: {
     backgroundColor: theme.palette.grey[300],
@@ -25,6 +38,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontWeight: 700,
     marginBottom: 4,
     cursor: "pointer"
+  },
+  personalTooltip: {
+    ...filteringStyles(theme),
+    ...commentBodyStyles(theme)
   }
 });
 
@@ -77,6 +94,8 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
     setAddedSuggestedTags(true);
   }
 
+  const currentUser = useCurrentUser()
+
   const { results: suggestedTags, loading: loadingSuggestedTags } = useMulti({
     terms: {
       view: "suggestedFilterTags",
@@ -92,6 +111,13 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
   if (suggestedTags && !addedSuggestedTags) {
     filterSettingsWithSuggestedTags = addSuggestedTagsToSettings(filterSettings, suggestedTags);
   }
+
+  const personalBlogpostCard = <Card><div className={classes.personalTooltip}>
+    <p><em>Click to show personal blogposts</em></p>
+    <div>{personalBlogpostTooltip}</div>
+  </div></Card>
+
+  const showPersonalBlogpostsButton = (currentUser && (filterSettingsWithSuggestedTags.personalBlog === "Hidden"))
 
   return <span>
     {loadingSuggestedTags && !filterSettingsWithSuggestedTags.tags.length && <Loading/>}
@@ -129,18 +155,31 @@ const TagFilterSettings = ({ filterSettings, setFilterSettings, classes }: {
       />
     )}
 
-    <FilterMode
-      label={personalBlogpostName}
-      description={personalBlogpostTooltip}
-      mode={filterSettingsWithSuggestedTags.personalBlog}
-      canRemove={false}
-      onChangeMode={(mode: FilterMode) => {
-        changeFilterSettings({
-          personalBlog: mode,
-          tags: filterSettingsWithSuggestedTags.tags,
-        });
-      }}
-    />
+
+
+    {showPersonalBlogpostsButton ?
+      <LWTooltip title={personalBlogpostCard} tooltip={false}>
+        <div className={classes.showPersonalBlogposts} onClick={() => changeFilterSettings({
+            personalBlog: 0,
+            tags: filterSettingsWithSuggestedTags.tags,
+          })}>
+          Show Personal Blogposts
+        </div>
+      </LWTooltip>
+      : 
+      <FilterMode
+        label={personalBlogpostName}
+        description={personalBlogpostTooltip}
+        mode={filterSettingsWithSuggestedTags.personalBlog}
+        canRemove={false}
+        onChangeMode={(mode: FilterMode) => {
+          changeFilterSettings({
+            personalBlog: mode,
+            tags: filterSettingsWithSuggestedTags.tags,
+          });
+        }}
+      />
+    }
 
     {<LWTooltip title="Add Tag Filter">
         <AddTagButton onTagSelected={({tagId,tagName}: {tagId: string, tagName: string}) => {


### PR DESCRIPTION
This increases the visibility of the personal-blog-filter for logged in users, who currently have it set to Hidden.

A change that might have wider ramifications: I made it so LWTooltip doesn't set it's width to 300 if the "tooltip" param is false. I checked for uses of this and *think* all the uses I could find were fine after the change, but it is possible I missed something.

![image](https://user-images.githubusercontent.com/3246710/104527897-b7bfa400-55ba-11eb-8733-0adc554f68db.png)

I think the UI happens to look a bit janky when we have a CTA Voting button right above it, but that won't be true most of the year I think.
