### PR TITLE
Fix bug that made new-tag-post notifications not emailable

### DIFF
--- a/packages/lesswrong/server/notificationTypesServer.tsx
+++ b/packages/lesswrong/server/notificationTypesServer.tsx
@@ -106,11 +106,11 @@ export const NewTagPostsNotification = serverRegisterNotificationType({
   name: "newTagPosts",
   canCombineEmails: false,
   emailSubject: async ({user, notifications}) => {
-    const [documentId, documentType] = notifications[0]
+    const {documentId, documentType} = notifications[0]
     return await taggedPostMessage({documentId, documentType})
   },
   emailBody: async ({user, notifications}) => {
-    const [documentId, documentType] = notifications[0]
+    const {documentId, documentType} = notifications[0]
     const tagRel = await TagRels.findOne({_id: documentId})
     if (tagRel) {
       return <Components.NewPostEmail documentId={ tagRel.postId}/>


### PR DESCRIPTION
Introduced in https://github.com/LessWrong2/Lesswrong2/pull/3158 and discovered in Sentry: https://sentry.io/organizations/lesswrong/issues/2218600431/?environment=production&project=1301611&query=is%3Aunresolved&statsPeriod=14d .