### PR TITLE
Frontpage personal tag improvements

### DIFF
--- a/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/menuTabs.tsx
@@ -15,6 +15,7 @@ import Sort from '@material-ui/icons/Sort'
 import Info from '@material-ui/icons/Info';
 import SupervisedUserCircleIcon from '@material-ui/icons/SupervisedUserCircle';
 import { AnalyticsContext } from "../../../lib/analyticsEvents";
+import type { ForumTypeString } from '../../../lib/instanceSettings';
 
 const EventsList = ({currentUser, onClick}) => {
   const { TabNavigationEventsList } = Components
@@ -75,7 +76,8 @@ const EventsList = ({currentUser, onClick}) => {
 //   customComponent: Component; instead of a TabNavigationItem, display this component
 //
 // See TabNavigation[Footer|Compressed]?Item.jsx for how these are used by the code
-export default {
+type MenuTab = any;
+export const menuTabs: Record<ForumTypeString,Array<MenuTab>> = {
   LessWrong: [
     {
       id: 'home',
@@ -303,3 +305,5 @@ export default {
     }
   ]
 }
+
+export default menuTabs;

--- a/packages/lesswrong/components/posts/PostsItemMeta.tsx
+++ b/packages/lesswrong/components/posts/PostsItemMeta.tsx
@@ -78,7 +78,7 @@ const PostsItemMeta = ({post, read, classes}: {
 
       <span className={classes.info}>
         <AnalyticsContext pageElementContext="tagsList">
-          <FooterTagList post={post} hideScore hideAddTag hidePersonalOrFrontpage smallText/>
+          <FooterTagList post={post} hideScore hideAddTag smallText/>
         </AnalyticsContext>
       </span>
 

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -4,7 +4,8 @@ import PersonIcon from '@material-ui/icons/Person'
 import HomeIcon from '@material-ui/icons/Home';
 import StarIcon from '@material-ui/icons/Star';
 import SubjectIcon from '@material-ui/icons/Subject';
-import { forumTypeSetting } from '../../../lib/instanceSettings';
+import { forumTypeSetting, ForumTypeString } from '../../../lib/instanceSettings';
+import { curatedUrl } from '../../recommendations/RecommendationsAndCurated';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -26,7 +27,16 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
 })
 
-export const contentTypes = {
+export type ContentTypeString = "frontpage"|"personal"|"curated"|"shortform";
+
+interface ContentTypeSettings {
+  tooltipTitle: string,
+  tooltipBody: React.ReactNode,
+  linkTarget: string|null,
+  Icon: any,
+}
+
+export const contentTypes: Record<ForumTypeString,Record<ContentTypeString,ContentTypeSettings>> = {
   LessWrong: {
     frontpage: {
       tooltipTitle: 'Frontpage Post',
@@ -38,6 +48,7 @@ export const contentTypes = {
           <li>Aiming to explain, rather than persuade</li>
         </ul>
       </React.Fragment>,
+      linkTarget: "/posts/5conQhfa4rgb4SaWx/site-guide-personal-blogposts-vs-frontpage-posts",
       Icon: HomeIcon
     },
     personal: {
@@ -55,14 +66,16 @@ export const contentTypes = {
           <li>Personal ramblings</li>
         </ul>
       </React.Fragment>,
+      linkTarget: "/posts/5conQhfa4rgb4SaWx/site-guide-personal-blogposts-vs-frontpage-posts",
       Icon: PersonIcon
     },
     curated: {
-      tooltiptitle: 'Curated Post',
+      tooltipTitle: 'Curated Post',
       tooltipBody: <div>
         The best 2-3 posts each week, selected by the moderation team. Curated
         posts are featured at the top of the front page and emailed to subscribers.
       </div>,
+      linkTarget: curatedUrl,
       Icon: StarIcon,
     },
     shortform: {
@@ -71,6 +84,7 @@ export const contentTypes = {
         Writing that is short in length, or written in a short amount of time.
         Off-the-cuff thoughts, brainstorming, early stage drafts, etc.
       </div>,
+      linkTarget: "/shortform",
       Icon: SubjectIcon
     }
   },
@@ -85,6 +99,7 @@ export const contentTypes = {
           <li>Aiming to explain, rather than persuade</li>
         </ul>
       </React.Fragment>,
+      linkTarget: null,
       Icon: HomeIcon
     },
     personal: {
@@ -101,13 +116,15 @@ export const contentTypes = {
           <li>Personal ramblings</li>
         </ul>
       </React.Fragment>,
+      linkTarget: null,
       Icon: PersonIcon
     },
     curated: {
-      tooltiptitle: 'Curated Post',
+      tooltipTitle: 'Curated Post',
       tooltipBody: <div>
         The best posts, selected by the moderation team.
       </div>,
+      linkTarget: curatedUrl,
       Icon: StarIcon,
     },
     shortform: {
@@ -116,6 +133,7 @@ export const contentTypes = {
         Writing that is short in length, or written in a short amount of time.
         Off-the-cuff thoughts, brainstorming, early stage drafts, etc.
       </div>,
+      linkTarget: "/shortform",
       Icon: SubjectIcon
     }
   },
@@ -125,6 +143,10 @@ export const contentTypes = {
       tooltipBody: <div>
         Posts that are relevant to doing good effectively.
       </div>,
+      // ea-forum-lookhere: When "frontpage" or "personal blog" appear in a tags-list,
+      // it's a link to a post explaining the policies. This is my best guess at which
+      // post that would be on EA Forum, but there might be a better one. --Jim
+      linkTarget: "/posts/5TAwep4tohN7SGp3P/the-frontpage-community-distinction",
       Icon: HomeIcon
     },
     personal: {
@@ -140,14 +162,17 @@ export const contentTypes = {
           <li>Personal ramblings</li>
         </ul>
       </React.Fragment>,
+      // ea-forum-loohere see above
+      linkTarget: "/posts/5TAwep4tohN7SGp3P/the-frontpage-community-distinction",
       Icon: PersonIcon
     },
     curated: {
-      tooltiptitle: 'Curated Post',
+      tooltipTitle: 'Curated Post',
       tooltipBody: <div>
         The best 2-3 posts each week, selected by the moderation team. Curated
         posts are featured at the top of the front page and emailed to subscribers.
       </div>,
+      linkTarget: curatedUrl,
       Icon: StarIcon,
     },
     shortform: {
@@ -156,6 +181,7 @@ export const contentTypes = {
         Writing that is short in length, or written in a short amount of time.
         Off-the-cuff thoughts, brainstorming, early stage drafts, etc.
       </div>,
+      linkTarget: "/shortform",
       Icon: SubjectIcon
     }
   }
@@ -163,7 +189,7 @@ export const contentTypes = {
 
 const ContentType = ({classes, type, label}: {
   classes: ClassesType,
-  type: string,
+  type: ContentTypeString,
   label?: string
 }) => {
   if (!type) {

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -133,7 +133,7 @@ const getPostCategory = (post: PostsBase) => {
     return categories.join(', ');
   else if (post.question)
     return "Question";
-  else if (post.reviewdByUserId)
+  else if (post.reviewedByUserId)
     return `Personal Blogpost`
   else
     return null;

--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -131,8 +131,12 @@ const getPostCategory = (post: PostsBase) => {
 
   if (categories.length > 0)
     return categories.join(', ');
+  else if (post.question)
+    return "Question";
+  else if (post.reviewdByUserId)
+    return `Personal Blogpost`
   else
-    return post.question ? `Question` : `Personal Blogpost`
+    return null;
 }
 
 const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
@@ -156,6 +160,8 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
   const renderedComment = comment || post.bestAnswer
 
   const tags = sortTags(post.tags, t=>t)
+  
+  const postCategory: string|null = getPostCategory(post);
 
   return <AnalyticsContext pageElementContext="hoverPreview">
       <Card className={classes.root}>
@@ -166,8 +172,8 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
             </div>
             <div className={classes.tooltipInfo}>
               { postsList && <span> 
-                {getPostCategory(post)}
-                {(tags?.length > 0) && " – "}
+                {postCategory}
+                {postCategory && (tags?.length > 0) && " – "}
                 {tags?.map((tag, i) => <span key={tag._id}>{tag.name}{(i !== (post.tags?.length - 1)) ? ",  " : ""}</span>)}
                 {renderWordCount && <span>{" "}<span className={classes.wordCount}>({wordCount} words)</span></span>}
               </span>}

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -5,6 +5,7 @@ import moment from '../../lib/moment-timezone';
 import { timeframeToTimeBlock, TimeframeType } from './timeframeUtils'
 import { useTimezone } from '../common/withTimezone';
 import { QueryLink } from '../../lib/reactRouterWrapper';
+import type { ContentTypeString } from './PostsPage/ContentType';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -49,7 +50,13 @@ const styles = (theme: ThemeType): JssStyles => ({
   divider: {/* Exists only to get overriden by the eaTheme */}
 })
 
-const postTypes = [
+interface PostTypeOptions {
+  name: ContentTypeString
+  postIsType: (post: PostsBase)=>boolean
+  label: string
+}
+
+const postTypes: PostTypeOptions[] = [
   {name: 'frontpage', postIsType: (post: PostsBase) => !!post.frontpageDate, label: 'Frontpage Posts'},
   {name: 'personal', postIsType: (post: PostsBase) => !post.frontpageDate, label: 'Personal Blogposts'}
 ]

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -10,7 +10,6 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import { tagStyle } from './FooterTag';
 import classNames from 'classnames';
 import { commentBodyStyles } from '../../themes/stylePiping'
-import { curatedUrl } from '../recommendations/RecommendationsAndCurated'
 import Card from '@material-ui/core/Card';
 import { Link } from '../../lib/reactRouterWrapper';
 import * as _ from 'underscore';
@@ -97,22 +96,39 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFron
   }, [setIsAwaiting, mutate, refetch, post._id, captureEvent]);
 
   const { Loading, FooterTag } = Components
+  
+  const MaybeLink = ({to, children}: {
+    to: string|null
+    children: React.ReactNode
+  }) => {
+    if (to) {
+      return <Link to={to}>{children}</Link>
+    } else {
+      return <>{children}</>;
+    }
+  }
+  
+  const contentTypeInfo = contentTypes[forumTypeSetting.get()];
 
   let postType = <></>
   if (!hidePersonalOrFrontpage) {
     postType = post.curatedDate
-      ? <Link to={curatedUrl}>
-          <LWTooltip title={<Card className={classes.card}>{contentTypes[forumTypeSetting.get()].curated.tooltipBody}</Card>} tooltip={false}>
+      ? <Link to={contentTypeInfo.curated.linkTarget}>
+          <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.curated.tooltipBody}</Card>} tooltip={false}>
             <div className={classes.frontpageOrPersonal}>Curated</div>
           </LWTooltip>
         </Link>
       : post.frontpageDate
-        ? <LWTooltip title={<Card className={classes.card}>{contentTypes[forumTypeSetting.get()].frontpage.tooltipBody}</Card>} tooltip={false}>
-            <div className={classes.frontpageOrPersonal}>Frontpage</div>
-          </LWTooltip>
-        : <LWTooltip title={<Card className={classes.card}>{contentTypes[forumTypeSetting.get()].personal.tooltipBody}</Card>} tooltip={false}>
-            <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
-          </LWTooltip>
+        ? <MaybeLink to={contentTypeInfo.frontpage.linkTarget}>
+            <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.frontpage.tooltipBody}</Card>} tooltip={false}>
+              <div className={classes.frontpageOrPersonal}>Frontpage</div>
+            </LWTooltip>
+          </MaybeLink>
+        : <MaybeLink to={contentTypeInfo.personal.linkTarget}>
+            <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.personal.tooltipBody}</Card>} tooltip={false}>
+              <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
+            </LWTooltip>
+          </MaybeLink>
   }
 
   if (loading || !results) {

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -46,12 +46,11 @@ export function sortTags<T>(list: Array<T>, toTag: (item: T)=>TagBasicInfo|null|
   return _.sortBy(list, item=>toTag(item)?.core);
 }
 
-const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFrontpage, smallText=false}: {
+const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false}: {
   post: PostsWithNavigation | PostsWithNavigationAndRevision | PostsList | SunshinePostsList,
   classes: ClassesType,
   hideScore?: boolean,
   hideAddTag?: boolean,
-  hidePersonalOrFrontpage?: boolean,
   smallText?: boolean
 
 }) => {
@@ -110,26 +109,23 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, hidePersonalOrFron
   
   const contentTypeInfo = contentTypes[forumTypeSetting.get()];
 
-  let postType = <></>
-  if (!hidePersonalOrFrontpage) {
-    postType = post.curatedDate
-      ? <Link to={contentTypeInfo.curated.linkTarget}>
-          <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.curated.tooltipBody}</Card>} tooltip={false}>
-            <div className={classes.frontpageOrPersonal}>Curated</div>
+  let postType = post.curatedDate
+    ? <Link to={contentTypeInfo.curated.linkTarget}>
+        <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.curated.tooltipBody}</Card>} tooltip={false}>
+          <div className={classes.frontpageOrPersonal}>Curated</div>
+        </LWTooltip>
+      </Link>
+    : post.frontpageDate
+      ? <MaybeLink to={contentTypeInfo.frontpage.linkTarget}>
+          <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.frontpage.tooltipBody}</Card>} tooltip={false}>
+            <div className={classes.frontpageOrPersonal}>Frontpage</div>
           </LWTooltip>
-        </Link>
-      : post.frontpageDate
-        ? <MaybeLink to={contentTypeInfo.frontpage.linkTarget}>
-            <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.frontpage.tooltipBody}</Card>} tooltip={false}>
-              <div className={classes.frontpageOrPersonal}>Frontpage</div>
-            </LWTooltip>
-          </MaybeLink>
-        : <MaybeLink to={contentTypeInfo.personal.linkTarget}>
-            <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.personal.tooltipBody}</Card>} tooltip={false}>
-              <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
-            </LWTooltip>
-          </MaybeLink>
-  }
+        </MaybeLink>
+      : <MaybeLink to={contentTypeInfo.personal.linkTarget}>
+          <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.personal.tooltipBody}</Card>} tooltip={false}>
+            <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
+          </LWTooltip>
+        </MaybeLink>
 
   if (loading || !results) {
     return <div className={classes.root}>

--- a/packages/lesswrong/components/tagging/FooterTagList.tsx
+++ b/packages/lesswrong/components/tagging/FooterTagList.tsx
@@ -109,23 +109,30 @@ const FooterTagList = ({post, classes, hideScore, hideAddTag, smallText=false}: 
   
   const contentTypeInfo = contentTypes[forumTypeSetting.get()];
 
+  // Post type is either Curated, Frontpage, Personal, or uncategorized (in which case
+  // we don't show any indicator). It's uncategorized if it's not frontpaged and doesn't
+  // have reviewedByUserId set to anything.
   let postType = post.curatedDate
     ? <Link to={contentTypeInfo.curated.linkTarget}>
         <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.curated.tooltipBody}</Card>} tooltip={false}>
           <div className={classes.frontpageOrPersonal}>Curated</div>
         </LWTooltip>
       </Link>
