### PR TITLE
Include date in post tooltip

### DIFF
--- a/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltip.tsx
@@ -145,7 +145,7 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
   classes: ClassesType,
   comment?: any,
 }) => {
-  const { PostsUserAndCoauthors, PostsTitle, ContentItemBody, CommentsNode, BookmarkButton, LWTooltip } = Components
+  const { PostsUserAndCoauthors, PostsTitle, ContentItemBody, CommentsNode, BookmarkButton, LWTooltip, FormatDate } = Components
   const [expanded, setExpanded] = useState(false)
 
   if (!post) return null
@@ -188,6 +188,9 @@ const PostsPreviewTooltip = ({ postsList, post, classes, comment }: {
                   <LWTooltip title={`${postGetCommentCountStr(post)}`}>
                     <span className={classes.smallText}>{postGetCommentCountStr(post)}</span>
                   </LWTooltip>
+                  <span className={classes.smallText}>
+                    <FormatDate date={post.postedAt}/>
+                  </span>
                 </div>
               </>}
             </div>


### PR DESCRIPTION
In a few different contexts (most recently Sunshine Sidebar) I've found myself wanting to know if a post was old or new. Adding a small date to the hoverover seemed nice.

![image](https://user-images.githubusercontent.com/3246710/113466371-29f09980-93f0-11eb-8b8e-6335c142873a.png)
