### PR TITLE
Fix text vertically shifting when expanded in Recent Discussion

### DIFF
--- a/packages/lesswrong/lib/editor/ellipsize.tsx
+++ b/packages/lesswrong/lib/editor/ellipsize.tsx
@@ -31,11 +31,12 @@ export const truncate = (html: string|null|undefined, truncateLength: number, tr
   const styles = html.match(/<style[\s\S]*?<\/style>/g) || ""
   const htmlRemovedStyles = html.replace(/<style[\s\S]*?<\/style>/g, '');
 
-  return truncatise(htmlRemovedStyles, {
+  const truncatedHtml = truncatise(htmlRemovedStyles, {
     TruncateLength: Math.floor(truncateLength - (truncateLength/4)) || truncateLength,
     TruncateBy: newTruncateBy,
-    Suffix: `${newSuffix} ${styles}`,
+    Suffix: `${newSuffix}`,
   });
+  return styles + truncatedHtml;
 }
 
 export function getTruncationCharCount (comment, currentUser?: UsersCurrent|null, postPage?: boolean) {

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -392,6 +392,9 @@ export const pBodyStyle = {
   '&:first-child': {
     marginTop: 0,
   },
+  'style~&': {
+    marginTop: 0,
+  },
   '&:last-child': {
     marginBottom: 0,
   }


### PR DESCRIPTION
`pBodyStyle` in `stylePiping.ts` has a `&:first-child` selector which removes the top-margin from the first paragraph. But there might be a MathJax stylesheet mixed into the post text, and if there is, that stylesheet is the first child, not the paragraph. `truncate` removed the styles from the beginning and put them back at the end, rather than the beginning, so it changes the vertical position. This made it so that if a post has MathJax, clicking See More on it would cause it to shift vertically, which is pretty disorienting.