### PR TITLE
Fixes discovered during merge

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,8 @@
-node_modules
+**/node_modules
 npm-debug.log
 yarn-debug.log
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 .git
 .gitignore
+.meteor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM node:15.5.0
 WORKDIR /usr/src/app
-COPY ./ ./
+# Copy only files necessary for yarn install, to avoid spurious changes
+# triggering re-install
+COPY package.json package.json
+COPY yarn.lock yarn.lock
+COPY public/lesswrong-editor public/lesswrong-editor
+COPY scripts/postinstall.sh scripts/postinstall.sh
 RUN yarn
+COPY . .
 EXPOSE 8080
 CMD [ "yarn", "run", "production" ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,17 @@
     "rebuild-reinstall-ckeditor": "cd ./public/lesswrong-editor && yarn install && yarn run build && cd ../.. && yarn add ./public/lesswrong-editor",
     "reinstall-ckeditor-after-git-checkout": "yarn add ./public/lesswrong-editor",
     "reinstall-ckeditor": "yarn add ./public/lesswrong-editor",
-    "production": "scripts/runProduction.sh"
+    "production": "scripts/runProduction.sh",
+    "ea-start": "./build.js -run -watch --settings ../ForumCredentials/settings-dev.json --mongoUrlFile ../ForumCredentials/dev-db-conn.txt",
+    "ea-start-staging-db": "./build.js -run --watch --mongoUrlFile ../ForumCredentials/staging-db-conn.txt --settings ../ForumCredentials/settings-local-dev-staging-db.json",
+    "ea-start-prod-db": "./build.js -run --watch --mongoUrlFile ../ForumCredentials/prod-db-conn.txt --settings ../ForumCredentials/settings-local-dev-prod-db.json",
+    "ea-mongod": "mongod --dbpath .meteor/local/db --port 3001",
+    "ea-mongo": "mongo $(< ../ForumCredentials/dev-db-conn.txt)",
+    "ea-mongo-staging": "mongo $(< ../ForumCredentials/staging-db-conn.txt)",
+    "ea-mongo-prod": "mongo $(< ../ForumCredentials/prod-db-conn.txt)",
+    "ea-load-dev-db": "mongo $(< ../ForumCredentials/dev-db-conn.txt) ../ForumCredentials/loadDevDbSettings.js",
+    "ea-load-staging-db": "mongo $(< ../ForumCredentials/staging-db-conn.txt) ../ForumCredentials/loadStagingDbSettings.js",
+    "ea-load-prod-db": "mongo $(< ../ForumCredentials/prod-db-conn.txt) ../ForumCredentials/loadProdDbSettings.js"
   },
   "dependencies": {
     "@apollo/client": "^3.2.0",

--- a/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/ContentType.tsx
@@ -143,10 +143,7 @@ export const contentTypes: Record<ForumTypeString,Record<ContentTypeString,Conte
       tooltipBody: <div>
         Posts that are relevant to doing good effectively.
       </div>,
-      // ea-forum-lookhere: When "frontpage" or "personal blog" appear in a tags-list,
-      // it's a link to a post explaining the policies. This is my best guess at which
-      // post that would be on EA Forum, but there might be a better one. --Jim
-      linkTarget: "/posts/5TAwep4tohN7SGp3P/the-frontpage-community-distinction",
+      linkTarget: "/about#Finding_content",
       Icon: HomeIcon
     },
     personal: {

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import Info from '@material-ui/icons/Info';
+import { siteNameWithArticleSetting } from '../../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   reviewInfo: {
@@ -19,6 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   infoIcon: {
     width: 16,
     height: 16,
+    marginLeft: theme.spacing.unit,
     verticalAlign: "top",
     color: "rgba(0,0,0,.4)",
   },
@@ -41,11 +43,10 @@ const PostBodyPrefix = ({post, query, classes}: {
     </div>} */}
 
     <AlignmentCrosspostMessage post={post} />
-    {/* ea-forum-look-here */}
     { post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>
       Because this is your first post, this post is awaiting moderator approval.
       <LWTooltip title={<p>
-        New users' first posts on LessWrong are checked by moderators before they appear on the site.
+        New users' first posts on {siteNameWithArticleSetting.get()} are checked by moderators before they appear on the site.
         Most posts will be approved within 24 hours; posts that are spam or that don't meet site
         standards will be deleted. After you've had a post approved, future posts will appear
         immediately without waiting for review.

--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -109,7 +109,8 @@ const UsersMenu = ({color="rgba(0, 0, 0, 0.6)", classes}: {
               </MenuItem>
             }
             {showNewButtons && <Divider/>}
-            {showNewButtons && <Link to={`/newPost?eventForm=true`}>
+            {showNewButtons && forumTypeSetting.get() !== 'EAForum' &&
+              <Link to={`/newPost?eventForm=true`}>
                 <MenuItem>New Event</MenuItem>
               </Link>
             }

--- a/packages/lesswrong/lib/collections/tags/views.ts
+++ b/packages/lesswrong/lib/collections/tags/views.ts
@@ -170,3 +170,16 @@ Tags.addView('tagsByTagFlag', (terms: TagsViewTerms) => {
     options: {sort: {createdAt: -1}}
   }
 });
+
+Tags.addView('allPublicTags', (terms: TagsViewTerms) => {
+  return {
+    selector: {
+      deleted: viewFieldAllowAny,
+      adminOnly: viewFieldAllowAny,
+      wikiOnly: viewFieldAllowAny
+    },
+    options: {sort: {name: 1}}
+  }
+});
+
+ensureIndex(Tags, {name: 1});

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -19,6 +19,7 @@ import { userEmailAddressIsVerified } from '../../../lib/collections/users/helpe
 import { clearCookie } from '../../utils/httpUtil';
 import { DatabaseServerSetting } from "../../databaseSettings";
 import request from 'request';
+import { forumTitleSetting } from '../../../lib/instanceSettings';
 
 // Meteor hashed its passwords twice, once on the client
 // and once again on the server. To preserve backwards compatibility
@@ -136,10 +137,10 @@ export async function sendVerificationEmail(user: DbUser) {
   const verifyEmailLink = await VerifyEmailToken.generateLink(user._id);
   await wrapAndSendEmail({
     user, 
-    subject: "Verify your LessWrong email",
+    subject: `Verify your ${forumTitleSetting.get()} email`,
     body: <div>
       <p>
-        Click here to verify your LessWrong email 
+        Click here to verify your {forumTitleSetting.get()} email
       </p>
       <p>
         <a href={verifyEmailLink}>

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -30,6 +30,11 @@ else
   exit 1
 fi
 
+if [ "$NODE_ENV" == "production" ]; then
+  echo "production run, skipping unnecessary checks"
+  exit 0
+fi
+
 echo -n "Checking for mongodb... "
 if which mongod >/dev/null; then
   mongod --version |head -1
@@ -76,4 +81,3 @@ if [ -e /proc/sys/fs/inotify/max_user_watches ]; then
 else
   echo 'N/A'
 fi
-


### PR DESCRIPTION
The main interesting change is that the Docker build can be greatly sped up. This is valuable when you're making changes locally and testing a deploy from your local machine, which isn't that common. However, when you do want to do so, it's a world of difference. The idea is that Docker tries to cache the results of previous builds. However when an input changes, all further caches are invalidated. The implication of that is that you want to delay `COPY . .` as long as possible. Specifically, try to do it after the yarn install. In an even more impactful move, we add .meteor to the dockerignore file, to avoid copying over the whole freaking database.