### PR TITLE
Move suggest curated to top of sidebar

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -48,11 +48,11 @@ const SunshineSidebar = ({classes}: {classes: ClassesType}) => {
   return (
     <div className={classes.root}>
       {showInitialSidebar && <div className={classes.background}>
+        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         <SunshineNewPostsList terms={{view:"sunshineNewPosts"}}/>
         <SunshineNewUsersList terms={{view:"sunshineNewUsers", limit: 10}}/>
         <SunshineReportedContentList terms={{view:"sunshineSidebarReports", limit: 30}}/>
         <SunshineNewTagsList />
-        <SunshineCuratedSuggestionsList terms={{view:"sunshineCuratedSuggestions", limit: 7}}/>
         
         {/* alignmentForumAdmins see AF content above the fold */}
         { currentUser.groups?.includes('alignmentForumAdmins') && <div>


### PR DESCRIPTION
I'm not sure whether this is longterm good, but I've been missing the "something needs curating" message fairly frequently and it seemed worth experimenting with moving the curated-list to the top. (shouldn't affect most of our day-to-day since it's usually hidden)