### PR TITLE
Fix IP-address tracking

### DIFF
--- a/packages/lesswrong/server/forwarded_whitelist.ts
+++ b/packages/lesswrong/server/forwarded_whitelist.ts
@@ -24,8 +24,8 @@ const computeForwardedWhitelist = () => {
 
 export const getForwardedWhitelist = () => ({
   getClientIP: (req) => {
-    // From: https://stackoverflow.com/a/19524949
-    const ip = (req.headers['x-forwarded-for'] || '').split(',').pop().trim() || 
+    // From: https://stackoverflow.com/a/19524949 (which contains incorrect sample code!)
+    const ip = (req.headers['x-forwarded-for'] || '').split(',').shift().trim() || 
       req.connection.remoteAddress || 
       req.socket.remoteAddress || 
       req.connection.socket.remoteAddress


### PR DESCRIPTION
The X-Forwarded-For HTTP header contains a comma-separated list with the real client IP address first, followed by the IP addresses of any intermediate proxies https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For). A bit of code copied from StackOverflow was taking this header and taking the last item in the list (which is a proxy) rather than the first item in the list (which is the desired client IP). Introduced while converting from Meteor accounts passportjs, in commit e74a2fa7396ad5e6b1a1ed2ff260eeea8066b9c8.


