### PR TITLE
SunshineUserInfo in profile

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -116,7 +116,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
 }) => {
   const currentUser = useCurrentUser();
 
-  const [notes, setNotes] = useState(user.sunshineNotes)
+  const [notes, setNotes] = useState(user.sunshineNotes || "")
 
   const handleReview = () => {
     updateUser({

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -215,6 +215,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
             <div className={classes.notes}>
               <Input 
                 value={notes} 
+                fullWidth
                 onChange={(e) => { setNotes(e.target.value)}} 
                 disableUnderline 
                 placeholder="Notes for other moderators"

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -1,0 +1,325 @@
+/* global confirm */
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { withUpdate } from '../../lib/crud/withUpdate';
+import React, { useState } from 'react';
+import { Link } from '../../lib/reactRouterWrapper'
+import moment from 'moment';
+import { useCurrentUser } from '../common/withUser';
+import withErrorBoundary from '../common/withErrorBoundary'
+import DoneIcon from '@material-ui/icons/Done';
+import SnoozeIcon from '@material-ui/icons/Snooze';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
+import DescriptionIcon from '@material-ui/icons/Description'
+import { useMulti } from '../../lib/crud/withMulti';
+import MessageIcon from '@material-ui/icons/Message'
+import Button from '@material-ui/core/Button';
+import EditIcon from '@material-ui/icons/Edit';
+import * as _ from 'underscore';
+import { DatabasePublicSetting } from '../../lib/publicSettings';
+import { Select, MenuItem } from '@material-ui/core';
+import Input from '@material-ui/core/Input';
+import { userCanDo } from '../../lib/vulcan-users/permissions';
+
+type ModeratorCommentRecord = {label: string, id: string}
+export const defaultModeratorComments = new DatabasePublicSetting<ModeratorCommentRecord[]>('defaultModeratorComments', [{label:"Not Good Enough", id:"yMHoNoYZdk5cKa3wQ"}])
+
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    backgroundColor: theme.palette.grey[50]
+  },
+  icon: {
+    height: 13,
+    color: theme.palette.grey[500],
+    position: "relative",
+    top: 3
+  },
+  hoverPostIcon: {
+    height: 16,
+    color: theme.palette.grey[700],
+    position: "relative",
+    top: 3
+  },
+  row: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center"
+  },
+  bigDownvotes: {
+    color: theme.palette.error.dark,
+    padding: 6,
+    paddingTop: 3,
+    paddingBottom: 3,
+    marginRight:8,
+    borderRadius: "50%",
+    fontWeight: 600,
+    border: `solid 2px ${theme.palette.error.dark}`
+  },
+  downvotes: {
+    color: theme.palette.error.dark,
+    opacity: .75,
+    padding: 6,
+    paddingTop: 3,
+    paddingBottom: 3,
+    marginRight:8,
+    borderRadius: "50%",
+    border: `solid 1px ${theme.palette.error.dark}`
+  },
+  upvotes: {
+    color: theme.palette.primary.dark,
+    opacity: .75,
+    padding: 6,
+    paddingTop: 3,
+    paddingBottom: 3,
+    marginRight:8,
+    borderRadius: "50%",
+    border: `solid 1px ${theme.palette.primary.dark}`
+  },
+  bigUpvotes: {
+    color: theme.palette.primary.dark,
+    padding: 6,
+    paddingTop: 3,
+    paddingBottom: 3,
+    marginRight:8,
+    borderRadius: "50%",
+    fontWeight: 600,
+    border: `solid 2px ${theme.palette.primary.dark}`
+  },
+  votesRow: {
+    marginTop: 12,
+    marginBottom: 12
+  },
+  hr: {
+    height: 0,
+    borderTop: "none",
+    borderBottom: "1px solid #ccc"
+  },
+  editIcon: {
+    width: 20,
+    color: theme.palette.grey[400]
+  },
+  notes: {
+    border: "solid 1px rgba(0,0,0,.2)",
+    borderRadius: 2,
+    paddingLeft: 8,
+    paddingRight: 8,
+    paddingTop: 4,
+    paddingBottom: 4,
+    marginTop: 8,
+    marginBottom: 8
+  }
+})
+const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
+  user: SunshineUsersList,
+  classes: ClassesType,
+  updateUser?: any
+}) => {
+  const currentUser = useCurrentUser();
+
+  const [notes, setNotes] = useState(user.sunshineNotes)
+
+  const handleReview = () => {
+    updateUser({
+      selector: {_id: user._id},
+      data: {
+        reviewedByUserId: currentUser!._id,
+        reviewedAt: new Date(),
+        sunshineSnoozed: false,
+        needsReview: false,
+        sunshineNotes: notes
+      }
+    })
+  }
+
+  const handleSnooze = () => {
+    updateUser({
+      selector: {_id: user._id},
+      data: {
+        needsReview: false,
+        reviewedAt: new Date(),
+        reviewedByUserId: currentUser!._id,
+        sunshineSnoozed: true,
+        sunshineNotes: notes
+      }
+    })
+  }
+
+  const handleBan = async () => {
+    if (confirm("Ban this user for 3 months?")) {
+      await updateUser({
+        selector: {_id: user._id},
+        data: {
+          reviewedByUserId: currentUser!._id,
+          voteBanned: true,
+          needsReview: false,
+          reviewedAt: new Date(),
+          banned: moment().add(3, 'months').toDate(),
+          sunshineNotes: notes
+        }
+      })
+    }
+  }
+
+  const handlePurge = async () => {
+    if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
+      await updateUser({
+        selector: {_id: user._id},
+        data: {
+          reviewedByUserId: currentUser!._id,
+          nullifyVotes: true,
+          voteBanned: true,
+          deleteContent: true,
+          needsReview: false,
+          reviewedAt: new Date(),
+          banned: moment().add(12, 'months').toDate(),
+          sunshineNotes: notes
+        }
+      })
+    }
+  }
+
+  const { results: posts, loading: postsLoading } = useMulti({
+    terms:{view:"sunshineNewUsersPosts", userId: user._id},
+    collectionName: "Posts",
+    fragmentName: 'SunshinePostsList',
+    fetchPolicy: 'cache-and-network',
+    limit: 50
+  });
+
+  const { results: comments, loading: commentsLoading } = useMulti({
+    terms:{view:"sunshineNewUsersComments", userId: user._id},
+    collectionName: "Comments",
+    fragmentName: 'CommentsListWithParentMetadata',
+    fetchPolicy: 'cache-and-network',
+    limit: 50
+  });
+
+  const commentKarmaPreviews = comments ? _.sortBy(comments, c=>c.baseScore) : []
+  const postKarmaPreviews = posts ? _.sortBy(posts, p=>p.baseScore) : []
+
+  const { MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, NewConversationButton, Typography } = Components
+
+  const hiddenPostCount = user.maxPostCount - user.postCount
+  const hiddenCommentCount = user.maxCommentCount - user.commentCount
+
+  if (!userCanDo(currentUser, "posts.moderate.all")) return null
+
+  return (
+      <div className={classes.root}>
+        <Typography variant="body2">
+          <MetaInfo>
+            {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by {user.reviewedByUserId}</em></p> : null }
+            {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
+            <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
+            <div dangerouslySetInnerHTML={{__html: user.htmlBio}}/>
+            <div className={classes.notes}>
+              <Input 
+                value={notes} 
+                onChange={(e) => { setNotes(e.target.value)}} 
+                disableUnderline 
+                placeholder="Notes for other moderators"
+                multiline
+              />
+            </div>
+            <div className={classes.row}>
+              <div className={classes.row}>
+                {!!(user.maxCommentCount || user.maxPostCount) && <LWTooltip title="Approve">
+                  <Button onClick={handleReview}>
+                    <DoneIcon />
+                  </Button>
+                </LWTooltip>}
+                <LWTooltip title="Snooze (approve all posts)">
+                  <Button title="Snooze" onClick={handleSnooze}>
+                    <SnoozeIcon />
+                  </Button>
+                </LWTooltip>
+                <LWTooltip title="Ban for 3 months">
+                  <Button onClick={handleBan}>
+                    <RemoveCircleOutlineIcon />
+                  </Button>
+                </LWTooltip>
+                {!user.reviewedByUserId && <LWTooltip title="Purge (delete and ban)">
+                  <Button onClick={handlePurge}>
+                    <DeleteForeverIcon />
+                  </Button>
+                </LWTooltip>}
+              </div>
+              <div className={classes.row}>
+                {currentUser && <Select value={0} variant="outlined">
+                  <MenuItem value={0}>Start a message</MenuItem>
+                  {defaultModeratorComments.get().map((template, i) => <MenuItem key={`template-${template.label}`}>
+                    <NewConversationButton user={user} currentUser={currentUser} templateCommentId={template.id}>
+                      {template.label}
+                    </NewConversationButton>
+                  </MenuItem>)}
+                </Select>}
+                <Link to="/tag/moderator-default-responses/discussion"><EditIcon className={classes.editIcon}/></Link>
+              </div>
+            </div>
+            <hr className={classes.hr}/>
+            <div className={classes.votesRow}>
+              <LWTooltip title="Big Upvotes">
+                <span className={classes.bigUpvotes}>
+                  { user.bigUpvoteCount || 0 }
+                </span>
+              </LWTooltip>
+              <LWTooltip title="Upvotes">
+                <span className={classes.upvotes}>
+                  { user.smallUpvoteCount || 0 }
+                </span>
+              </LWTooltip>
+              <LWTooltip title="Downvotes">
+                <span className={classes.downvotes}>
+                  { user.smallDownvoteCount || 0 }
+                </span>
+              </LWTooltip>
+              <LWTooltip title="Big Downvotes">
+                <span className={classes.bigDownvotes}>
+                  { user.bigDownvoteCount || 0 }
+                </span>
+              </LWTooltip>
+            </div>
+            <div>
+              <LWTooltip title="Post count">
+                <span>
+                  { user.postCount || 0 }
+                  <DescriptionIcon className={classes.hoverPostIcon}/>
+                </span> 
+              </LWTooltip>
+              {postKarmaPreviews.map(post => <PostKarmaWithPreview key={post._id} post={post}/>)}
+              { hiddenPostCount ? <span> ({hiddenPostCount} deleted)</span> : null} 
+            </div>
+            {(commentsLoading || postsLoading) && <Loading/>}
+            <div>
+              <LWTooltip title="Comment count">
+                { user.commentCount || 0 }
+              </LWTooltip>
+              <MessageIcon className={classes.icon}/> 
+              {commentKarmaPreviews.map(comment => <CommentKarmaWithPreview key={comment._id} comment={comment}/>)}
+              { hiddenCommentCount ? <span> ({hiddenCommentCount} deleted)</span> : null}
+            </div>
+            <SunshineNewUserPostsList posts={posts} user={user}/>
+            <SunshineNewUserCommentsList comments={comments} user={user}/>
+          </MetaInfo>
+        </Typography>
+      </div>
+  )
+}
+
+const SunshineNewUsersInfoComponent = registerComponent('SunshineNewUsersInfo', SunshineNewUsersInfo, {
+  styles,
+  hocs: [
+    withUpdate({
+      collectionName: "Users",
+      fragmentName: 'SunshineUsersList',
+    }),
+    withErrorBoundary,
+  ]
+});
+
+declare global {
+  interface ComponentTypes {
+    SunshineNewUsersInfo: typeof SunshineNewUsersInfoComponent
+  }
+}
+

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -8,7 +8,6 @@ import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import red from '@material-ui/core/colors/red';
 import DescriptionIcon from '@material-ui/icons/Description'
