### PR TITLE
fix max height recent-discussion bug

### DIFF
--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { truncate } from '../../lib/editor/ellipsize';
+import classNames from 'classnames';
 
 const styles = theme => ({
   maxHeight: {
@@ -11,13 +12,12 @@ const styles = theme => ({
 
 // ContentItemTruncated: Wrapper around ContentItemBody with options for
 // limiting length and height in various ways.
-const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description, maxHeight=false}: {
+const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description}: {
   classes: ClassesType,
   maxLengthWords: number,
   graceWords?: number,
   expanded?: boolean,
-  rawWordCount: number,
-  maxHeight?: boolean,
+  rawWordCount: number
   
   // Suffix, shown only if truncated
   getTruncatedSuffix?: (props: {wordsLeft: number}) => React.ReactNode,
@@ -40,13 +40,11 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
     } : truncateWithGrace(html, maxLengthWords, graceWords, rawWordCount);
   
   return <>
-    <div className={maxHeight ? classes.maxHeight : null}>
-      <ContentItemBody
-        dangerouslySetInnerHTML={{__html: truncatedHtml}}
-        className={className}
-        description={description}
-      />
-    </div>
+    <ContentItemBody
+      dangerouslySetInnerHTML={{__html: truncatedHtml}}
+      className={classNames(className, {[classes.maxHeight]:!expanded})}
+      description={description}
+    />
     {wasTruncated && getTruncatedSuffix && getTruncatedSuffix({wordsLeft})}
     {!wasTruncated && nonTruncatedSuffix}
   </>

--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -17,8 +17,7 @@ const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=
   maxLengthWords: number,
   graceWords?: number,
   expanded?: boolean,
-  rawWordCount: number
-  
+  rawWordCount: number,
   // Suffix, shown only if truncated
   getTruncatedSuffix?: (props: {wordsLeft: number}) => React.ReactNode,
   // Alternate suffix, shown if truncated didn't happen (because it wasn't long

--- a/packages/lesswrong/components/common/ContentItemTruncated.tsx
+++ b/packages/lesswrong/components/common/ContentItemTruncated.tsx
@@ -2,13 +2,22 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { truncate } from '../../lib/editor/ellipsize';
 
+const styles = theme => ({
+  maxHeight: {
+    maxHeight: 600,
+    overflow: "hidden"
+  }
+})
+
 // ContentItemTruncated: Wrapper around ContentItemBody with options for
 // limiting length and height in various ways.
-const ContentItemTruncated = ({maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description}: {
+const ContentItemTruncated = ({classes, maxLengthWords, graceWords=20, expanded=false, rawWordCount, getTruncatedSuffix, nonTruncatedSuffix, dangerouslySetInnerHTML, className, description, maxHeight=false}: {
+  classes: ClassesType,
   maxLengthWords: number,
   graceWords?: number,
   expanded?: boolean,
   rawWordCount: number,
+  maxHeight?: boolean,
   
   // Suffix, shown only if truncated
   getTruncatedSuffix?: (props: {wordsLeft: number}) => React.ReactNode,
@@ -31,11 +40,13 @@ const ContentItemTruncated = ({maxLengthWords, graceWords=20, expanded=false, ra
     } : truncateWithGrace(html, maxLengthWords, graceWords, rawWordCount);
   
   return <>
-    <ContentItemBody
-      dangerouslySetInnerHTML={{__html: truncatedHtml}}
-      className={className}
-      description={description}
-    />
+    <div className={maxHeight ? classes.maxHeight : null}>
+      <ContentItemBody
+        dangerouslySetInnerHTML={{__html: truncatedHtml}}
+        className={className}
+        description={description}
+      />
+    </div>
     {wasTruncated && getTruncatedSuffix && getTruncatedSuffix({wordsLeft})}
     {!wasTruncated && nonTruncatedSuffix}
   </>
@@ -63,7 +74,7 @@ const truncateWithGrace = (html: string, maxLengthWords: number, graceWords: num
   };
 }
 
-const ContentItemTruncatedComponent = registerComponent('ContentItemTruncated', ContentItemTruncated);
+const ContentItemTruncatedComponent = registerComponent('ContentItemTruncated', ContentItemTruncated, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -12,10 +12,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   highlightContinue: {
     marginTop:theme.spacing.unit*2
-  },
-  maxHeight: {
-    maxHeight: 600,
-  },
+  }
 })
 
 const PostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
@@ -39,10 +36,11 @@ const PostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
     ev.preventDefault();
   }, []);
   
-  return <div className={classNames(classes.root, {[classes.maxHeight]: !expanded})}>
+  return <div className={classes.root}>
     <Components.LinkPostMessage post={post} />
     <Components.ContentItemTruncated
       maxLengthWords={maxLengthWords}
+      maxHeight={!expanded}
       graceWords={20}
       rawWordCount={wordCount}
       expanded={expanded}

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -39,7 +39,6 @@ const PostsHighlight = ({post, maxLengthWords, forceSeeMore=false, classes}: {
     <Components.LinkPostMessage post={post} />
     <Components.ContentItemTruncated
       maxLengthWords={maxLengthWords}
-      maxHeight={!expanded}
       graceWords={20}
       rawWordCount={wordCount}
       expanded={expanded}

--- a/packages/lesswrong/components/posts/PostsHighlight.tsx
+++ b/packages/lesswrong/components/posts/PostsHighlight.tsx
@@ -4,7 +4,6 @@ import React, {useState, useCallback} from 'react';
 import { postHighlightStyles } from '../../themes/stylePiping'
 import { Link } from '../../lib/reactRouterWrapper';
 import { useSingle } from '../../lib/crud/withSingle';
-import classNames from 'classnames';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {


### PR DESCRIPTION
Fixes the issue in recent discussion where large images would hit the max-height of a postHighlight, and then prevent the "show all" button from appearing.