### PR TITLE
Fix spurious unsaved-data warnings when you edit and then clear an input

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -471,6 +471,7 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
         name,
         prefix: this.getLSKeyPrefix()
       });
+      this.hasUnsavedData = false;
     } else {
       const serialized = this.editorContentsToJson();
   
@@ -484,7 +485,6 @@ class EditorFormComponent extends Component<EditorFormComponentProps,EditorFormC
       if (success) {
         this.hasUnsavedData = false;
       }
-      return success;
     }
   }
 


### PR DESCRIPTION
Fix spurious "you have unsaved changes" warning when you type into an input and then delete all of it. Introduced in 4172241a03746a9d02d20d02164ac40b3715d9ce.