-import * as _ from 'underscore';
 
 const styles = (theme: ThemeType): JssStyles => ({
   negativeKarma: {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -1,31 +1,14 @@
 /* global confirm */
 import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { withUpdate } from '../../lib/crud/withUpdate';
-import React, { useState } from 'react';
+import React from 'react';
 import { userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { Link } from '../../lib/reactRouterWrapper'
-import moment from 'moment';
-import { useCurrentUser } from '../common/withUser';
+
 import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import red from '@material-ui/core/colors/red';
-import DoneIcon from '@material-ui/icons/Done';
-import SnoozeIcon from '@material-ui/icons/Snooze';
-import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
 import DescriptionIcon from '@material-ui/icons/Description'
-import { useMulti } from '../../lib/crud/withMulti';
-import MessageIcon from '@material-ui/icons/Message'
-import Button from '@material-ui/core/Button';
-import EditIcon from '@material-ui/icons/Edit';
 import * as _ from 'underscore';
-import { DatabasePublicSetting } from '../../lib/publicSettings';
-import { Select, MenuItem } from '@material-ui/core';
-import Input from '@material-ui/core/Input';
-
-type ModeratorCommentRecord = {label: string, id: string}
-export const defaultModeratorComments = new DatabasePublicSetting<ModeratorCommentRecord[]>('defaultModeratorComments', [{label:"Not Good Enough", id:"yMHoNoYZdk5cKa3wQ"}])
-
 
 const styles = (theme: ThemeType): JssStyles => ({
   negativeKarma: {
@@ -41,284 +24,23 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[500],
     position: "relative",
     top: 3
-  },
-  hoverPostIcon: {
-    height: 16,
-    color: theme.palette.grey[700],
-    position: "relative",
-    top: 3
-  },
-  reviewed: {
-    backgroundColor: theme.palette.grey[100]
-  },
-  row: {
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center"
-  },
-  bigDownvotes: {
-    color: theme.palette.error.dark,
-    padding: 6,
-    paddingTop: 3,
-    paddingBottom: 3,
-    marginRight:8,
-    borderRadius: "50%",
-    fontWeight: 600,
-    border: `solid 2px ${theme.palette.error.dark}`
-  },
-  downvotes: {
-    color: theme.palette.error.dark,
-    opacity: .75,
-    padding: 6,
-    paddingTop: 3,
-    paddingBottom: 3,
-    marginRight:8,
-    borderRadius: "50%",
-    border: `solid 1px ${theme.palette.error.dark}`
-  },
-  upvotes: {
-    color: theme.palette.primary.dark,
-    opacity: .75,
-    padding: 6,
-    paddingTop: 3,
-    paddingBottom: 3,
-    marginRight:8,
-    borderRadius: "50%",
-    border: `solid 1px ${theme.palette.primary.dark}`
-  },
-  bigUpvotes: {
-    color: theme.palette.primary.dark,
-    padding: 6,
-    paddingTop: 3,
-    paddingBottom: 3,
-    marginRight:8,
-    borderRadius: "50%",
-    fontWeight: 600,
-    border: `solid 2px ${theme.palette.primary.dark}`
-  },
-  votesRow: {
-    marginTop: 12,
-    marginBottom: 12
-  },
-  hr: {
-    height: 0,
-    borderTop: "none",
-    borderBottom: "1px solid #ccc"
-  },
-  editIcon: {
-    width: 20,
-    color: theme.palette.grey[400]
-  },
-  notes: {
-    border: "solid 1px rgba(0,0,0,.2)",
-    borderRadius: 2,
-    paddingLeft: 8,
-    paddingRight: 8,
-    paddingTop: 4,
-    paddingBottom: 4,
-    marginTop: 8,
-    marginBottom: 8
   }
 })
-const SunshineNewUsersItem = ({ user, classes, updateUser }: {
+const SunshineNewUsersItem = ({ user, classes }: {
   user: SunshineUsersList,
   classes: ClassesType,
   updateUser?: any
 }) => {
-  const currentUser = useCurrentUser();
-  const [hidden, setHidden] = useState(false)
-
-  const [notes, setNotes] = useState(user.sunshineNotes)
   const { eventHandlers, hover, anchorEl } = useHover();
 
-  const handleReview = () => {
-    updateUser({
-      selector: {_id: user._id},
-      data: {
-        reviewedByUserId: currentUser!._id,
-        reviewedAt: new Date(),
-        sunshineSnoozed: false,
-        needsReview: false,
-        sunshineNotes: notes
-      }
-    })
-  }
+  const { SunshineListItem, SidebarHoverOver, SunshineNewUsersInfo, MetaInfo, FormatDate } = Components
 
-  const handleSnooze = () => {
-    updateUser({
-      selector: {_id: user._id},
-      data: {
-        needsReview: false,
-        reviewedAt: new Date(),
-        reviewedByUserId: currentUser!._id,
-        sunshineSnoozed: true,
-        sunshineNotes: notes
-      }
-    })
-  }
-
-  const handleBan = async () => {
-    if (confirm("Ban this user for 3 months?")) {
-      setHidden(true)
-      await updateUser({
-        selector: {_id: user._id},
-        data: {
-          reviewedByUserId: currentUser!._id,
-          voteBanned: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(3, 'months').toDate(),
-          sunshineNotes: notes
-        }
-      })
-    }
-  }
-
-  const handlePurge = async () => {
-    if (confirm("Are you sure you want to delete all this user's posts, comments and votes?")) {
-      setHidden(true)
-      await updateUser({
-        selector: {_id: user._id},
-        data: {
-          reviewedByUserId: currentUser!._id,
-          nullifyVotes: true,
-          voteBanned: true,
-          deleteContent: true,
-          needsReview: false,
-          reviewedAt: new Date(),
-          banned: moment().add(12, 'months').toDate(),
-          sunshineNotes: notes
-        }
-      })
-    }
-  }
-
-  const { results: posts, loading: postsLoading } = useMulti({
-    terms:{view:"sunshineNewUsersPosts", userId: user._id},
-    collectionName: "Posts",
-    fragmentName: 'SunshinePostsList',
-    fetchPolicy: 'cache-and-network',
-    limit: 50
-  });
-
-  const { results: comments, loading: commentsLoading } = useMulti({
-    terms:{view:"sunshineNewUsersComments", userId: user._id},
-    collectionName: "Comments",
-    fragmentName: 'CommentsListWithParentMetadata',
-    fetchPolicy: 'cache-and-network',
-    limit: 50
-  });
-
-  const commentKarmaPreviews = comments ? _.sortBy(comments, c=>c.baseScore) : []
-  const postKarmaPreviews = posts ? _.sortBy(posts, p=>p.baseScore) : []
-
-  const { SunshineListItem, SidebarHoverOver, MetaInfo, FormatDate, SunshineNewUserPostsList, SunshineNewUserCommentsList, CommentKarmaWithPreview, PostKarmaWithPreview, LWTooltip, Loading, NewConversationButton, Typography } = Components
-
-  if (hidden) { return null }
-
-  const hiddenPostCount = user.maxPostCount - user.postCount
-  const hiddenCommentCount = user.maxCommentCount - user.commentCount
 
   return (
     <span {...eventHandlers}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
-          <Typography variant="body2">
-            <MetaInfo>
-              {user.reviewedAt ? <p><em>Reviewed <FormatDate date={user.reviewedAt}/> ago by {user.reviewedByUserId}</em></p> : null }
-              {user.banned ? <p><em>Banned until <FormatDate date={user.banned}/></em></p> : null }
-              <div>ReCaptcha Rating: {user.signUpReCaptchaRating || "no rating"}</div>
-              <div dangerouslySetInnerHTML={{__html: user.htmlBio}}/>
-              <div className={classes.notes}>
-                <Input 
-                  value={notes} 
-                  onChange={(e) => { setNotes(e.target.value)}} 
-                  disableUnderline 
-                  placeholder="Notes for other moderators"
-                  multiline
-                />
-              </div>
-              <div className={classes.row}>
-                <div className={classes.row}>
-                  {!!(user.maxCommentCount || user.maxPostCount) && <LWTooltip title="Approve">
-                    <Button onClick={handleReview}>
-                      <DoneIcon />
-                    </Button>
-                  </LWTooltip>}
-                  <LWTooltip title="Snooze (approve all posts)">
-                    <Button title="Snooze" onClick={handleSnooze}>
-                      <SnoozeIcon />
-                    </Button>
-                  </LWTooltip>
-                  <LWTooltip title="Ban for 3 months">
-                    <Button onClick={handleBan}>
-                      <RemoveCircleOutlineIcon />
-                    </Button>
-                  </LWTooltip>
-                  {!user.reviewedByUserId && <LWTooltip title="Purge (delete and ban)">
-                    <Button onClick={handlePurge}>
-                      <DeleteForeverIcon />
-                    </Button>
-                  </LWTooltip>}
-                </div>
-                <div className={classes.row}>
-                  {currentUser && <Select value={0} variant="outlined">
-                    <MenuItem value={0}>Start a message</MenuItem>
-                    {defaultModeratorComments.get().map((template, i) => <MenuItem key={`template-${template.label}`}>
-                      <NewConversationButton user={user} currentUser={currentUser} templateCommentId={template.id}>
-                        {template.label}
-                      </NewConversationButton>
-                    </MenuItem>)}
-                  </Select>}
-                  <Link to="/tag/moderator-default-responses/discussion"><EditIcon className={classes.editIcon}/></Link>
-                </div>
-              </div>
-              <hr className={classes.hr}/>
-              <div className={classes.votesRow}>
-                <LWTooltip title="Big Upvotes">
-                  <span className={classes.bigUpvotes}>
-                    { user.bigUpvoteCount || 0 }
-                  </span>
-                </LWTooltip>
-                <LWTooltip title="Upvotes">
-                  <span className={classes.upvotes}>
-                    { user.smallUpvoteCount || 0 }
-                  </span>
-                </LWTooltip>
-                <LWTooltip title="Downvotes">
-                  <span className={classes.downvotes}>
-                    { user.smallDownvoteCount || 0 }
-                  </span>
-                </LWTooltip>
-                <LWTooltip title="Big Downvotes">
-                  <span className={classes.bigDownvotes}>
-                    { user.bigDownvoteCount || 0 }
-                  </span>
-                </LWTooltip>
-              </div>
-              <div>
-                <LWTooltip title="Post count">
-                  <span>
-                    { user.postCount || 0 }
-                    <DescriptionIcon className={classes.hoverPostIcon}/>
-                  </span> 
-                </LWTooltip>
-                {postKarmaPreviews.map(post => <PostKarmaWithPreview key={post._id} post={post}/>)}
-                { hiddenPostCount ? <span> ({hiddenPostCount} deleted)</span> : null} 
-              </div>
-              {(commentsLoading || postsLoading) && <Loading/>}
-              <div>
-                <LWTooltip title="Comment count">
-                  { user.commentCount || 0 }
-                </LWTooltip>
-                <MessageIcon className={classes.icon}/> 
-                {commentKarmaPreviews.map(comment => <CommentKarmaWithPreview key={comment._id} comment={comment}/>)}
-                { hiddenCommentCount ? <span> ({hiddenCommentCount} deleted)</span> : null}
-              </div>
-              <SunshineNewUserPostsList posts={posts} user={user}/>
-              <SunshineNewUserCommentsList comments={comments} user={user}/>
-            </MetaInfo>
-          </Typography>
+          <SunshineNewUsersInfo user={user} />
         </SidebarHoverOver>
         <div>
           <MetaInfo className={classes.info}>
@@ -345,10 +67,6 @@ const SunshineNewUsersItem = ({ user, classes, updateUser }: {
 const SunshineNewUsersItemComponent = registerComponent('SunshineNewUsersItem', SunshineNewUsersItem, {
   styles,
   hocs: [
-    withUpdate({
-      collectionName: "Users",
-      fragmentName: 'SunshineUsersList',
-    }),
     withErrorBoundary,
   ]
 });

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -3,8 +3,20 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import * as _ from 'underscore';
 import { useSingle } from '../../lib/crud/withSingle';
+import { useCurrentUser } from '../common/withUser';
+import { userCanDo } from '../../lib/vulcan-users';
 
-const SunshineNewUsersProfileInfo = ({userId}:{userId:string}) => {
+const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    backgroundColor: theme.palette.grey[50],
+    padding: 12,
+    border: "solid 1px rgba(0,0,0,.1)"
+  }
+})
+
+const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: ClassesType}) => {
+
+  const currentUser = useCurrentUser()
 
   const { SunshineNewUsersInfo } = Components
 
@@ -13,10 +25,16 @@ const SunshineNewUsersProfileInfo = ({userId}:{userId:string}) => {
     collectionName: "Users",
     fragmentName: 'SunshineUsersList',
   });
-  return <SunshineNewUsersInfo user={user}/>
+
+  if (!user) return null
+  if (!userCanDo(currentUser, 'posts.moderate.all')) return null
+  if (user.reviewedByUserId && !user.sunshineSnoozed) return null
+  return <div className={classes.root}>
+      <SunshineNewUsersInfo user={user}/>
+    </div>
 }
 
-const SunshineNewUsersProfileInfoComponent = registerComponent('SunshineNewUsersProfileInfo', SunshineNewUsersProfileInfo);
+const SunshineNewUsersProfileInfoComponent = registerComponent('SunshineNewUsersProfileInfo', SunshineNewUsersProfileInfo, {styles});
 
 declare global {
   interface ComponentTypes {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -30,10 +30,10 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   if (!userCanDo(currentUser, 'posts.moderate.all')) return null
   if (user.reviewedByUserId && !user.sunshineSnoozed) return null
   return <div className={classes.root}>
-      <NoSsr>
-        <SunshineNewUsersInfo user={user}/>
-      </NoSsr>
-    </div>
+    <NoSsr>
+      <SunshineNewUsersInfo user={user}/>
+    </NoSsr>
+  </div>
 }
 
 const SunshineNewUsersProfileInfoComponent = registerComponent('SunshineNewUsersProfileInfo', SunshineNewUsersProfileInfo, {styles});

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -1,7 +1,6 @@
 /* global confirm */
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
-import * as _ from 'underscore';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -1,0 +1,26 @@
+/* global confirm */
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import React from 'react';
+import * as _ from 'underscore';
+import { useSingle } from '../../lib/crud/withSingle';
+
+const SunshineNewUsersProfileInfo = ({userId}:{userId:string}) => {
+
+  const { SunshineNewUsersInfo } = Components
+
+  const { document: user } = useSingle({
+    documentId:userId,
+    collectionName: "Users",
+    fragmentName: 'SunshineUsersList',
+  });
+  return <SunshineNewUsersInfo user={user}/>
+}
+
+const SunshineNewUsersProfileInfoComponent = registerComponent('SunshineNewUsersProfileInfo', SunshineNewUsersProfileInfo);
+
+declare global {
+  interface ComponentTypes {
+    SunshineNewUsersProfileInfo: typeof SunshineNewUsersProfileInfoComponent
+  }
+}
+

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersProfileInfo.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useSingle } from '../../lib/crud/withSingle';
 import { useCurrentUser } from '../common/withUser';
 import { userCanDo } from '../../lib/vulcan-users';
+import NoSsr from '@material-ui/core/NoSsr';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -29,7 +30,9 @@ const SunshineNewUsersProfileInfo = ({userId, classes}:{userId:string, classes: 
   if (!userCanDo(currentUser, 'posts.moderate.all')) return null
   if (user.reviewedByUserId && !user.sunshineSnoozed) return null
   return <div className={classes.root}>
-      <SunshineNewUsersInfo user={user}/>
+      <NoSsr>
+        <SunshineNewUsersInfo user={user}/>
+      </NoSsr>
     </div>
 }
 

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -174,7 +174,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   
   const render = () => {
     const user = getUserFromResults(results)
-    const { SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags, Typography } = Components
+    const { SunshineNewUsersInfo, SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags, Typography } = Components
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
         <Loading/>
@@ -261,6 +261,10 @@ const UsersProfileFn = ({terms, slug, classes}: {
             </Typography>
 
             { user.bio && <ContentItemBody className={classes.bio} dangerouslySetInnerHTML={{__html: user.htmlBio }} description={`user ${user._id} bio`} /> }
+          </SingleColumnSection>
+
+          <SingleColumnSection>
+            <SunshineNewUsersInfo user={user} />
           </SingleColumnSection>
 
           {/* Sequences Section */}

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -174,7 +174,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   
   const render = () => {
     const user = getUserFromResults(results)
-    const { SunshineNewUsersInfo, SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags, Typography } = Components
+    const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags, Typography } = Components
     if (loading) {
       return <div className={classNames("page", "users-profile", classes.profilePage)}>
         <Loading/>
@@ -264,7 +264,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
           </SingleColumnSection>
 
           <SingleColumnSection>
-            <SunshineNewUsersInfo user={user} />
+            <SunshineNewUsersProfileInfo userId={user._id} />
           </SingleColumnSection>
 
           {/* Sequences Section */}

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1012,7 +1012,7 @@ addFieldsDict(Users, {
 
   sunshineNotes: {
     type: String,
-    canRead: ['guests'],
+    canRead: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
     optional: true,

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -365,6 +365,7 @@ importComponent("SunshineNewUserCommentsList", () => require('../components/suns
 importComponent("SunshineNewUsersItem", () => require('../components/sunshineDashboard/SunshineNewUsersItem'));
 importComponent("SunshineNewUsersInfo", () => require('../components/sunshineDashboard/SunshineNewUsersInfo'));
 importComponent("SunshineNewUsersList", () => require('../components/sunshineDashboard/SunshineNewUsersList'));
+importComponent("SunshineNewUsersProfileInfo", () => require('../components/sunshineDashboard/SunshineNewUsersProfileInfo'));
 importComponent("SunshineNewPostsList", () => require('../components/sunshineDashboard/SunshineNewPostsList'));
 importComponent("SunshineNewPostsItem", () => require('../components/sunshineDashboard/SunshineNewPostsItem'));
 importComponent("SunshineNewCommentsItem", () => require('../components/sunshineDashboard/SunshineNewCommentsItem'));

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -363,6 +363,7 @@ importComponent("AFSuggestUsersList", () => require('../components/sunshineDashb
 importComponent("SunshineNewUserPostsList", () => require('../components/sunshineDashboard/SunshineNewUserPostsList'));
 importComponent("SunshineNewUserCommentsList", () => require('../components/sunshineDashboard/SunshineNewUserCommentsList'));
 importComponent("SunshineNewUsersItem", () => require('../components/sunshineDashboard/SunshineNewUsersItem'));
+importComponent("SunshineNewUsersInfo", () => require('../components/sunshineDashboard/SunshineNewUsersInfo'));
 importComponent("SunshineNewUsersList", () => require('../components/sunshineDashboard/SunshineNewUsersList'));
 importComponent("SunshineNewPostsList", () => require('../components/sunshineDashboard/SunshineNewPostsList'));
 importComponent("SunshineNewPostsItem", () => require('../components/sunshineDashboard/SunshineNewPostsItem'));


### PR DESCRIPTION
Factors out the SunshineNewUsersItem hoverover into a new component, which can then be displayed on the UserProfile page to admins. This makes it easier for moderators to link each other to "edge case" users, and discuss them.

I'm experiencing a weird bug. In a previous recent PR I added an "Input" field to SunshineNewUsersItem. It renders normally in the sunshine sidebar:

![image](https://user-images.githubusercontent.com/3246710/113090943-c1ab7900-919f-11eb-9fb8-3726dce7546a.png)

But on the UserProfile page, there are two extra "textarea" fields which are supposed to be hidden, but aren't:

![image](https://user-images.githubusercontent.com/3246710/113090512-c7ed2580-919e-11eb-8f4c-65e6717cf2fb.png)
