### PR TITLE
[HOTFIX] Walled garden fixes

### DIFF
--- a/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodesList.tsx
@@ -23,7 +23,7 @@ export const GardenCodesList = ({classes, limit, personal=false}: {
   
   const { results, loading, loadMoreProps } = useMulti({
     terms: {
-      userId: currentUser?._id,
+      ...(personal && {userId: currentUser?._id}),
       ...terms
     },
     enableTotal: true,

--- a/packages/lesswrong/components/walledGarden/GatherTown.tsx
+++ b/packages/lesswrong/components/walledGarden/GatherTown.tsx
@@ -146,11 +146,11 @@ const GatherTown = ({classes}: {
   const tooltip = currentUser.walledGardenInvite ? <LWTooltip title={
     <div>
       Click to read more about this space
-      <div>{"password: the12thvirtue"}</div></div>
-    }>
-      <Link to="/walledGarden" className={classes.learn}>
-        Learn More
-      </Link>
+    </div>
+  }>
+    <Link to="/walledGarden" className={classes.learn}>
+      Learn More
+    </Link>
   </LWTooltip> : null
 
   return (

--- a/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
@@ -48,7 +48,6 @@ const WalledGardenHome = ({classes}:{classes:ClassesType}) => {
       </Typography>
       <p>
         <a href="https://gather.town/app/aPVfK3G76UukgiHx/lesswrong-campus"><strong>Link to the Garden</strong></a><br/>
-        <strong>Password:&nbsp;</strong> <i><strong>the12thvirtue</strong> (please don't share)</i> 
       </p>
       <p>
         There are many kinds of important social interactions; and not all of those can be achieved on a scheduled Zoom call or from behind a keyboard. Even before the pandemic, it was challenging to make all the worthwhile conversations happen.

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortal.tsx
@@ -92,6 +92,7 @@ const WalledGardenPortal = ({ classes }: { classes: ClassesType }) => {
   const [ hideBar, setHideBar ] = useState(false);
 
   const { results } = useMulti({
+    skip: !inviteCodeQuery,
     terms: {
       code: inviteCodeQuery
     },

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -128,6 +128,15 @@ const schema: SchemaType<DbGardenCode> = {
     },
     order: 30,
   },
+  hidden: {
+    type: Boolean,
+    viewableBy: ['guests'],
+    editableBy: ['admins', 'sunshineRegiment'],
+    optional: true,
+    order: 32,
+    hidden: true,
+    ...schemaDefaultValue(false),
+  },
   deleted: {
     type: Boolean,
     viewableBy: ['guests'],

--- a/packages/lesswrong/lib/collections/gardencodes/views.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/views.ts
@@ -35,9 +35,16 @@ GardenCodes.addDefaultView((terms: GardenCodesViewTerms) => {
   }
   if (terms?.code) {
     selector = {
+      ...selector,
       code: terms.code,
     }
+  } else {
+    selector = {
+      ...selector,
+      hidden: false,
+    }
   }
+  
   return {
     selector,
     options: {

--- a/packages/lesswrong/lib/collections/gardencodes/views.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/views.ts
@@ -12,7 +12,10 @@ declare global {
 
 
 GardenCodes.addDefaultView((terms: GardenCodesViewTerms) => {
-  let selector: any
+  let selector: any = {
+    deleted: false,
+  };
+  
   if (terms?.types) {
     const eventTypeStrings = eventTypes.map(type=>type.value)
     const types = terms.types?.filter(type => eventTypeStrings.includes(type))
@@ -20,26 +23,25 @@ GardenCodes.addDefaultView((terms: GardenCodesViewTerms) => {
       throw Error("You didn't provide a valid type")
     }
     selector = {
+      ...selector,
       type: {$in: types},
-      deleted: false
     }
-  } else if (terms?.userId) {
+  }
+  if (terms?.userId) {
     selector = {
+      ...selector,
       userId: terms.userId,
-      deleted: false
     }
-  } else if (!terms?.code) {
+  }
+  if (terms?.code) {
     selector = {
-      keyDoesNotExist: "valueDoesNotExist"
+      code: terms.code,
     }
   }
   return {
-    selector: selector || {
-      code: terms.code,
-      deleted: false
-    },
+    selector,
     options: {
-      sort: { 
+      sort: {
         startTime: 1
       }
     }
@@ -53,7 +55,6 @@ GardenCodes.addView("usersPrivateGardenCodes", function (terms) {
   const twoHoursAgo = new Date(new Date().getTime()-(2*60*60*1000));
   return {
     selector: {
-      // userId: terms.userId,
       type: 'private',
       $or: [{startTime: {$gt: twoHoursAgo }}, {endTime: {$gt: new Date()}}]
     }


### PR DESCRIPTION
Fixes a bug that hid all Walled Garden events on the front page, except from their creator. Removes obsolete mentions of a Walled Garden password. Adds a `hidden` field, so that a particular AI Impacts link with a month-long date range can be made to not permanently fill the top slot.