### PR TITLE
Remove TagDetails sections from Concepts Page

### DIFF
--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -117,38 +117,6 @@ const AllTagsPage = ({classes}: {
             </div>
           </AnalyticsContext>
         </div>
-        <AnalyticsContext pageSectionContext="tagDetails">
-          <SectionTitle title={`Tag Details`}>
-            {forumTypeSetting.get() !== 'EAForum' && <Select
-              value={wikiGrade||"none"}
-              inputProps={{
-                name: 'Showing All Tags'
-              }}
-            >
-              <UntypedMenuItem value="none" component={QueryLink} query={{ tagFilter: undefined }}>
-                No Filters
-              </UntypedMenuItem>  
-              {Object.entries(wikiGradeDefinitions).reverse().map(([value, name]) => {
-                if(name === wikiGradeDefinitions[0]) return null
-                if(name === wikiGradeDefinitions[1]) return null
-                return <UntypedMenuItem key={value} value={name} component={QueryLink} query={{ tagFilter: name }}>
-                  {name}
-                </UntypedMenuItem>
-              })}
-            </Select>}
-          </SectionTitle>
-          <div>
-            {results && results.map(tag => {
-              return <TagsDetailsItem key={tag._id} tag={tag} />
-            })}
-            {results && !results.length && <div>
-              There aren't any tags yet.
-            </div>}
-          </div>
-          <SectionFooter>
-            <LoadMore {...loadMoreProps} />
-          </SectionFooter>
-        </AnalyticsContext>
         <AnalyticsContext pageSectionContext="allTagsAlphabetical">
           <AllTagsAlphabetical />
         </AnalyticsContext>

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -1,20 +1,14 @@
 import React, { useState } from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { useMulti } from '../../lib/crud/withMulti';
 import { useTagBySlug } from './useTag';
 import { commentBodyStyles } from '../../themes/stylePiping'
 import { EditTagForm } from './EditTagPage';
 import { userCanEditTagPortal } from '../../lib/betas'
 import { useCurrentUser } from '../common/withUser';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
-import { Link, QueryLink } from '../../lib/reactRouterWrapper';
+import { Link } from '../../lib/reactRouterWrapper';
 import AddBoxIcon from '@material-ui/icons/AddBox';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
-import { wikiGradeDefinitions } from '../../lib/collections/tags/schema';
-import { useLocation } from '../../lib/routeUtil';
 import { useDialog } from '../common/withDialog';
-import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -55,32 +49,17 @@ const styles = (theme: ThemeType): JssStyles => ({
   }
 })
 
-const reverseWikiGradeDescriptions = Object.fromEntries(Object.entries(wikiGradeDefinitions).map(([key, value]) => [value, key]))
 
 const AllTagsPage = ({classes}: {
   classes: ClassesType,
 }) => {
-  const { query } = useLocation()
   const { openDialog } = useDialog()
-  const wikiGrade = query?.tagFilter
-  const { results, loadMoreProps } = useMulti({
-    terms: {
-      view: "allTagsHierarchical",
-      wikiGrade: reverseWikiGradeDescriptions[wikiGrade]
-    },
-    collectionName: "Tags",
-    fragmentName: "TagFragment",
-    limit: 20,
-    itemsPerPage: 100,
-  });
-
   const currentUser = useCurrentUser()
   const { tag } = useTagBySlug("portal", "TagFragment");
   const [ editing, setEditing ] = useState(false)
   // Type hack because MenuItem is too narrowly typed and doesn't properly take into account props-forwarding
-  const UntypedMenuItem = MenuItem as any
 
-  const { AllTagsAlphabetical, SectionButton, TagsDetailsItem, SectionTitle, LoadMore, SectionFooter, ContentItemBody } = Components;
+  const { AllTagsAlphabetical, SectionButton, SectionTitle, ContentItemBody } = Components;
 
   return (
     <AnalyticsContext pageContext="allTagsPage">


### PR DESCRIPTION
Does what it says on the tin. Page is redundant with Tagging Dashboard and just clutters things up.