### PR TITLE
Add a second Buy button which goes to Amazon instead of Stripe

### DIFF
--- a/packages/lesswrong/components/books/BookAnimation.tsx
+++ b/packages/lesswrong/components/books/BookAnimation.tsx
@@ -107,7 +107,7 @@ const styles = (theme: ThemeType): JssStyles => ({
         paddingLeft: 0,
         paddingTop: 15,
         overflow: 'hidden',
-        minHeight: 310,
+        minHeight: 350,
       },
       '& .book-container': {
         transform: "scale(0.6, 0.6)",

--- a/packages/lesswrong/components/books/BookFrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/BookFrontpageWidget.tsx
@@ -5,6 +5,7 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { postBodyStyles } from '../../themes/stylePiping';
 import { useDialog } from '../common/withDialog';
 import { useCurrentUser } from '../common/withUser';
+import { legacyBreakpoints } from '../../lib/utils/theme';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -62,6 +63,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     fontSize: '1.2rem',
     marginLeft: 16,
     marginRight: 16
+    whiteSpace: "nowrap",
   },
   buttonRow: {
     display: 'flex',
@@ -74,7 +76,10 @@ const styles = (theme: ThemeType): JssStyles => ({
       flexDirection: 'row-reverse',
       paddingLeft: 25,
       paddingRight: 10,
-    }
+    },
+    [legacyBreakpoints.maxTiny]: {
+      paddingLeft: 10,
+    },
   },
   closeButton: {
     ...theme.typography.commentStyle,
@@ -97,6 +102,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: 'rgba(0,0,0,0.6)',
     marginLeft: 'auto',
     display: 'none',
+    whiteSpace: "nowrap",
     [theme.breakpoints.down('xs')]: {
       display: 'block'
     }

--- a/packages/lesswrong/components/books/BookFrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/BookFrontpageWidget.tsx
@@ -177,7 +177,7 @@ const BookFrontpageWidget = ({ classes }: {
             <Link className={classes.learnMore} to="/books">
               Learn More
             </Link>
-            <BookCheckout ignoreMessages text={"Buy Another Book"}/>
+            <BookCheckout ignoreMessages text={"Buy Another"}/>
           </>}
         />
       }>

--- a/packages/lesswrong/components/books/BookFrontpageWidget.tsx
+++ b/packages/lesswrong/components/books/BookFrontpageWidget.tsx
@@ -62,7 +62,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     height: 36,
     fontSize: '1.2rem',
     marginLeft: 16,
-    marginRight: 16
+    marginRight: 16,
     whiteSpace: "nowrap",
   },
   buttonRow: {

--- a/packages/lesswrong/components/review/BookCheckout.tsx
+++ b/packages/lesswrong/components/review/BookCheckout.tsx
@@ -3,6 +3,7 @@ import { loadStripe } from "@stripe/stripe-js";
 import { registerComponent } from "../../lib/vulcan-lib";
 import { DatabasePublicSetting } from "../../lib/publicSettings";
 import { useTracking } from "../../lib/analyticsEvents";
+import classNames from 'classnames';
 
 const stripePublicKeySetting = new DatabasePublicSetting<null|string>('stripe.publicKey', null)
 
@@ -28,19 +29,39 @@ const styles = theme => ({
     '&:hover': {
       opacity: 0.8
     }
-  }
-
+  },
+  buyUsButton: {
+    minWidth: 140,
+  },
+  intlButton: {
+    background: "white",
+    marginLeft: 10,
+    color: "#606060",
+    border: "1px solid #ccc",
+  },
 })
 
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
 const stripePublicKey = stripePublicKeySetting.get()
 const stripePromise = stripePublicKey && loadStripe(stripePublicKey);
