### PR TITLE
Log to postgres analytics whether Google Analytics is blocked

### DIFF
--- a/packages/lesswrong/lib/utils/browserProperties.ts
+++ b/packages/lesswrong/lib/utils/browserProperties.ts
@@ -1,21 +1,28 @@
 import bowser from "bowser";
 import { isClient } from '../executionEnvironment';
 
-export const browserProperties = () => {
-    if (isClient &&
-        window &&
-        window.navigator &&
-        window.navigator.userAgent) {
-
-        return {
-            // detect: bowser.detect(),
-            mobile: bowser.mobile,
-            tablet: bowser.tablet,
-            chrome: bowser.chrome,
-            firefox: bowser.firefox,
-            safari: bowser.safari,
-            osname: bowser.osname
-        }
-    }
-    return false
+export const browserProperties = (): {} => {
+  if (!isClient) return {};
+  
+  const userAgentInfo = (window?.navigator?.userAgent) ? {
+    // detect: bowser.detect(),
+    userAgent: window?.navigator?.userAgent,
+    mobile: bowser.mobile,
+    tablet: bowser.tablet,
+    chrome: bowser.chrome,
+    firefox: bowser.firefox,
+    safari: bowser.safari,
+    osname: bowser.osname
+  } : {};
+  
+  const W = (window as any);
+  const blocks = W ? {
+    blocksGA: !(W.ga?.create),
+    blocksGTM: !(W.google_tag_manager),
+  } : {};
+  
+  return {
+    ...userAgentInfo,
+    ...blocks,
+  };
 }


### PR DESCRIPTION
Log to our postgres analytics DB whether a user has Google Analytics and Google Tag Manager blocked.

Among the US population, ~27% use adblock: https://www.statista.com/statistics/804008/ad-blocking-reach-usage-us/ . uBlock Origin blocks Google Analytics by default (I checked), and I think most other adblock does too (but I didn't check).

Use of adblock is strongly correlated with general internet-sophistication, which means that among our userbase, it may be a lot higher, and among the subset of users we care most about, I expect it to be higher still. This means Google Analytics may be specifically measuring the least-sophisticated subset of our users, which would be pretty bad.