### PR TITLE
Show (some) children of reviews on voting page

### DIFF
--- a/packages/lesswrong/components/comments/CommentWithReplies.tsx
+++ b/packages/lesswrong/components/comments/CommentWithReplies.tsx
@@ -19,7 +19,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const CommentWithReplies = ({comment, post, refetch, showTitle=true, expandByDefault, classes}: {
   comment: CommentWithRepliesFragment,
   post: PostsBase,
-  refetch: any,
+  refetch?: any,
   showTitle?: boolean,
   expandByDefault?: boolean,
   classes: ClassesType,

--- a/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
+++ b/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
@@ -58,7 +58,7 @@ const PostReviewsAndNominations = ({ terms, classes, title, post, singleLine }: 
           forceSingleLine
         />
         : <div>
-          {results && results.map((comment) => <CommentWithReplies comment={comment} post={comment.post}/>)}
+          {results && results.map((comment) => <CommentWithReplies key={comment._id} comment={comment} post={post}/>)}
           <LoadMore {...loadMoreProps} />
         </div>}
       </SubSection>

--- a/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
+++ b/packages/lesswrong/components/review/PostReviewsAndNominations.tsx
@@ -21,16 +21,15 @@ const PostReviewsAndNominations = ({ terms, classes, title, post, singleLine }: 
   singleLine?: boolean,
 }) => {
 
-  const { loading, results } = useMulti({
+  const { loading, results, loadMoreProps } = useMulti({
     terms,
     collectionName: "Comments",
-    fragmentName: 'CommentsList',
+    fragmentName: 'CommentWithRepliesFragment',
     fetchPolicy: 'cache-and-network',
-    limit: 5,
-    // enableTotal: false,
+    limit: 5
   });
   
-  const { Loading, CommentsList, SubSection } = Components
+  const { Loading, CommentsList, SubSection, CommentWithReplies, LoadMore } = Components
 
   if (!loading && results && !results.length) {
     return null
@@ -47,18 +46,21 @@ const PostReviewsAndNominations = ({ terms, classes, title, post, singleLine }: 
         {(results && results.length > 1) && "s"}
       </div>}
       <SubSection>
-        <CommentsList
+        {singleLine ? <CommentsList
           treeOptions={{
             lastCommentId: lastCommentId,
-            hideSingleLineMeta: singleLine,
+            hideSingleLineMeta: true,
             enableHoverPreview: false,
             post: post,
           }}
           comments={nestedComments}
           startThreadTruncated={true}
-          forceSingleLine={singleLine}
-          forceNotSingleLine={!singleLine}
+          forceSingleLine
         />
+        : <div>
+          {results && results.map((comment) => <CommentWithReplies comment={comment} post={comment.post}/>)}
+          <LoadMore {...loadMoreProps} />
+        </div>}
       </SubSection>
     </div>
   );


### PR DESCRIPTION
This uses the tools we built to show some (but not all) children of shortform comments to make the Voting page more legible. (i.e. if there's been a huge thread on a given review-comment, you won't see all 20 replies, but you'll see the most recent 3 replies, and see that there are more you can view)

![image](https://user-images.githubusercontent.com/3246710/104988824-eb8d3600-59cd-11eb-9dea-026b3ca1698b.png)
