### PR TITLE
Change elicit.org to forecast.elicit.org

### DIFF
--- a/packages/lesswrong/server/resolvers/elicitPredictions.ts
+++ b/packages/lesswrong/server/resolvers/elicitPredictions.ts
@@ -41,7 +41,7 @@ const ElicitBlockDataType = `type ElicitBlockData {
 
 addGraphQLSchema(ElicitBlockDataType);
 
-const elicitAPIUrl = "https://elicit.org/api/v1"
+const elicitAPIUrl = "https://forecast.elicit.org/api/v1"
 const elicitAPIKey = new DatabaseServerSetting('elicitAPIKey', null)
 // const elicitSourceName = new DatabaseServerSetting('elicitSourceName', 'LessWrong')
 

--- a/public/lesswrong-editor/src/ckeditor.js
+++ b/public/lesswrong-editor/src/ckeditor.js
@@ -159,7 +159,7 @@ const embedConfig = {
 	extraProviders: [
 		{
 			name: 'Elicit',
-			url: /^(forecast.)elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
+			url: /^(forecast.)?elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
 			html: ([match, questionId]) => `
 				<div data-elicit-id="${questionId}" style="position:relative;height:50px;background-color: rgba(0,0,0,0.05);display: flex;justify-content: center;align-items: center;" class="elicit-binary-prediction">
 					<div style=>Elicit Prediction (<a href="${match}">${match}</a>)</div>

--- a/public/lesswrong-editor/src/ckeditor.js
+++ b/public/lesswrong-editor/src/ckeditor.js
@@ -159,7 +159,7 @@ const embedConfig = {
 	extraProviders: [
 		{
 			name: 'Elicit',
-			url: /^elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
+			url: /^(forecast.)elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
 			html: ([match, questionId]) => `
 				<div data-elicit-id="${questionId}" style="position:relative;height:50px;background-color: rgba(0,0,0,0.05);display: flex;justify-content: center;align-items: center;" class="elicit-binary-prediction">
 					<div style=>Elicit Prediction (<a href="${match}">${match}</a>)</div>

--- a/public/lesswrong-editor/src/ckeditor.js
+++ b/public/lesswrong-editor/src/ckeditor.js
@@ -159,7 +159,7 @@ const embedConfig = {
 	extraProviders: [
 		{
 			name: 'Elicit',
-			url: /^(forecast.)?elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
+			url: /^(?:forecast.)?elicit.org\/binary\/questions\/([a-zA-Z0-9_-]+)/,
 			html: ([match, questionId]) => `
 				<div data-elicit-id="${questionId}" style="position:relative;height:50px;background-color: rgba(0,0,0,0.05);display: flex;justify-content: center;align-items: center;" class="elicit-binary-prediction">
 					<div style=>Elicit Prediction (<a href="${match}">${match}</a>)</div>


### PR DESCRIPTION
We're moving the current elicit.org to forecast.elicit.org. These changes should be all that LW needs to do to accomodate this.