### PR TITLE
Fix broken Algolia index updating

### DIFF
--- a/packages/lesswrong/server/search/utils.ts
+++ b/packages/lesswrong/server/search/utils.ts
@@ -486,7 +486,7 @@ export async function algoliaDocumentExport<T extends AlgoliaIndexedDbObject>({ 
   collection: AlgoliaIndexedCollection<T>,
   updateFunction?: any,
 }) {
-  if (!collectionIsAlgoliaIndexed(collection as any)) {
+  if (!collectionIsAlgoliaIndexed(collection.collectionName)) {
     // If this is a collection that isn't Algolia-indexed, don't index it. (This
     // gets called from voting code, which tried to update Algolia indexes to
     // change baseScore. tagRels have voting, but aren't Algolia-indexed.)


### PR DESCRIPTION
Broken in this commit: 98e19da08807002c8eadc633ca5ef684a71184de . Valid type error foolishly suppressed in this commit: 5884a20784d8ae9b77b9b92437d3f8a52f1f99ce . 