### PR TITLE
Fix bugs discovered while investigating user form issue

### DIFF
--- a/packages/lesswrong/client/vulcan-lib/apollo-client/links/error.ts
+++ b/packages/lesswrong/client/vulcan-lib/apollo-client/links/error.ts
@@ -5,8 +5,9 @@ const locationsToStr = (locations:Array<any> = []) => locations.map(({column, li
 const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
     graphQLErrors.map(({ message, locations, path }) => {
+      const locationStr = locations && locationsToStr([...locations])
       // eslint-disable-next-line no-console
-      console.log(`[GraphQL error]: Message: ${message}, Location: ${locationsToStr([...locations])}, Path: ${path}`);
+      console.log(`[GraphQL error]: Message: ${message}, Location: ${locationStr}, Path: ${path}`);
     });
   if (networkError) {
     // eslint-disable-next-line no-console

--- a/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
+++ b/packages/lesswrong/components/vulcan-forms/FormErrors.tsx
@@ -30,39 +30,3 @@ declare global {
     FormErrors: typeof FormErrorsComponent
   }
 }
-
-// /*
-
-//   Render errors
-
-//   */
-//  renderErrors = () => {
-//   return (
-//     <div className="form-errors">
-//       {this.state.errors.map((error, index) => {
-//         let message;
-
-//         if (error.data && error.data.errors) {
-//           // this error is a "multi-error" with multiple sub-errors
-
-//           message = error.data.errors.map(error => {
-//             return {
-//               content: this.getErrorMessage(error),
-//               data: error.data,
-//             };
-//           });
-//         } else {
-//           // this is a regular error
-
-//           message = {
-//             content:
-//               error.message ||
-//               this.context.intl.formatMessage({ id: error.id, defaultMessage: error.id }, error.data),
-//           };
-//         }
-
-//         return <Components.FormFlash key={index} message={message} type="error" />;
-//       })}
-//     </div>
-//   );
-// };

--- a/packages/lesswrong/lib/vulcan-lib/intl.ts
+++ b/packages/lesswrong/lib/vulcan-lib/intl.ts
@@ -31,8 +31,6 @@ export const getString = ({id, values, defaultMessage, locale}) => {
     // if default locale hasn't got the message too
     if(!message && locale !== defaultLocale)
       debug(`\x1b[32m>> INTL: No string found for id "${id}" in the default locale ("${defaultLocale}").\x1b[0m`);
-    
-    return defaultMessage
   }
 
   if (message && values) {
@@ -40,7 +38,7 @@ export const getString = ({id, values, defaultMessage, locale}) => {
       message = replaceAll(message, `{${key}}`, values[key]);
     });
   }
-  return message;
+  return message || defaultMessage;
 };
 
 /*

--- a/packages/lesswrong/lib/vulcan-lib/intl.ts
+++ b/packages/lesswrong/lib/vulcan-lib/intl.ts
@@ -31,6 +31,8 @@ export const getString = ({id, values, defaultMessage, locale}) => {
     // if default locale hasn't got the message too
     if(!message && locale !== defaultLocale)
       debug(`\x1b[32m>> INTL: No string found for id "${id}" in the default locale ("${defaultLocale}").\x1b[0m`);
+    
+    return defaultMessage
   }
 
   if (message && values) {

--- a/packages/lesswrong/server/vulcan-users/callbacks.ts
+++ b/packages/lesswrong/server/vulcan-users/callbacks.ts
@@ -26,7 +26,7 @@ getCollectionHooks("Users").editSync.add(function usersEditCheckEmail (modifier,
       }
 
       // if user.emails exists, change it too
-      if (!!user.emails) {
+      if (!!user.emails && user.emails.length) {
         if (user.emails[0].address !== newEmail) {
           user.emails[0].address = newEmail;
           user.emails[0].verified = false;
@@ -38,4 +38,3 @@ getCollectionHooks("Users").editSync.add(function usersEditCheckEmail (modifier,
     }
     return modifier;
 });
-


### PR DESCRIPTION
Three bugs:
 * Need to null check the strange copy of error locations.
 * If no internationalization message is found, return the default message.
 * Guard against empty list when updating emails.[1]

[1] It took me too long to memorize these so I'll repeat them here for helpfulness:
```
0: falsey
"": falsey
[]: truthy
{}: truthy
```