### PR TITLE
Fix broken email-token links

### DIFF
--- a/packages/lesswrong/lib/random.ts
+++ b/packages/lesswrong/lib/random.ts
@@ -26,7 +26,7 @@ export const randomId = () => {
 
 export const randomSecret = () => {
   if (bundleIsServer) {
-    return crypto.randomBytes(15).toString('base64');
+    return crypto.randomBytes(15).toString('hex');
   } else {
     throw new Error("No CSPRNG available on the client");
   }


### PR DESCRIPTION
In the process of migrating away from Meteor, we wrote our own versions of some Meteor random-ID-generation functions, including the `randomSecret` function. This function is used for generating token links in emails (for password reset and unsubscribe) and nothing else. Unfortunately, in node's `crypto` library, "base64" uses the `+` and `/` characters, which are not URL-safe. (There is a different variant of base64 which uses - and _, which would have been fine; see https://en.wikipedia.org/wiki/Base64.) The practical upshot is that we sent out some emails where the token link was broken, and clicks on those links showed up as errors in Sentry.