### PR TITLE
visitedAt recent discussion items are smaller

### DIFF
--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop:theme.spacing.unit*2
   },
   maxHeight: {
-    maxHeight: 500,
+    maxHeight: 600,
   },
 })
 

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop:theme.spacing.unit*2
   },
   maxHeight: {
-    maxHeight: 1000,
+    maxHeight: 500,
   },
 })
 

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -175,7 +175,7 @@ const RecentDiscussionThread = ({
             </div>
           </div>
           <div className={highlightClasses}>
-            <PostsHighlight post={post} maxLengthWords={200} />
+            <PostsHighlight post={post} maxLengthWords={lastVisitedAt ? 50 : 200} />
           </div>
         </div>
         {nestedComments.length ? <div className={classes.content}>

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionThread.tsx
@@ -175,7 +175,7 @@ const RecentDiscussionThread = ({
             </div>
           </div>
           <div className={highlightClasses}>
-            <PostsHighlight post={post} maxLengthWords={lastVisitedAt ? 50 : 200} />
+            <PostsHighlight post={post} maxLengthWords={lastVisitedAt ? 50 : 170} />
           </div>
         </div>
         {nestedComments.length ? <div className={classes.content}>


### PR DESCRIPTION
Makes recent discussion highlights smaller if you've already read them, and sets the maxHeight to 500 instead of 1000px.

(note: at some point someone should fix highlights such that if they have a bunch of images, the "show more" button doesn't get crowed out below the max-height)