### PR TITLE
Bugfix roundup

### DIFF
--- a/packages/lesswrong/components/users/UsersNameDisplay.tsx
+++ b/packages/lesswrong/components/users/UsersNameDisplay.tsx
@@ -77,7 +77,7 @@ const UsersNameDisplay = ({user, nofollow=false, simple=false, classes, tooltipP
 
   return <span {...eventHandlers} className={className}>
     <AnalyticsContext pageElementContext="userNameDisplay" userIdDisplayed={user._id}>
-    <LWTooltip title={tooltip} placement={tooltipPlacement}>
+    <LWTooltip title={tooltip} placement={tooltipPlacement} inlineBlock={false}>
       <Link to={userGetProfileUrl(user)} className={classes.userName}
           {...(nofollow ? {rel:"nofollow"} : {})}
         >

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -3,9 +3,10 @@ import { CallbackChainHook } from './vulcan-lib/callbacks';
 import { RateLimiter } from './rateLimiter';
 import React, { useContext, useEffect, useState, useRef, useCallback } from 'react'
 import { hookToHoc } from './hocUtils'
-import { isClient, isServer, isDevelopment } from './executionEnvironment';
+import { isClient, isServer, isDevelopment, isAnyTest } from './executionEnvironment';
 import { ColorHash } from './vendor/colorHash';
 import { DatabasePublicSetting } from './publicSettings';
+import { getPublicSettingsLoaded } from './settingsCache';
 import * as _ from 'underscore';
 
 const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug ", "dev");
@@ -42,9 +43,12 @@ export const AnalyticsUtil: any = {
 };
 
 function getShowAnalyticsDebug() {
-  if (showAnalyticsDebug.get()==="always")
+  if (isAnyTest)
+    return false;
+  const debug = getPublicSettingsLoaded() ? showAnalyticsDebug.get() : "dev";
+  if (debug==="always")
     return true;
-  else if (showAnalyticsDebug.get()==="dev")
+  else if (debug==="dev")
     return isDevelopment;
   else
     return false;

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -29,10 +29,10 @@ export async function commentGetPageUrlFromDB(comment: DbComment, isAbsolute = f
 };
 
 export function commentGetPageUrl(comment: CommentsListWithParentMetadata, isAbsolute = false): string {
-  const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
   if (comment.post) {
-    return `${prefix}/${postGetPageUrl(comment.post, isAbsolute)}?commentId=${comment._id}`;
+    return `${postGetPageUrl(comment.post, isAbsolute)}?commentId=${comment._id}`;
   } else if (comment.tag) {
+    const prefix = isAbsolute ? getSiteUrl().slice(0,-1) : '';
     return `${prefix}/tag/${comment.tag.slug}/discussion#${comment._id}`;
   } else {
     throw new Error(`Unable to find document for comment: ${comment._id}`);

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { postGetPageUrl } from '../../lib/collections/posts/helpers';
+import { postGetPageUrl, postGetLink, postGetLinkTarget } from '../../lib/collections/posts/helpers';
 import { Components, registerComponent } from '../../lib/vulcan-lib/components';
 import { useSingle } from '../../lib/crud/withSingle';
 import './EmailFormatDate';
@@ -60,6 +60,10 @@ const NewPostEmail = ({documentId, classes, reason}: {
       </div>}
       {document.contactInfo && <div>
         Contact: {document.contactInfo}
+      </div>}
+      
+      {document.url && <div>
+        This is a linkpost for <a href={postGetLink(document)} target={postGetLinkTarget(document)}>{document.url}</a>
       </div>}
     </div>
     

--- a/packages/lesswrong/server/loginTokens.ts
+++ b/packages/lesswrong/server/loginTokens.ts
@@ -13,3 +13,9 @@ export function tokenExpiration(when) {
   // `when` used to be a number.
   return new Date((new Date(when)).getTime() + tokenLifetimeMs);
 }
+
+export function userIsBanned(user: DbUser) {
+  if (user.banned && new Date(user.banned) > new Date())
+    return true;
+  return false;
+}

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -9,7 +9,7 @@ import { addGraphQLMutation, addGraphQLSchema, addGraphQLResolvers, } from "../.
 import { getForwardedWhitelist } from "../../forwarded_whitelist";
 import { LWEvents } from "../../../lib/collections/lwevents";
 import Users from "../../../lib/vulcan-users";
-import { hashLoginToken } from "../../loginTokens";
+import { hashLoginToken, userIsBanned } from "../../loginTokens";
 import { LegacyData } from '../../../lib/collections/legacyData/collection';
 import { AuthenticationError } from 'apollo-server'
 import { EmailTokenType } from "../../emails/emailTokens";
@@ -184,7 +184,7 @@ const authenticationResolvers = {
         return new Promise((resolve, reject) => {
           if (err) throw Error(err)
           if (!user) throw new AuthenticationError("Invalid username/password")
-          if (user.banned && new Date(user.banned) > new Date()) throw new AuthenticationError("This user is banned")
+          if (userIsBanned(user)) throw new AuthenticationError("This user is banned")
 
           req!.logIn(user, async err => {
             if (err) throw new AuthenticationError(err)

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/context.ts
@@ -18,7 +18,7 @@ import findByIds from '../findbyids';
 import { getHeaderLocale } from '../intl';
 import Users from '../../../lib/collections/users/collection';
 import * as _ from 'underscore';
-import { hashLoginToken, tokenExpiration } from '../../loginTokens';
+import { hashLoginToken, tokenExpiration, userIsBanned } from '../../loginTokens';
 import type { Request, Response } from 'express';
 
 // From https://github.com/apollographql/meteor-integration/blob/master/src/server.js
@@ -33,7 +33,7 @@ export const getUser = async (loginToken: string): Promise<DbUser|null> => {
       'services.resume.loginTokens.hashedToken': hashedToken
     })
 
-    if (user) {
+    if (user && !userIsBanned(user)) {
       // find the right login token corresponding, the current user may have
       // several sessions logged on different browsers / computers
       const tokenInformation = user.services.resume.loginTokens.find(


### PR DESCRIPTION
* New-post emails show if it's a linkpost
* Enforce bans on existing user login tokens
* Fix warning during startup about trying to get analytics-debug config setting before it's loaded
* Fix truncated coauthor lists on PostsItem2
* Fix broken links to comments in emails due to adding the prefix twice
