### PR TITLE
Sunshine flag

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -7,9 +7,11 @@ import moment from 'moment';
 import { useCurrentUser } from '../common/withUser';
 import withErrorBoundary from '../common/withErrorBoundary'
 import DoneIcon from '@material-ui/icons/Done';
+import FlagIcon from '@material-ui/icons/Flag';
 import SnoozeIcon from '@material-ui/icons/Snooze';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
+import OutlinedFlagIcon from '@material-ui/icons/OutlinedFlag';
 import DescriptionIcon from '@material-ui/icons/Description'
 import { useMulti } from '../../lib/crud/withMulti';
 import MessageIcon from '@material-ui/icons/Message'
@@ -122,6 +124,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
     updateUser({
       selector: {_id: user._id},
       data: {
+        sunshineFlagged: false,
         reviewedByUserId: currentUser!._id,
         reviewedAt: new Date(),
         sunshineSnoozed: false,
@@ -135,6 +138,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
     updateUser({
       selector: {_id: user._id},
       data: {
+        sunshineFlagged: false,
         needsReview: false,
         reviewedAt: new Date(),
         reviewedByUserId: currentUser!._id,
@@ -149,6 +153,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
       await updateUser({
         selector: {_id: user._id},
         data: {
+          sunshineFlagged: false,
           reviewedByUserId: currentUser!._id,
           voteBanned: true,
           needsReview: false,
@@ -165,6 +170,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
       await updateUser({
         selector: {_id: user._id},
         data: {
+          sunshineFlagged: false,
           reviewedByUserId: currentUser!._id,
           nullifyVotes: true,
           voteBanned: true,
@@ -176,6 +182,16 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
         }
       })
     }
+  }
+
+  const handleFlag = () => {
+    updateUser({
+      selector: {_id: user._id},
+      data: {
+        sunshineFlagged: !user.sunshineFlagged,
+        sunshineNotes: notes
+      }
+    })
   }
 
   const { results: posts, loading: postsLoading } = useMulti({
@@ -244,6 +260,11 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
                     <DeleteForeverIcon />
                   </Button>
                 </LWTooltip>}
+                <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : "Flag this user for more review"}>
+                  <Button onClick={handleFlag}>
+                    {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
+                  </Button>
+                </LWTooltip>
               </div>
               <div className={classes.row}>
                 {currentUser && <Select value={0} variant="outlined">

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -260,7 +260,10 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
                     <DeleteForeverIcon />
                   </Button>
                 </LWTooltip>}
-                <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : "Flag this user for more review"}>
+                <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
+                  <div>Flag this user for more review</div>
+                  <div><em>(This will not remove them from sidebar)</em></div>
+                </div>}>
                   <Button onClick={handleFlag}>
                     {user.sunshineFlagged ? <FlagIcon /> : <OutlinedFlagIcon />}
                   </Button>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -8,6 +8,7 @@ import { useHover } from '../common/withHover'
 import withErrorBoundary from '../common/withErrorBoundary'
 import red from '@material-ui/core/colors/red';
 import DescriptionIcon from '@material-ui/icons/Description'
+import FlagIcon from '@material-ui/icons/Flag'
 
 const styles = (theme: ThemeType): JssStyles => ({
   negativeKarma: {
@@ -54,6 +55,7 @@ const SunshineNewUsersItem = ({ user, classes }: {
             <FormatDate date={user.createdAt}/>
           </MetaInfo>
           {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon  className={classes.icon}/>}
+          {user.sunshineFlagged && <FlagIcon className={classes.icon}/>}
           {!user.reviewedByUserId && <MetaInfo className={classes.info}>
             { user.email }
           </MetaInfo>}

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1021,7 +1021,7 @@ addFieldsDict(Users, {
 
   sunshineFlagged: {
     type: Boolean,
-    canRead: ['guests'],
+    canRead: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
     optional: true,
@@ -1030,7 +1030,7 @@ addFieldsDict(Users, {
 
   needsReview: {
     type: Boolean,
-    canRead: ['guests'],
+    canRead: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
     optional: true,
@@ -1039,7 +1039,7 @@ addFieldsDict(Users, {
 
   sunshineSnoozed: {
     type: Boolean,
-    canRead: ['guests'],
+    canRead: ['admins', 'sunshineRegiment'],
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1019,6 +1019,15 @@ addFieldsDict(Users, {
     ...schemaDefaultValue(false),
   },
 
+  sunshineFlagged: {
+    type: Boolean,
+    canRead: ['guests'],
+    canUpdate: ['admins', 'sunshineRegiment'],
+    group: formGroups.adminOptions,
+    optional: true,
+    ...schemaDefaultValue(false),
+  },
+
   needsReview: {
     type: Boolean,
     canRead: ['guests'],

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1016,7 +1016,7 @@ addFieldsDict(Users, {
     canUpdate: ['admins', 'sunshineRegiment'],
     group: formGroups.adminOptions,
     optional: true,
-    ...schemaDefaultValue(false),
+    ...schemaDefaultValue(""),
   },
 
   sunshineFlagged: {

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -206,6 +206,7 @@ registerFragment(`
     needsReview
     sunshineSnoozed
     sunshineNotes
+    sunshineFlagged
   }
 `);
 

--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -109,6 +109,7 @@ Users.addView("sunshineNewUsers", function (terms: UsersViewTerms) {
     },
     options: {
       sort: {
+        sunshineFlagged: -1,
         reviewedByUserId: 1,
         postCount: -1,
         signUpReCaptchaRating: -1,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -673,6 +673,7 @@ interface DbUser extends DbObject {
   hideTaggingProgressBar: boolean
   hideFrontpageBookAd: boolean
   sunshineNotes: string
+  sunshineFlagged: boolean
   needsReview: boolean
   sunshineSnoozed: boolean
   reviewedByUserId: string

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1499,6 +1499,7 @@ interface SunshineUsersList extends UsersMinimumInfo { // fragment on Users
   readonly needsReview: boolean,
   readonly sunshineSnoozed: boolean,
   readonly sunshineNotes: string,
+  readonly sunshineFlagged: boolean,
 }
 
 interface SharedUserBooleans { // fragment on Users


### PR DESCRIPTION
Adds the "sunshineFlagged" field to new users, which bumps a user to the top of the sunshine queue and gives a small visual indicator.

Also fixes some permissions and default field errors in the sunshine sidebar.

![image](https://user-images.githubusercontent.com/3246710/113342981-05a79680-92e4-11eb-87f1-093742135a84.png)
