### PR TITLE
SunshineReportItem-hover-over uses CommentsNode

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -1,9 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
-import { Comments } from '../../lib/collections/comments/collection';
-import { commentGetPageUrlFromIds } from '../../lib/collections/comments/helpers';
 import { commentBodyStyles } from '../../themes/stylePiping'
-import { Link } from '../../lib/reactRouterWrapper'
 import _filter from 'lodash/filter';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -34,7 +31,7 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
   classes: ClassesType,
   user: SunshineUsersList
 }) => {
-  const { FormatDate, MetaInfo, SmallSideVote } = Components
+  const { CommentsNode } = Components
 
   if (!comments) return null 
 
@@ -42,19 +39,14 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
 
   return (
     <div className={classes.root}>
-      {(newComments.length > 0) && newComments.map(comment=><div className={classes.comment} key={comment._id}>
-        <Link to={commentGetPageUrlFromIds({postId: comment.post?._id, postSlug: comment.post?.slug, tagSlug: comment.tag?.slug, commentId: comment._id})}>
-          <MetaInfo>
-            {comment.deleted && "[Deleted] "}Comment on '{comment.post?.title}'
-          </MetaInfo>
-          <span className={classes.meta}>
-            <MetaInfo><FormatDate date={comment.postedAt}/></MetaInfo>
-            <SmallSideVote document={comment} collection={Comments}/>
-          </span>
-        </Link>
-        {comment.deleted && <div><MetaInfo>{`[Comment deleted${comment.deletedReason ? ` because "${comment.deletedReason}"` : ""}]`}</MetaInfo></div>}
-        <div className={classes.commentStyle} dangerouslySetInnerHTML={{__html: (comment.contents && comment.contents.html) || ""}} />
-      </div>)}
+      {(newComments.length > 0) && newComments.map(comment=><CommentsNode
+              treeOptions={{
+                condensed: false,
+                post: comment.post || undefined,
+                showPostTitle: true,
+              }}
+              comment={comment}
+            />)}
     </div>
   )
 }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -39,7 +39,8 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
 
   return (
     <div className={classes.root}>
-      {(newComments.length > 0) && newComments.map(comment=><CommentsNode
+      {(newComments.length > 0) && newComments.map(comment=><CommentsNode 
+              key={`sunshine-new-user-${comment._id}`}
               treeOptions={{
                 condensed: false,
                 post: comment.post || undefined,

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -1,8 +1,6 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
 import React, { Component } from 'react';
-import { Link } from '../../lib/reactRouterWrapper'
-import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import withHover from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import withUser from '../common/withUser'

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -70,7 +70,7 @@ class SunshineReportedItem extends Component<SunshineReportedItemProps> {
     const { report, hover, anchorEl } = this.props
     const comment = report.comment
     const post = report.post
-    const { MetaInfo, SunshineListItem, SidebarInfo, SidebarHoverOver, CommentBody, PostsHighlight, SidebarActionMenu, SidebarAction, FormatDate, CommentsNode, Typography, SunshineCommentsItemOverview } = Components
+    const { SunshineListItem, SidebarInfo, SidebarHoverOver, PostsTitle, PostsHighlight, SidebarActionMenu, SidebarAction, FormatDate, CommentsNode, Typography, SunshineCommentsItemOverview } = Components
 
     if (!post) return null;
 
@@ -78,9 +78,6 @@ class SunshineReportedItem extends Component<SunshineReportedItemProps> {
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl} >
           <Typography variant="body2">
-            <Link to={postGetPageUrl(post) + (comment ? ("#" + comment._id) : (""))}>
-              Post: <strong>{ post.title }</strong>
-            </Link>
             {comment && <CommentsNode
               treeOptions={{
                 condensed: false,
@@ -89,7 +86,10 @@ class SunshineReportedItem extends Component<SunshineReportedItemProps> {
               }}
               comment={comment}
             />}
-            {!comment && <PostsHighlight post={post} maxLengthWords={600}/>}
+            {!comment && <div>
+              <PostsTitle post={post}/>
+              <PostsHighlight post={post} maxLengthWords={600}/>
+            </div>}
           </Typography>
         </SidebarHoverOver>
         {comment && <SunshineCommentsItemOverview comment={comment}/>}

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -70,7 +70,7 @@ class SunshineReportedItem extends Component<SunshineReportedItemProps> {
     const { report, hover, anchorEl } = this.props
     const comment = report.comment
     const post = report.post
-    const { MetaInfo, SunshineListItem, SidebarInfo, SidebarHoverOver, CommentBody, PostsHighlight, SidebarActionMenu, SidebarAction, FormatDate, SunshineCommentsItemOverview, Typography } = Components
+    const { MetaInfo, SunshineListItem, SidebarInfo, SidebarHoverOver, CommentBody, PostsHighlight, SidebarActionMenu, SidebarAction, FormatDate, CommentsNode, Typography, SunshineCommentsItemOverview } = Components
 
     if (!post) return null;
 
@@ -81,10 +81,14 @@ class SunshineReportedItem extends Component<SunshineReportedItemProps> {
             <Link to={postGetPageUrl(post) + (comment ? ("#" + comment._id) : (""))}>
               Post: <strong>{ post.title }</strong>
             </Link>
-            {comment && <div>
-              <MetaInfo>Comment:</MetaInfo>
-              <div><CommentBody comment={comment}/></div>
-            </div>}
+            {comment && <CommentsNode
+              treeOptions={{
+                condensed: false,
+                post: comment.post || undefined,
+                showPostTitle: true,
+              }}
+              comment={comment}
+            />}
             {!comment && <PostsHighlight post={post} maxLengthWords={600}/>}
           </Typography>
         </SidebarHoverOver>


### PR DESCRIPTION
I found it hard to tell when a reported item was a post, or comment. Also I usually care about seeing the parent comment if there is one. I switched it from using a custom sunshine component to using the usual CommentsNode