-    : post.frontpageDate
+    : (post.frontpageDate
       ? <MaybeLink to={contentTypeInfo.frontpage.linkTarget}>
           <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.frontpage.tooltipBody}</Card>} tooltip={false}>
             <div className={classes.frontpageOrPersonal}>Frontpage</div>
           </LWTooltip>
         </MaybeLink>
-      : <MaybeLink to={contentTypeInfo.personal.linkTarget}>
-          <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.personal.tooltipBody}</Card>} tooltip={false}>
-            <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
-          </LWTooltip>
-        </MaybeLink>
+      : (post.reviewedByUserId
+        ? <MaybeLink to={contentTypeInfo.personal.linkTarget}>
+            <LWTooltip title={<Card className={classes.card}>{contentTypeInfo.personal.tooltipBody}</Card>} tooltip={false}>
+              <div className={classNames(classes.tag, classes.frontpageOrPersonal)}>Personal Blog</div>
+            </LWTooltip>
+          </MaybeLink>
+        : null
+      )
+    )
 
   if (loading || !results) {
     return <div className={classes.root}>

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -101,7 +101,8 @@ export class PublicInstanceSetting<SettingValueType> {
   Public Instance Settings
 */
 
-export const forumTypeSetting = new PublicInstanceSetting<string>('forumType', 'LessWrong', 'warning') // What type of Forum is being run, {LessWrong, AlignmentForum, EAForum}
+export type ForumTypeString = "LessWrong"|"AlignmentForum"|"EAForum";
+export const forumTypeSetting = new PublicInstanceSetting<ForumTypeString>('forumType', 'LessWrong', 'warning') // What type of Forum is being run, {LessWrong, AlignmentForum, EAForum}
 export const forumTitleSetting = new PublicInstanceSetting<string>('title', 'LessWrong', 'warning') // Default title for URLs
 
 // Your site name may be referred to as "The Alignment Forum" or simply "LessWrong". Use this setting to prevent something like "view on Alignment Forum". Leave the article uncapitalized ("the Alignment Forum") and capitalize if necessary.


### PR DESCRIPTION
Changes to make the Frontpage/Personal thing easier to understand/more legible.

 * Frontpage/Personal buttons in the tag-list are links to a post about the distinction
 * The Frontpage/Personal/Curated status is shown in Recent Discussion
 * Posts are not marked as Personal Blog in their tag list or hover preview if they have not yet been reviewed