### PR TITLE
red sunshineFlagged background

### DIFF
--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -93,7 +93,7 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
   const { pathname } = useLocation();
   const { PostsItemIcons, CuratedIcon } = Components
 
-  const shared = post.draft && (post.userId !== currentUser?._id)
+  const shared = post.draft && (post.userId !== currentUser?._id) && post.shareWithUsers
 
   // const shouldRenderQuestionTag = (pathname !== "/questions") && showQuestionTag
   const shouldRenderEventsTag = pathname !== "/community"

--- a/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/CommentKarmaWithPreview.tsx
@@ -11,6 +11,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   commentPreview: {
     maxWidth: 600
+  },
+  deleted: {
+    color: theme.palette.grey[400]
+  },
+  default: {
+    color: theme.palette.grey[900],
   }
 })
 
@@ -25,7 +31,11 @@ const CommentKarmaWithPreview = ({ comment, classes }: {
   if (!comment) return null 
 
   return <span className={classes.root} {...eventHandlers}>
-    <Link to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>{comment.baseScore}</Link>
+    <Link className={comment.deleted ? classes.deleted : classes.default}
+      to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}
+    >
+      {comment.baseScore}
+    </Link>
     <LWPopper
         open={hover}
         anchorEl={anchorEl}

--- a/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/PostKarmaWithPreview.tsx
@@ -8,6 +8,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginRight: 8,
     wordBreak: "break-word"
+  },
+  draft: {
+    color: theme.palette.grey[400]
+  },
+  default: {
+    color: theme.palette.grey[900],
   }
 })
 
@@ -22,7 +28,7 @@ const PostKarmaWithPreview = ({ post, classes }: {
   if (!post) return null 
 
   return <span className={classes.root} {...eventHandlers}>
-    <Link to={postGetPageUrl(post)}>{post.baseScore}</Link>
+    <Link className={post.draft ? classes.draft : classes.default} to={postGetPageUrl(post)}>{post.baseScore}</Link>
     <LWPopper
         open={hover}
         anchorEl={anchorEl}

--- a/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
@@ -3,11 +3,11 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    position:"sticky",
+    position:"relative",
     zIndex: theme.zIndexes.sidebarHoverOver,
   },
   hoverInfo: {
-    position: "sticky",
+    position: "relative",
     backgroundColor: theme.palette.grey[50],
     padding: theme.spacing.unit*2,
     border: "solid 1px rgba(0,0,0,.1)",

--- a/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SidebarHoverOver.tsx
@@ -3,11 +3,11 @@ import { Components, registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
-    position:"relative",
+    position:"sticky",
     zIndex: theme.zIndexes.sidebarHoverOver,
   },
   hoverInfo: {
-    position: "relative",
+    position: "sticky",
     backgroundColor: theme.palette.grey[50],
     padding: theme.spacing.unit*2,
     border: "solid 1px rgba(0,0,0,.1)",

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserPostsList.tsx
@@ -56,7 +56,7 @@ const SunshineNewUserPostsList = ({posts, user, classes}: {
           </div>
           <PostsPageActions post={post} />
         </div>
-        <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents?.htmlHighlight || "")}} />
+        {!post.draft && <div className={classes.postBody} dangerouslySetInnerHTML={{__html: (post.contents?.htmlHighlight || "")}} />}
       </div>)}
     </div>
   )

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -200,7 +200,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
           deleteContent: true,
           needsReview: false,
           reviewedAt: new Date(),
-          banned: moment().add(99, 'months').toDate(),
+          banned: moment().add(1000, 'years').toDate(),
           sunshineNotes: notes
         }
       })
@@ -370,4 +370,3 @@ declare global {
     SunshineNewUsersInfo: typeof SunshineNewUsersInfoComponent
   }
 }
-

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -1,7 +1,7 @@
 /* global confirm */
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { withUpdate } from '../../lib/crud/withUpdate';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from '../../lib/reactRouterWrapper'
 import moment from 'moment';
 import { useCurrentUser } from '../common/withUser';
@@ -126,6 +126,19 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
 
   const canReview = !!(user.maxCommentCount || user.maxPostCount)
 
