### PR TITLE
Update lastCommentedAt for commentless posts on new postedAt

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -203,7 +203,7 @@ addFieldsDict(Posts, {
     optional: true,
     hidden: true,
     viewableBy: ['guests'],
-    onInsert: () => new Date(),
+    onInsert: (post: DbPost) => post.postedAt || new Date(),
   },
 
   // curatedDate: Date at which the post was promoted to curated (null or false

--- a/packages/lesswrong/server/callbacks/postCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/postCallbacks.ts
@@ -191,3 +191,16 @@ async function extractSocialPreviewImage (post: DbPost) {
 
 getCollectionHooks("Posts").editAsync.add(async function updatedExtractSocialPreviewImage(post: DbPost) {await extractSocialPreviewImage(post)})
 getCollectionHooks("Posts").newAfter.add(extractSocialPreviewImage)
+
+// For posts without comments, update lastCommentedAt to match postedAt
+//
+// When the post is created, lastCommentedAt was set to the current date. If an
+// admin or site feature updates postedAt that should change the "newness" of
+// the post unless there's been active comments.
+async function oldPostsLastCommentedAt (post: DbPost) {
+  if (post.commentCount) return
+
+  Posts.update({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
+}
+
+getCollectionHooks("Posts").editAsync.add(oldPostsLastCommentedAt)


### PR DESCRIPTION
```
// For posts without comments, update lastCommentedAt to match postedAt
//
// When the post is created, lastCommentedAt was set to the current date. If an
// admin or site feature updates postedAt that should change the "newness" of
// the post unless there's been active comments.
```

The motivating factor is Aaron's desire to ad a bunch of old posts without them clogging up recent discussion.