### PR TITLE
Fixes the footnote quote scaling discussed in issue 3962

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -252,6 +252,13 @@ export const postBodyStyles = (theme: ThemeType) => {
       '& li': {
         fontSize: '0.9em' // Overwriting default size setting for list items
       },
+      '& blockquote': {
+        fontSize: '0.9em',
+        lineHeight: '1.5em',
+        padding: 1,
+        paddingLeft: 3,
+        marginTop: -10,
+      },
     },
     // Hiding the footnote-separator that markdown-it adds by default
     '& .footnotes-sep': {


### PR DESCRIPTION
Fixes issue 3962

![Footnote Quote Changes](https://user-images.githubusercontent.com/22739836/110768426-83cdcb80-8257-11eb-9d6d-9040f3368a50.png)
