### PR TITLE
Fix mis-positioned degree-sign marker on links in Firefox first render

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -146,14 +146,10 @@ const PostLinkPreviewVariantCheck = ({ href, innerHTML, post, targetLocation, co
 const PostLinkPreviewVariantCheckComponent = registerComponent('PostLinkPreviewVariantCheck', PostLinkPreviewVariantCheck);
 
 export const linkStyle = (theme: ThemeType) => ({
-  position: "relative",
-  marginRight: 6,
   '&:after': {
     content: '"°"',
     marginLeft: 1,
-    marginRight: 1,
     color: theme.palette.primary.main,
-    position: "absolute"
   }
 })
 


### PR DESCRIPTION
On Firefox (not in Chrome), on first render (goes away when the browser is horizontally resized), the degree symbol after links that have a hover-preview is mis-positioned. This seems to be because of an interaction between a bug in Firefox, and a weird CSS hack in the implementation of that degree symbol. But AFAICT the CSS hack doesn't seem to do anything; I'm not sure why it's there, and everything seems to work if I take it out.