### PR TITLE
Remove walled garden from frontpage

### DIFF
--- a/packages/lesswrong/components/common/Home2.tsx
+++ b/packages/lesswrong/components/common/Home2.tsx
@@ -8,11 +8,6 @@ const Home2 = () => {
   return (
       <AnalyticsContext pageContext="homePage">
         <React.Fragment>
-          <SingleColumnSection>
-            <AnalyticsContext pageSectionContext="gatherTownWelcome">
-              <GatherTown/>
-            </AnalyticsContext>
-          </SingleColumnSection>
           <RecommendationsAndCurated configName="frontpage" />
           <AnalyticsInViewTracker
               eventProps={{inViewType: "latestPosts"}}

--- a/packages/lesswrong/components/common/Home2.tsx
+++ b/packages/lesswrong/components/common/Home2.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 
 const Home2 = () => {
-  const { RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, RecommendationsAndCurated, GatherTown, SingleColumnSection } = Components
+  const { RecentDiscussionFeed, HomeLatestPosts, AnalyticsInViewTracker, RecommendationsAndCurated } = Components
 
   return (
       <AnalyticsContext pageContext="homePage">

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1467,14 +1467,14 @@ addFieldsDict(Users, {
     canUpdate: ['admins'],
     group: formGroups.adminOptions,
   },
-  // hideWalledGardenUI: {
-  //   type: Boolean,
-  //   optional:true,
-  //   canRead: ['guests'],
-  //   canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-  //   group: formGroups.siteCustomizations,
-  //   hidden: forumTypeSetting.get() === "EAForum",
-  // },
+  hideWalledGardenUI: {
+    type: Boolean,
+    optional:true,
+    canRead: ['guests'],
+    // canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+    group: formGroups.siteCustomizations,
+    hidden: forumTypeSetting.get() === "EAForum",
+  },
   walledGardenPortalOnboarded: {
     type: Boolean,
     optional:true,

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1467,14 +1467,14 @@ addFieldsDict(Users, {
     canUpdate: ['admins'],
     group: formGroups.adminOptions,
   },
-  hideWalledGardenUI: {
-    type: Boolean,
-    optional:true,
-    canRead: ['guests'],
-    canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
-    group: formGroups.siteCustomizations,
-    hidden: forumTypeSetting.get() === "EAForum",
-  },
+  // hideWalledGardenUI: {
+  //   type: Boolean,
+  //   optional:true,
+  //   canRead: ['guests'],
+  //   canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
+  //   group: formGroups.siteCustomizations,
+  //   hidden: forumTypeSetting.get() === "EAForum",
+  // },
   walledGardenPortalOnboarded: {
     type: Boolean,
     optional:true,


### PR DESCRIPTION
Walled Garden widget isn't currently working, and I think it just makes sense to remove unless we consciously decide to prioritize it.