+  const handleNotes = () => {
+    updateUser({
+      selector: {_id: user._id},
+      data: {
+        sunshineNotes: notes
+      }
+    })
+  }
+
+  useEffect(() => {
+    handleNotes()
+  });
+
   const handleReview = () => {
     if (canReview) {
       updateUser({
@@ -156,8 +169,10 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
     })
   }
 
+  const banMonths = 3
+
   const handleBan = async () => {
-    if (confirm("Ban this user for 3 months?")) {
+    if (confirm(`Ban this user for ${banMonths} months?`)) {
       await updateUser({
         selector: {_id: user._id},
         data: {
@@ -166,7 +181,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
           voteBanned: true,
           needsReview: false,
           reviewedAt: new Date(),
-          banned: moment().add(3, 'months').toDate(),
+          banned: moment().add(banMonths, 'months').toDate(),
           sunshineNotes: notes
         }
       })
@@ -185,7 +200,7 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
           deleteContent: true,
           needsReview: false,
           reviewedAt: new Date(),
-          banned: moment().add(12, 'months').toDate(),
+          banned: moment().add(99, 'months').toDate(),
           sunshineNotes: notes
         }
       })
@@ -263,11 +278,11 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
                     <RemoveCircleOutlineIcon />
                   </Button>
                 </LWTooltip>
-                {!user.reviewedByUserId && <LWTooltip title="Purge (delete and ban)">
+                <LWTooltip title="Purge (delete and ban)">
                   <Button onClick={handlePurge}>
                     <DeleteForeverIcon />
                   </Button>
-                </LWTooltip>}
+                </LWTooltip>
                 <LWTooltip title={user.sunshineFlagged ? "Unflag this user" : <div>
                   <div>Flag this user for more review</div>
                   <div><em>(This will not remove them from sidebar)</em></div>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -136,7 +136,9 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
   }
 
   useEffect(() => {
-    handleNotes()
+    return () => {
+      handleNotes();
+    }
   });
 
   const handleReview = () => {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -24,6 +24,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     color: theme.palette.grey[500],
     position: "relative",
     top: 3
+  },
+  flagged: {
+    background: "rgba(150,0,0,.05)"
   }
 })
 const SunshineNewUsersItem = ({ user, classes }: {
@@ -37,7 +40,7 @@ const SunshineNewUsersItem = ({ user, classes }: {
 
 
   return (
-    <span {...eventHandlers}>
+    <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl}>
           <SunshineNewUsersInfo user={user} />
@@ -61,7 +64,7 @@ const SunshineNewUsersItem = ({ user, classes }: {
           </MetaInfo>}
         </div>
       </SunshineListItem>
-    </span>
+    </div>
   )
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersItem.tsx
@@ -38,7 +38,6 @@ const SunshineNewUsersItem = ({ user, classes }: {
 
   const { SunshineListItem, SidebarHoverOver, SunshineNewUsersInfo, MetaInfo, FormatDate } = Components
 
-
   return (
     <div {...eventHandlers} className={user.sunshineFlagged ? classes.flagged : null}>
       <SunshineListItem hover={hover}>
@@ -60,7 +59,7 @@ const SunshineNewUsersItem = ({ user, classes }: {
           {(user.postCount > 0 && !user.reviewedByUserId) && <DescriptionIcon  className={classes.icon}/>}
           {user.sunshineFlagged && <FlagIcon className={classes.icon}/>}
           {!user.reviewedByUserId && <MetaInfo className={classes.info}>
-            { user.email }
+            { user.email || "This user has no email" }
           </MetaInfo>}
         </div>
       </SunshineListItem>

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -27,6 +27,8 @@ registerFragment(`
     status
     frontpageDate
     meta
+
+    shareWithUsers
     
     commentCount
     voteCount
@@ -130,7 +132,6 @@ registerFragment(`
   fragment PostsListBase on Post {
     ...PostsBase
     ...PostsAuthors
-    shareWithUsers
     moderationGuidelines {
       _id
       html

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -257,6 +257,7 @@ interface PostsBase extends PostsMinimumInfo { // fragment on Posts
   readonly status: number,
   readonly frontpageDate: Date,
   readonly meta: boolean,
+  readonly shareWithUsers: Array<string>,
   readonly commentCount: number,
   readonly voteCount: number,
   readonly baseScore: number,
@@ -333,7 +334,6 @@ interface PostsAuthors_user extends UsersMinimumInfo { // fragment on Users
 }
 
 interface PostsListBase extends PostsBase, PostsAuthors { // fragment on Posts
-  readonly shareWithUsers: Array<string>,
   readonly moderationGuidelines: PostsListBase_moderationGuidelines|null,
   readonly customHighlight: PostsListBase_customHighlight|null,
   readonly lastPromotedComment: PostsListBase_lastPromotedComment|null,


### PR DESCRIPTION
I found myself wanting to more easily skip past the flagged users (since those are users I already thought about and now I'm waiting for someone else to comment on), so adding a more noticeable visual indicator.

Also fixes other things like:
1. mousing off the hoverover saves your notes instead of discarding them
2. the drafts don't all say "[shared]"
3. I recently started making drafts more prominent in the sunshineNewUsersInfo, but then they ended up kinda _too_ prominent, and now it shows only the titles, not the bodies.

![image](https://user-images.githubusercontent.com/3246710/113635654-debfcc00-9625-11eb-8d15-b85314b56a8b.png)
