### PR TITLE
Implement redirect for April Fools

### DIFF
--- a/packages/lesswrong/components/common/Home2.tsx
+++ b/packages/lesswrong/components/common/Home2.tsx
@@ -1,12 +1,16 @@
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import React from 'react';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
+import { useLocation } from '../../lib/routeUtil';
+import { isServer } from '../../lib/executionEnvironment';
 
 const Home2 = () => {
-  const { RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, RecommendationsAndCurated, GatherTown, SingleColumnSection } = Components
+  const { RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, RecommendationsAndCurated, GatherTown, SingleColumnSection, PermanentRedirect } = Components
 
+  const { query } = useLocation();
   return (
       <AnalyticsContext pageContext="homePage">
+        {!query?.avoidAprilFools && isServer && <PermanentRedirect url={"https://lesswrong.substack.com"} status={302} />}
         <React.Fragment>
           <SingleColumnSection>
             <AnalyticsContext pageSectionContext="gatherTownWelcome">


### PR DESCRIPTION
Makes the frontpage redirect to lesswrong.substack.com.

Only does it on SSR. When you navigate to it from a post-page, it doesn't redirect. 

The redirect can be circumvented by adding `?avoidAprilFools=true` to the URL.