### PR TITLE
noIndex for users with no posts, comments or karma

### DIFF
--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -225,6 +225,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
       <div className={classNames("page", "users-profile", classes.profilePage)}>
         <HeadTags
           description={metaDescription}
+          noIndex={!user.postCount || !user.commentCount || user.karma <= 0}
         />
         <AnalyticsContext pageContext={"userPage"}>
           {/* Bio Section */}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -225,7 +225,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
       <div className={classNames("page", "users-profile", classes.profilePage)}>
         <HeadTags
           description={metaDescription}
-          noIndex={!user.postCount || !user.commentCount || user.karma <= 0}
+          noIndex={(!user.postCount && !user.commentCount) || user.karma <= 0}
         />
         <AnalyticsContext pageContext={"userPage"}>
           {/* Bio Section */}


### PR DESCRIPTION
I'm not sure I did this right, but the idea is:

Sometimes users make bios that look _plausibly_ spammy, but not overdeterminedly spammy, before they make their first post. We mostly don't want to have to evaluate those bios. It'd be nice if they just didn't give the spammer any credit for existing, so we didn't have to worry about them. I'm not sure this is actually sufficient to discourage spammers but seemed like an improvement over status quo.