### PR TITLE
Make canonicalSource admin-editable

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -464,10 +464,10 @@ const schema: SchemaType<DbPost> = {
   canonicalSource: {
     type: String,
     optional: true,
-    hidden: true,
     viewableBy: ['guests'],
     insertableBy: ['admins'],
     editableBy: ['admins'],
+    group: formGroups.adminOptions,
   },
 
   nominationCount2018: {


### PR DESCRIPTION
Allow admins to edit the post setting `canonicalSource`, allowing them to set the `rel="canonical"` tags on linkposts that are not auto-posted through RSS.