### PR TITLE
No intermediate degree symbol on tags

### DIFF
--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -35,8 +35,8 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}
   const { PopperCard, TagPreview, Loading } = Components;
   const { hover, anchorEl, eventHandlers } = useHover();
   const { showPostCount: showPostCountQuery, useTagName: useTagNameQuery } = targetLocation.query
-  const showPostCount = tag && tag.postCount && showPostCountQuery === "true" // query parameters are stored as strings
-  const useTagName = tag && tag.name && useTagNameQuery === "true" // query parameters are stored as strings
+  const showPostCount = showPostCountQuery === "true" // query parameters are strings
+  const useTagName = tag && tag.name && useTagNameQuery === "true" // query parameters are strings
 
   return <span {...eventHandlers}>
     <PopperCard open={hover} anchorEl={anchorEl}>
@@ -49,7 +49,7 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}
       to={href}
       dangerouslySetInnerHTML={{__html: useTagName ? tag?.name : innerHTML}}
     />
-    {!!showPostCount && <span className={classes.count}>({tag?.postCount})</span>}
+    {!!(showPostCount && tag?.postCount) && <span className={classes.count}>({tag?.postCount})</span>}
   </span>;
 }
 

--- a/packages/lesswrong/components/tagging/TagHoverPreview.tsx
+++ b/packages/lesswrong/components/tagging/TagHoverPreview.tsx
@@ -4,6 +4,7 @@ import { useHover } from '../common/withHover';
 import { Link } from '../../lib/reactRouterWrapper';
 import { useTagBySlug } from './useTag';
 import { linkStyle } from '../linkPreview/PostLinkPreview';
+import { removeUrlParameters } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   link: {
@@ -22,6 +23,9 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 });
 
+function normalizeTagLink(link: string) {
+  return removeUrlParameters(link, ["showPostCount", "useTagName"]);
+}
 
 const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}: {
   href: string,
@@ -37,6 +41,9 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}
   const { showPostCount: showPostCountQuery, useTagName: useTagNameQuery } = targetLocation.query
   const showPostCount = showPostCountQuery === "true" // query parameters are strings
   const useTagName = tag && tag.name && useTagNameQuery === "true" // query parameters are strings
+  
+  // Remove showPostCount and useTagName query parameters from the link, if present
+  const linkTarget = normalizeTagLink(href);
 
   return <span {...eventHandlers}>
     <PopperCard open={hover} anchorEl={anchorEl}>
@@ -46,7 +53,7 @@ const TagHoverPreview = ({href, targetLocation, innerHTML, classes, postCount=6}
     </PopperCard>
     <Link
       className={showPostCount ? classes.linkWithoutDegreeSymbol : classes.link}
-      to={href}
+      to={linkTarget}
       dangerouslySetInnerHTML={{__html: useTagName ? tag?.name : innerHTML}}
     />
     {!!(showPostCount && tag?.postCount) && <span className={classes.count}>({tag?.postCount})</span>}

--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -4,6 +4,7 @@ import React, { useContext } from 'react';
 import { forumTypeSetting } from './instanceSettings';
 import { LocationContext, NavigationContext, ServerRequestStatusContext, SubscribeLocationContext, ServerRequestStatusContextType } from './vulcan-core/appContext';
 import type { RouterLocation } from './vulcan-lib/routes';
+import * as _ from 'underscore';
 
 // Given the props of a component which has withRouter, return the parsed query
 // from the URL.
@@ -107,6 +108,24 @@ export const getUrlClass = (): typeof URL => {
   } else {
     return URL
   }
+}
+
+// Given a URL which might or might not have query parameters, return a URL in
+// which any query parameters found in queryParameterBlacklist are removed.
+export const removeUrlParameters = (url: string, queryParameterBlacklist: string[]): string => {
+  if (url.indexOf("?") < 0) return url;
+  const [baseUrl, queryAndHash] = url.split("?");
+  const [query, hash] = queryAndHash.split("#");
+  
+  const parsedQuery = qs.parse(query);
+  let filteredQuery = {};
+  for (let key of _.keys(parsedQuery)) {
+    if (_.indexOf(queryParameterBlacklist, key) < 0) {
+      filteredQuery[key] = parsedQuery[key];
+    }
+  }
+  
+  return baseUrl + (Object.keys(filteredQuery).length>0 ? '?'+qs.stringify(filteredQuery) : '') + (hash ? '#'+hash : '');
 }
 
 const LwAfDomainWhitelist: Array<string> = [


### PR DESCRIPTION
Before: Links to tags with showPostCount=true are bare in the SSR, then switch to having a degree symbol, then switch a second time to having a post count. This removes the second of those three states.

Also, if a tag link has query parameters that influence the preview, ie `showPostCount` and `useTagName`, leave them out of the link target.