### PR TITLE
Change handling of canonicalSequenceId to fix some broken sequence navigation

### DIFF
--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -454,18 +454,25 @@ addFieldsDict(Posts, {
         const nextPostID = await sequenceGetNextPostID(sequenceId, post._id);
         if (nextPostID) {
           const nextPost = await context.loaders.Posts.load(nextPostID);
-          return await accessFilterSingle(currentUser, Posts, nextPost, context);
+          const nextPostFiltered = await accessFilterSingle(currentUser, Posts, nextPost, context);
+          if (nextPostFiltered)
+            return nextPostFiltered;
+        }
+      }
+      if(post.canonicalSequenceId) {
+        const nextPostID = await sequenceGetNextPostID(post.canonicalSequenceId, post._id);
+        if (nextPostID) {
+          const nextPost = await context.loaders.Posts.load(nextPostID);
+          const nextPostFiltered = await accessFilterSingle(currentUser, Posts, nextPost, context);
+          if (nextPostFiltered)
+            return nextPostFiltered;
         }
       }
       if (post.canonicalNextPostSlug) {
         const nextPost = await Posts.findOne({ slug: post.canonicalNextPostSlug });
-        return await accessFilterSingle(currentUser, Posts, nextPost, context);
-      }
-      if(post.canonicalSequenceId) {
-        const nextPostID = await sequenceGetNextPostID(post.canonicalSequenceId, post._id);
-        if (!nextPostID) return null;
-        const nextPost = await context.loaders.Posts.load(nextPostID);
-        return await accessFilterSingle(currentUser, Posts, nextPost, context);
+        const nextPostFiltered = await accessFilterSingle(currentUser, Posts, nextPost, context);
+        if (nextPostFiltered)
+          return nextPostFiltered;
       }
 
       return null;
@@ -487,18 +494,31 @@ addFieldsDict(Posts, {
         const prevPostID = await sequenceGetPrevPostID(sequenceId, post._id);
         if (prevPostID) {
           const prevPost = await context.loaders.Posts.load(prevPostID);
-          return await accessFilterSingle(currentUser, Posts, prevPost, context);
+          const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
+          if (prevPostFiltered) {
+            console.log(`prevPost = ${prevPostFiltered.slug}, from sequenceId`);
+            return prevPostFiltered;
+          }
+        }
+      }
+      if(post.canonicalSequenceId) {
+        const prevPostID = await sequenceGetPrevPostID(post.canonicalSequenceId, post._id);
+        if (prevPostID) {
+          const prevPost = await context.loaders.Posts.load(prevPostID);
+          const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
+          if (prevPostFiltered) {
+            console.log(`prevPost = ${prevPostFiltered.slug}, from canonicalSequenceId`);
+            return prevPostFiltered;
+          }
         }
       }
       if (post.canonicalPrevPostSlug) {
         const prevPost = await Posts.findOne({ slug: post.canonicalPrevPostSlug });
-        return await accessFilterSingle(currentUser, Posts, prevPost, context);
-      }
-      if(post.canonicalSequenceId) {
-        const prevPostID = await sequenceGetPrevPostID(post.canonicalSequenceId, post._id);
-        if (!prevPostID) return null;
-        const prevPost = await context.loaders.Posts.load(prevPostID);
-        return await accessFilterSingle(currentUser, Posts, prevPost, context);
+        const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
+        if (prevPostFiltered) {
+          console.log(`prevPost = ${prevPostFiltered.slug}, from canonicalPrevPostSlug`);
+          return prevPostFiltered;
+        }
       }
 
       return null;


### PR DESCRIPTION
Before: If both canonicalNextPostSlug/canonicalPrevPostSlug and canonicalSequenceId are present, then for purposes of finding the next/prev post, canonicalSequenceId is ignored. If the canonical next/prev slug points to a post that doesn't exist or is inaccessible (such as a draft), then is no next/previous link.

After: canonicalSequenceId takes precedence over canonicalNextPostSlug/canonicalPrevPostSlug, which are only meant to be used for bridging the gaps at the start and end of sequences which connect to each other. If canonicalSequenceId is invalid or can't be used to find a next/prev post.


