### PR TITLE
thoughtsaver slightly prettier

### DIFF
--- a/packages/lesswrong/lib/globalStyles.ts
+++ b/packages/lesswrong/lib/globalStyles.ts
@@ -81,8 +81,7 @@ const globalStyle = (theme: ThemeType): JssStyles => ({
     width: "100%",
     height: "500px",
     border: "none",
-    borderRadius: 5,
-    boxShadow: "0 0 5px rgba(0,0,0,.2)"
+    borderRadius: 5
   },
 });
 

--- a/packages/lesswrong/lib/globalStyles.ts
+++ b/packages/lesswrong/lib/globalStyles.ts
@@ -80,6 +80,9 @@ const globalStyle = (theme: ThemeType): JssStyles => ({
   ".thoughtSaverFrame": {
     width: "100%",
     height: "500px",
+    border: "none",
+    borderRadius: 5,
+    boxShadow: "0 0 5px rgba(0,0,0,.2)"
   },
 });
 


### PR DESCRIPTION
Found myself annoyed by thoughtsaver iframe styling and wanted to slightly improve it. Current version has drop shadows because I like them, and because I think the color of grey is juuuuust a bit too hard too hard to see (causes some eyestrain).. But, I think it also works okay if we remove the drop shadow.

option 1:

![image](https://user-images.githubusercontent.com/3246710/115458228-5111de00-a1da-11eb-935c-b968a829166e.png)

option 2:

![image](https://user-images.githubusercontent.com/3246710/115458204-46efdf80-a1da-11eb-97a3-4089c9a4e72d.png)
