### PR TITLE
Make categorizing posts as personal remove frontpageDate

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewPostsItem.tsx
@@ -67,11 +67,12 @@ const SunshineNewPostsItem = ({post, classes}: {
     });
   }
   
-  const handleReview = () => {
+  const handlePersonal = () => {
     applyTags();
     void updatePost({
       selector: { _id: post._id},
       data: {
+        frontpageDate: null,
         reviewedByUserId: currentUser!._id,
         authorIsUnreviewed: false
       },
@@ -119,7 +120,7 @@ const SunshineNewPostsItem = ({post, classes}: {
           }}/>
           <FooterTagList post={post} />
           <div className={classes.buttonRow}>
-              <Button onClick={handleReview}>
+              <Button onClick={handlePersonal}>
                 <PersonIcon className={classes.icon} /> Personal
               </Button>
               {post.submitToFrontpage && <Button onClick={handlePromote}>


### PR DESCRIPTION
The EA Forum a few months ago made the decision to automatically categorize posts as frontpage unless marked otherwise. There was a bug in our approach, in that marking posts as personal using the sunshine sidebar did not categorize them as personal. This is due to the fact that LW does not need to mutate the frontpageDate field on personal categorization. The field is already null, and you leave it null. However, we need to explicitly set it to null. This PR does so. I don't foresee an issue with it for LW. I've thought about it, and I can't think of a time where you'd want to click the icon that says "Personal" and not set the frontpageDate field to null, even if it did somehow manage to be in the sidebar while also having frontpageDate set.

I've tested that the behavior is correct while running localhost in EAForum-mode and LessWrong-mode.