### PR TITLE
Put back an internally-unused resolver that's being used externally

### DIFF
--- a/packages/lesswrong/lib/collections/sequences/schema.ts
+++ b/packages/lesswrong/lib/collections/sequences/schema.ts
@@ -35,6 +35,29 @@ const schema: SchemaType<DbSequence> = {
     control: 'EditSequenceTitle',
   },
 
+  // This resolver isn't used within LessWrong AFAICT, but is used by an external API user
+  chaptersDummy: {
+    type: Array,
+    optional: true,
+    viewableBy: ['guests'],
+    resolveAs: {
+      fieldName: 'chapters',
+      type: '[Chapter]',
+      resolver: async (sequence: DbSequence, args: void, context: ResolverContext): Promise<Array<DbChapter>> => {
+        const books = await context.Chapters.find(
+          {sequenceId: sequence._id},
+        ).fetch();
+        return books;
+      }
+    }
+  },
+
+  'chaptersDummy.$': {
+    type: String,
+    foreignKey: "Chapters",
+    optional: true,
+  },
+  
   //Cloudinary image id for the grid Image
   gridImageId: {
     type: String,


### PR DESCRIPTION
The `chapters` resolver on the `Sequences` collection was removed as unused in e006210833e2908094a38079a6b1de55e1eca9e3, but started generating Sentry errors, suggesting an external usage. Put the resolver back.