-const ProductDisplay = ({ handleClick, classes, text = "Pre-Order – $29"}) => (
-  <button className={classes.checkoutButton} id="checkout-button" role="link" onClick={handleClick}>
-    {text}
-  </button>
-);
+const amazonLink = "https://www.amazon.com/Map-that-Reflects-Territory-LessWrong/dp/1736128507"
+
+const ProductDisplay = ({ handleClickAmazon, handleClickStripe, text="Buy", classes }: {
+  handleClickAmazon: (event: any)=>void,
+  handleClickStripe: (event: any)=>void,
+  text?: string,
+  classes: ClassesType,
+}) => {
+  return <>
+    <button className={classNames(classes.checkoutButton, classes.buyUsButton)} id="checkout-button-amazon-us" role="link" onClick={handleClickAmazon}>
+      {`${text} (US) - $29`}
+    </button>
+    <button className={classNames(classes.checkoutButton, classes.intlButton)} id="checkout-button" role="link" onClick={handleClickStripe}>
+      {`${text} (international) - $29`}
+    </button>
+  </>
+};
 const Message = ({ message, classes }) => (
   <section>
     <p className={classes.messageParagraph}>{message}</p>
@@ -49,6 +70,7 @@ const Message = ({ message, classes }) => (
 export default function BookCheckout({classes, ignoreMessages = false, text}: {classes: ClassesType, ignoreMessages?: boolean, text?: string}) {
   const [message, setMessage] = useState("");
   const { captureEvent } = useTracking()
+  
   useEffect(() => {
     // Check to see if this is a redirect back from Checkout
     const query = new URLSearchParams(window.location.search);
@@ -56,7 +78,11 @@ export default function BookCheckout({classes, ignoreMessages = false, text}: {c
       setMessage("Order placed! You will receive an email confirmation.");
     }
   }, []);
-  const handleClick = async (event) => {
+  const handleClickAmazon = async (event) => {
+    captureEvent("preOrderButtonClicked")
+    window.location.assign(amazonLink);
+  }
+  const handleClickStripe = async (event) => {
     captureEvent("preOrderButtonClicked")
     const stripe = await stripePromise;
     if (stripe) {
@@ -80,7 +106,7 @@ export default function BookCheckout({classes, ignoreMessages = false, text}: {c
     { (message && !ignoreMessages) ? (
       <Message message={message} classes={classes} />
     ) : (
-      <ProductDisplay handleClick={handleClick} classes={classes} text={text}/>
+      <ProductDisplay handleClickAmazon={handleClickAmazon} handleClickStripe={handleClickStripe} text={text} classes={classes}/>
     ) }
   </div>
 }

--- a/packages/lesswrong/components/review/BookCheckout.tsx
+++ b/packages/lesswrong/components/review/BookCheckout.tsx
@@ -9,7 +9,11 @@ const stripePublicKeySetting = new DatabasePublicSetting<null|string>('stripe.pu
 
 const styles = theme => ({
   root: {
-    ...theme.typography.commentStyle
+    ...theme.typography.commentStyle,
+    
+    [theme.breakpoints.down('xs')]: {
+      maxWidth: 200,
+    },
   },
   checkoutButton: {
     ...theme.typography.commentStyle,
@@ -28,16 +32,25 @@ const styles = theme => ({
     boxShadow: '0px 4px 5.5px 0px rgba(0, 0, 0, 0.07)',
     '&:hover': {
       opacity: 0.8
-    }
+    },
+    
+    [theme.breakpoints.down('xs')]: {
+      width: 175,
+    },
   },
   buyUsButton: {
     minWidth: 140,
+    marginBottom: 8,
   },
   intlButton: {
     background: "white",
     marginLeft: 10,
     color: "#606060",
     border: "1px solid #ccc",
+    
+    [theme.breakpoints.down('xs')]: {
+      marginLeft: 0,
+    },
   },
 })
 

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -496,7 +496,6 @@ addFieldsDict(Posts, {
           const prevPost = await context.loaders.Posts.load(prevPostID);
           const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
           if (prevPostFiltered) {
-            console.log(`prevPost = ${prevPostFiltered.slug}, from sequenceId`);
             return prevPostFiltered;
           }
         }
@@ -507,7 +506,6 @@ addFieldsDict(Posts, {
           const prevPost = await context.loaders.Posts.load(prevPostID);
           const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
           if (prevPostFiltered) {
-            console.log(`prevPost = ${prevPostFiltered.slug}, from canonicalSequenceId`);
             return prevPostFiltered;
           }
         }
@@ -516,7 +514,6 @@ addFieldsDict(Posts, {
         const prevPost = await Posts.findOne({ slug: post.canonicalPrevPostSlug });
         const prevPostFiltered = await accessFilterSingle(currentUser, Posts, prevPost, context);
         if (prevPostFiltered) {
-          console.log(`prevPost = ${prevPostFiltered.slug}, from canonicalPrevPostSlug`);
           return prevPostFiltered;
         }
       }


### PR DESCRIPTION
Currently our Amazon page works for the US, but mostly not for other countries. For US orders, selling through Amazon is preferable because (a) people can leave Amazon reviews, and (b) Jacob doesn't have to do a manual process to get them their book.

Replace the Pre-Order button with two Buy buttons, one for the US (which goes to Amazon) and one for International (which goes to Stripe).

![Screen Shot 2021-02-02 at 23 15 39](https://user-images.githubusercontent.com/101191/106711794-e4a91a80-65ac-11eb-867c-dd9ffb5939b7.png)
