### PR TITLE
Fix tag comment subscription management

### DIFF
--- a/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
+++ b/packages/lesswrong/components/users/ViewSubscriptionsPage.tsx
@@ -145,8 +145,8 @@ const ViewSubscriptionsPage = ({classes}: {
       title="Subscribed to Comment Replies"
       collectionName="Comments"
       subscriptionType="newReplies"
-      fragmentName="ShortformComments"
-      renderDocument={(comment: ShortformComments) => <Link to={commentGetPageUrlFromIds({postId: comment?.post?._id, postSlug: comment?.post?.slug, commentId: comment?._id, permalink: true})}>
+      fragmentName="CommentsListWithParentMetadata"
+      renderDocument={(comment: CommentsListWithParentMetadata) => <Link to={commentGetPageUrlFromIds({postId: comment?.post?._id, postSlug: comment?.post?.slug, tagSlug: comment?.tag?.slug, commentId: comment?._id, permalink: true})}>
         author: {comment?.user?.displayName} post: {comment?.post?.title}
       </Link>}
       noSubscriptionsMessage="You are not subscribed to any comment replies."


### PR DESCRIPTION
From Pablo: 

Steps to reproduce:

1. Open [this link](https://forum.effectivealtruism.org/tag/certificates-of-impact/discussion)
2. Click on three vertical dots, 'Subscribe to comment replies'
3. Go to your profile, 'Manage subscriptions'
4. Under 'Subscribed to comment replies', follow the link 'author: MichaelA post:'

The URL should point to MichaelA's comment, but instead points to forum.effectivealtruism.org
(I noticed this because I would like to subscribe to comment replies as a way of keeping track of the comments I still haven't responded to.)