### PR TITLE
fix bug with overwriting sunshineNotes

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -134,12 +134,14 @@ const SunshineNewUsersInfo = ({ user, classes, updateUser }: {
   const canReview = !!(user.maxCommentCount || user.maxPostCount)
 
   const handleNotes = () => {
-    updateUser({
-      selector: {_id: user._id},
-      data: {
-        sunshineNotes: notes
-      }
-    })
+    if (notes != user.sunshineNotes) {
+      updateUser({
+        selector: {_id: user._id},
+        data: {
+          sunshineNotes: notes
+        }
+      })
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
Hopefully fixes the issue where if someone else updates a sunshine-user-notes, and then I accidentally mouseover it before reloading my own page, it overrwrites their work.