### PR TITLE
Tag pages have table of contents

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -21,7 +21,7 @@ import { pBodyStyle } from '../themes/stylePiping';
 import { DatabasePublicSetting, googleTagManagerIdSetting } from '../lib/publicSettings';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { globalStyles } from '../lib/globalStyles';
-import type { ToCData } from '../server/tableOfContents';
+import type { ToCData, ToCSection } from '../server/tableOfContents';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 1601103600000)
@@ -119,7 +119,7 @@ interface LayoutProps extends ExternalProps, WithLocationProps, WithStylesProps,
 }
 interface LayoutState {
   timezone: string,
-  toc: any,
+  toc: {title: string|null, sections?: ToCSection[]}|null,
   postsRead: Record<string,boolean>,
   tagsRead: Record<string,boolean>,
   hideNavigationSidebar: boolean,
@@ -144,11 +144,11 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
     this.searchResultsAreaRef = React.createRef<HTMLDivElement>();
   }
 
-  setToC = (document: PostsBase|null, sectionData: ToCData|null) => {
-    if (document) {
+  setToC = (title: string|null, sectionData: ToCData|null) => {
+    if (title) {
       this.setState({
         toc: {
-          document: document,
+          title: title,
           sections: sectionData?.sections
         }
       });

--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -21,6 +21,7 @@ import { pBodyStyle } from '../themes/stylePiping';
 import { DatabasePublicSetting, googleTagManagerIdSetting } from '../lib/publicSettings';
 import { forumTypeSetting } from '../lib/instanceSettings';
 import { globalStyles } from '../lib/globalStyles';
+import type { ToCData } from '../server/tableOfContents';
 
 const intercomAppIdSetting = new DatabasePublicSetting<string>('intercomAppId', 'wtb8z7sj')
 const petrovBeforeTime = new DatabasePublicSetting<number>('petrov.beforeTime', 1601103600000)
@@ -143,12 +144,12 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
     this.searchResultsAreaRef = React.createRef<HTMLDivElement>();
   }
 
-  setToC = (document, sectionData) => {
+  setToC = (document: PostsBase|null, sectionData: ToCData|null) => {
     if (document) {
       this.setState({
         toc: {
           document: document,
-          sections: sectionData && sectionData.sections
+          sections: sectionData?.sections
         }
       });
     } else {

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { registerComponent, Components } from '../../../lib/vulcan-lib';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import classNames from 'classnames';
+import type { ToCData } from '../../../server/tableOfContents';
 
 const styles = (theme: ThemeType): JssStyles => ({
   paperWithoutToC: {
@@ -55,7 +56,7 @@ const NavigationDrawer = ({open, handleOpen, handleClose, toc, classes}: {
   open: boolean,
   handleOpen: ()=>void,
   handleClose: ()=>void,
-  toc: any,
+  toc: ToCData,
   classes: ClassesType,
 }) => {
   const { TabNavigationMenu, TabNavigationMenuCompressed } = Components

--- a/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
+++ b/packages/lesswrong/components/common/TabNavigationMenu/NavigationDrawer.tsx
@@ -81,6 +81,7 @@ const NavigationDrawer = ({open, handleOpen, handleClose, toc, classes}: {
       <div className={classes.tableOfContents}>
         <Components.TableOfContentsList
           sectionData={toc}
+          title={null}
           onClickSection={() => handleClose()}
           drawerStyle={true}
         />

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -72,7 +72,7 @@ const PostsPage = ({post, refetch, classes}: {
   const { query, params } = location;
   const { HeadTags, PostsPagePostHeader, PostsPagePostFooter, PostBodyPrefix,
     PostsCommentsThread, ContentItemBody, PostsPageQuestionContent,
-    CommentPermalink, AnalyticsInViewTracker, ToCColumn } = Components
+    CommentPermalink, AnalyticsInViewTracker, ToCColumn, TableOfContents } = Components
 
   useEffect(() => {
     recordPostView({
@@ -107,8 +107,11 @@ const PostsPage = ({post, refetch, classes}: {
 
   return (<AnalyticsContext pageContext="postsPage" postId={post._id}>
     <ToCColumn
-      sectionData={sectionData}
-      title={post.title}
+      tableOfContents={
+        sectionData
+          ? <TableOfContents sectionData={sectionData} title={post.title} />
+          : null
+      }
       header={<>
         <HeadTags
           ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -72,7 +72,7 @@ const PostsPage = ({post, refetch, classes}: {
   const { query, params } = location;
   const { HeadTags, PostsPagePostHeader, PostsPagePostFooter, PostBodyPrefix,
     PostsCommentsThread, ContentItemBody, PostsPageQuestionContent,
-    TableOfContents, CommentPermalink, AnalyticsInViewTracker, ToCColumn } = Components
+    CommentPermalink, AnalyticsInViewTracker, ToCColumn } = Components
 
   useEffect(() => {
     recordPostView({

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
+import type { ToCData } from '../../../server/tableOfContents';
 
 const styles = (theme: ThemeType): JssStyles => ({
   stickyBlock: {
@@ -51,7 +52,7 @@ type setToCFn = (document: PostsBase|null, sectionData: any)=>void
 export const TableOfContentsContext = React.createContext<setToCFn|null>(null);
 
 const TableOfContents = ({sectionData, document, classes}: {
-  sectionData: any,
+  sectionData: ToCData,
   document: PostsBase,
   classes: ClassesType,
 }) => {

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
@@ -48,12 +48,12 @@ const styles = (theme: ThemeType): JssStyles => ({
 //
 // The reference is to a function setToC, which puts the ToC in the state of
 // Layout.
-type setToCFn = (document: PostsBase|null, sectionData: any)=>void
+type setToCFn = (document: PostsBase|null, sectionData: ToCData|null)=>void
 export const TableOfContentsContext = React.createContext<setToCFn|null>(null);
 
 const TableOfContents = ({sectionData, document, classes}: {
   sectionData: ToCData,
-  document: PostsBase,
+  document: PostsBase|null,
   classes: ClassesType,
 }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -76,7 +76,7 @@ const TableOfContents = ({sectionData, document, classes}: {
     <div className={classes.stickyBlock}>
       <Components.TableOfContentsList
         sectionData={sectionData}
-        document={document}
+        title={document.title}
         drawerStyle={false}
       />
     </div>

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
@@ -51,9 +51,10 @@ const styles = (theme: ThemeType): JssStyles => ({
 type setToCFn = (title: string|null, sectionData: ToCData|null)=>void
 export const TableOfContentsContext = React.createContext<setToCFn|null>(null);
 
-const TableOfContents = ({sectionData, title, classes}: {
+const TableOfContents = ({sectionData, title, onClickSection, classes}: {
   sectionData: ToCData,
   title: string|null,
+  onClickSection?: ()=>void,
   classes: ClassesType,
 }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -78,6 +79,7 @@ const TableOfContents = ({sectionData, title, classes}: {
         sectionData={sectionData}
         title={title}
         drawerStyle={false}
+        onClickSection={onClickSection}
       />
     </div>
   );

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContents.tsx
@@ -48,12 +48,12 @@ const styles = (theme: ThemeType): JssStyles => ({
 //
 // The reference is to a function setToC, which puts the ToC in the state of
 // Layout.
-type setToCFn = (document: PostsBase|null, sectionData: ToCData|null)=>void
+type setToCFn = (title: string|null, sectionData: ToCData|null)=>void
 export const TableOfContentsContext = React.createContext<setToCFn|null>(null);
 
-const TableOfContents = ({sectionData, document, classes}: {
+const TableOfContents = ({sectionData, title, classes}: {
   sectionData: ToCData,
-  document: PostsBase|null,
+  title: string|null,
   classes: ClassesType,
 }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -61,22 +61,22 @@ const TableOfContents = ({sectionData, document, classes}: {
 
   useEffect(() => {
     if (setToC)
-      setToC(document, sectionData);
+      setToC(title, sectionData);
     
     return () => {
       if (setToC)
         setToC(null, null);
     }
-  }, [document, sectionData, setToC]);
+  }, [title, sectionData, setToC]);
 
-  if (!sectionData || !document)
+  if (!sectionData)
     return <div/>
 
   return (
     <div className={classes.stickyBlock}>
       <Components.TableOfContentsList
         sectionData={sectionData}
-        title={document.title}
+        title={title}
         drawerStyle={false}
       />
     </div>

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -1,96 +1,43 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { isServer } from '../../../lib/executionEnvironment';
-import { withNavigation } from '../../../lib/routeUtil';
+import { useNavigation } from '../../../lib/routeUtil';
+import type { ToCData } from '../../../server/tableOfContents';
 
 const topSection = "top";
 
-interface TableOfContentsListProps {
-  sectionData: any,
+const TableOfContentsList = ({sectionData, document, onClickSection, drawerStyle}: {
+  sectionData: ToCData,
   document?: PostsBase,
-  onClickSection?: any,
+  onClickSection?: ()=>void,
   drawerStyle: boolean,
-  history?: any
-}
-interface TableOfContentsListState {
-  currentSection: any,
-  drawerOpen: boolean,
-}
+}) => {
+  const [currentSection,setCurrentSection] = useState<string|null>(topSection);
+  const [drawerOpen,setDrawerOpen] = useState(false);
+  const { history } = useNavigation();
 
-class TableOfContentsList extends Component<TableOfContentsListProps,TableOfContentsListState> {
-  state: TableOfContentsListState = {
-    currentSection: {anchor: topSection},
-    drawerOpen: false,
-  }
-
-  componentDidMount() {
-    window.addEventListener('scroll', this.updateHighlightedSection);
-    this.updateHighlightedSection();
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('scroll', this.updateHighlightedSection);
-  }
-
-  render() {
-    const { sectionData, document} = this.props;
-    const { currentSection } = this.state;
-    const { TableOfContentsRow, AnswerTocRow } = Components;
-    // const Row = TableOfContentsRow;
-
-    if (!sectionData)
-      return <div/>
-
-    const { sections } = sectionData;
-
-    const title = (document && document.title) || (sectionData.document && sectionData.document.title);
-
-    return <div>
-      <div>
-        <TableOfContentsRow key="postTitle"
-          href="#"
-          onClick={ev => this.jumpToY(0, ev)}
-          highlighted={currentSection && currentSection.anchor === topSection}
-          title
-        >
-          {title?.trim()}
-        </TableOfContentsRow>
-        {sections && sections.map((section, index) => {
-          return (
-            <TableOfContentsRow
-              key={section.anchor}
-              indentLevel={section.level}
-              divider={section.divider}
-              highlighted={section.anchor === currentSection}
-              href={"#"+section.anchor}
-              onClick={(ev) => this.jumpToAnchor(section.anchor, ev)}
-              answer={!!section.answer}
-            >
-                {section.answer ?
-                  <AnswerTocRow answer={section.answer} />
-                  :
-                  <span>{section.title?.trim()}</span>
-                }
-            </TableOfContentsRow>
-          )
-        })}
-      </div>
-    </div>
-  }
+  useEffect(() => {
+    window.addEventListener('scroll', updateHighlightedSection);
+    updateHighlightedSection();
+    
+    return () => {
+      window.removeEventListener('scroll', updateHighlightedSection);
+    };
+  });
 
 
   // Return the screen-space current section mark - that is, the spot on the
   // screen where the current-post will transition when its heading passes.
-  getCurrentSectionMark() {
+  const getCurrentSectionMark = () => {
     return window.innerHeight/3
   }
 
   // Return the screen-space Y coordinate of an anchor. (Screen-space meaning
   // if you've scrolled, the scroll is subtracted from the effective Y
   // position.)
-  getAnchorY(anchorName: string): number|null {
-    let anchor = document.getElementById(anchorName);
+  const getAnchorY = (anchorName: string): number|null => {
+    let anchor = window.document.getElementById(anchorName);
     if (anchor) {
       let anchorBounds = anchor.getBoundingClientRect();
       return anchorBounds.top + (anchorBounds.height/2);
@@ -99,30 +46,29 @@ class TableOfContentsList extends Component<TableOfContentsListProps,TableOfCont
     }
   }
 
-  jumpToAnchor(anchor: string, ev: MouseEvent|null) {
+  const jumpToAnchor = (anchor: string, ev: MouseEvent|null) => {
     if (isServer) return;
 
-    const anchorY = this.getAnchorY(anchor);
+    const anchorY = getAnchorY(anchor);
     if (anchorY !== null) {
-      const { history } = this.props
       history.push(`#${anchor}`)
       let sectionYdocumentSpace = anchorY + window.scrollY;
-      this.jumpToY(sectionYdocumentSpace, ev);
+      jumpToY(sectionYdocumentSpace, ev);
     }
   }
 
-  jumpToY(y: number, ev: MouseEvent|null) {
+  const jumpToY = (y: number, ev: MouseEvent|null) => {
     if (isServer) return;
 
     if (ev && (ev.button>0 || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.metaKey))
       return;
 
-    if (this.props.onClickSection) {
-      this.props.onClickSection();
+    if (onClickSection) {
+      onClickSection();
     }
     try {
       window.scrollTo({
-        top: y - this.getCurrentSectionMark() + 1,
+        top: y - getCurrentSectionMark() + 1,
         behavior: "smooth"
       });
 
@@ -131,21 +77,17 @@ class TableOfContentsList extends Component<TableOfContentsListProps,TableOfCont
       // eslint-disable-next-line no-console
       console.warn("scrollTo not supported, using link fallback", e)
     }
-
   }
 
-  updateHighlightedSection = () => {
-    let newCurrentSection = this.getCurrentSection();
-    if(newCurrentSection !== this.state.currentSection) {
-      this.setState({
-        currentSection: newCurrentSection,
-      });
+  const updateHighlightedSection = () => {
+    let newCurrentSection = getCurrentSection();
+    if(newCurrentSection !== currentSection) {
+      setCurrentSection(newCurrentSection);
     }
   }
 
-  getCurrentSection = () => {
-    const { sectionData } = this.props;
-    const sections = sectionData && sectionData.sections
+  const getCurrentSection = (): string|null => {
+    const sections = sectionData?.sections
 
     if (isServer)
       return null;
@@ -155,12 +97,12 @@ class TableOfContentsList extends Component<TableOfContentsListProps,TableOfCont
     // The current section is whichever section a spot 1/3 of the way down the
     // window is inside. So the selected section is the section whose heading's
     // Y is as close to the 1/3 mark as possible without going over.
-    let currentSectionMark = this.getCurrentSectionMark();
+    let currentSectionMark = getCurrentSectionMark();
 
-    let currentSection = null;
+    let currentSection: string|null = null;
     for(let i=0; i<sections.length; i++)
     {
-      let sectionY = this.getAnchorY(sections[i].anchor);
+      let sectionY = getAnchorY(sections[i].anchor);
 
       if(sectionY && sectionY < currentSectionMark)
         currentSection = sections[i].anchor;
@@ -168,16 +110,51 @@ class TableOfContentsList extends Component<TableOfContentsListProps,TableOfCont
 
     if (currentSection === null) {
       // Was above all the section headers, so return the special "top" section
-      return { anchor: topSection}
+      return topSection;
     }
 
     return currentSection;
   }
+  
+  const { TableOfContentsRow, AnswerTocRow } = Components;
+
+  if (!sectionData)
+    return <div/>
+
+  return <div>
+    <TableOfContentsRow key="postTitle"
+      href="#"
+      onClick={ev => jumpToY(0, ev)}
+      highlighted={currentSection === topSection}
+      title
+    >
+      {document?.title?.trim()}
+    </TableOfContentsRow>
+    
+    {sectionData?.sections && sectionData.sections.map((section, index) => {
+      return (
+        <TableOfContentsRow
+          key={section.anchor}
+          indentLevel={section.level}
+          divider={section.divider}
+          highlighted={section.anchor === currentSection}
+          href={"#"+section.anchor}
+          onClick={(ev) => jumpToAnchor(section.anchor, ev)}
+          answer={!!section.answer}
+        >
+          {section.answer
+            ? <AnswerTocRow answer={section.answer} />
+            : <span>{section.title?.trim()}</span>
+          }
+        </TableOfContentsRow>
+      )
+    })}
+  </div>
 }
 
 const TableOfContentsListComponent = registerComponent(
   "TableOfContentsList", TableOfContentsList, {
-    hocs: [withErrorBoundary, withNavigation]
+    hocs: [withErrorBoundary]
   }
 );
 

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -9,7 +9,7 @@ const topSection = "top";
 
 const TableOfContentsList = ({sectionData, title, onClickSection, drawerStyle}: {
   sectionData: ToCData,
-  title?: string,
+  title: string|null,
   onClickSection?: ()=>void,
   drawerStyle: boolean,
 }) => {

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -7,9 +7,9 @@ import type { ToCData } from '../../../server/tableOfContents';
 
 const topSection = "top";
 
-const TableOfContentsList = ({sectionData, document, onClickSection, drawerStyle}: {
+const TableOfContentsList = ({sectionData, title, onClickSection, drawerStyle}: {
   sectionData: ToCData,
-  document?: PostsBase,
+  title?: string,
   onClickSection?: ()=>void,
   drawerStyle: boolean,
 }) => {
@@ -128,7 +128,7 @@ const TableOfContentsList = ({sectionData, document, onClickSection, drawerStyle
       highlighted={currentSection === topSection}
       title
     >
-      {document?.title?.trim()}
+      {title?.trim()}
     </TableOfContentsRow>
     
     {sectionData?.sections && sectionData.sections.map((section, index) => {

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsList.tsx
@@ -131,7 +131,7 @@ const TableOfContentsList = ({sectionData, title, onClickSection, drawerStyle}: 
       {title?.trim()}
     </TableOfContentsRow>
     
-    {sectionData?.sections && sectionData.sections.map((section, index) => {
+    {sectionData.sections.map((section, index) => {
       return (
         <TableOfContentsRow
           key={section.anchor}

--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -102,7 +102,7 @@ const TableOfContentsRow = ({
   indentLevel?: number,
   highlighted?: boolean,
   href: string,
-  onClick: any,
+  onClick: (ev: any)=>void,
   children: React.ReactNode,
   classes: ClassesType,
   title?: boolean,

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Components, registerComponent } from '../../../lib/vulcan-lib';
+import type { ToCData } from '../../../server/tableOfContents';
+import { MAX_COLUMN_WIDTH } from '../PostsPage/PostsPage';
+import classNames from 'classnames';
+
+const DEFAULT_TOC_MARGIN = 100
+const MAX_TOC_WIDTH = 270
+const MIN_TOC_WIDTH = 200
+
+export const styles = (theme: ThemeType): JssStyles => ({
+  root: {
+    position: "relative",
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: 12
+    }
+  },
+  header: {
+    gridArea: 'title',
+  },
+  tocActivated: {
+    // Check for support for template areas before applying
+    '@supports (grid-template-areas: "title")': {
+      display: 'grid',
+      gridTemplateColumns: `
+        1fr
+        minmax(${MIN_TOC_WIDTH}px, ${MAX_TOC_WIDTH}px)
+        minmax(0px, ${DEFAULT_TOC_MARGIN}px)
+        minmax(min-content, ${MAX_COLUMN_WIDTH}px)
+        minmax(0px, ${DEFAULT_TOC_MARGIN}px)
+        1.5fr
+      `,
+      gridTemplateAreas: `
+        "... ... .... title   .... ..."
+        "... toc gap1 content gap2 ..."
+      `,
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'block'
+    }
+  },
+  toc: {
+    '@supports (grid-template-areas: "title")': {
+      gridArea: 'toc',
+      position: 'unset',
+      width: 'unset'
+    },
+    //Fallback styles in case we don't have CSS-Grid support. These don't get applied if we have a grid
+    position: 'absolute',
+    width: MAX_TOC_WIDTH,
+    left: -DEFAULT_TOC_MARGIN,
+  },
+  content: { gridArea: 'content' },
+  gap1: { gridArea: 'gap1'},
+  gap2: { gridArea: 'gap2'},
+});
+
+export const ToCColumn = ({sectionData, title, header, children, classes}: {
+  sectionData: ToCData,
+  title: string|null,
+  header: React.ReactNode,
+  children: React.ReactNode,
+  classes: ClassesType
+}) => {
+  const { TableOfContents } = Components;
+  
+  return (
+    <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
+      <div className={classes.header}>
+        {header}
+      </div>
+      <div className={classes.toc}>
+        <TableOfContents sectionData={sectionData} title={title} />
+      </div>
+      <div className={classes.gap1}/>
+      <div className={classes.content}>
+        {children}
+      </div>
+      <div className={classes.gap2}/>
+    </div>
+  );
+}
+
+const ToCColumnComponent = registerComponent("ToCColumn", ToCColumn, {styles});
+
+declare global {
+  interface ComponentTypes {
+    ToCColumn: typeof ToCColumnComponent
+  }
+}

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Components, registerComponent } from '../../../lib/vulcan-lib';
-import type { ToCData } from '../../../server/tableOfContents';
 import { MAX_COLUMN_WIDTH } from '../PostsPage/PostsPage';
 import classNames from 'classnames';
 
@@ -61,8 +60,6 @@ export const ToCColumn = ({tableOfContents, header, children, classes}: {
   children: React.ReactNode,
   classes: ClassesType
 }) => {
-  const { TableOfContents } = Components;
-  
   return (
     <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents})}>
       <div className={classes.header}>

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -55,9 +55,8 @@ export const styles = (theme: ThemeType): JssStyles => ({
   gap2: { gridArea: 'gap2'},
 });
 
-export const ToCColumn = ({sectionData, title, header, children, classes}: {
-  sectionData: ToCData,
-  title: string|null,
+export const ToCColumn = ({tableOfContents, header, children, classes}: {
+  tableOfContents: React.ReactNode|null,
   header: React.ReactNode,
   children: React.ReactNode,
   classes: ClassesType
@@ -65,12 +64,12 @@ export const ToCColumn = ({sectionData, title, header, children, classes}: {
   const { TableOfContents } = Components;
   
   return (
-    <div className={classNames(classes.root, {[classes.tocActivated]: !!sectionData})}>
+    <div className={classNames(classes.root, {[classes.tocActivated]: !!tableOfContents})}>
       <div className={classes.header}>
         {header}
       </div>
       <div className={classes.toc}>
-        <TableOfContents sectionData={sectionData} title={title} />
+        {tableOfContents}
       </div>
       <div className={classes.gap1}/>
       <div className={classes.content}>

--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Components, registerComponent } from '../../../lib/vulcan-lib';
+import { registerComponent } from '../../../lib/vulcan-lib';
 import { MAX_COLUMN_WIDTH } from '../PostsPage/PostsPage';
 import classNames from 'classnames';
 

--- a/packages/lesswrong/components/posts/TableOfContents/index.ts
+++ b/packages/lesswrong/components/posts/TableOfContents/index.ts
@@ -4,3 +4,4 @@ importComponent("TableOfContents", () => require('./TableOfContents'));
 importComponent("TableOfContentsList", () => require('./TableOfContentsList'));
 importComponent("TableOfContentsRow", () => require('./TableOfContentsRow'));
 importComponent("AnswerTocRow", () => require('./AnswerTocRow'));
+importComponent("ToCColumn", () => require('./ToCColumn'));

--- a/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewAnswerCommentQuestionForm.tsx
@@ -73,7 +73,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 interface ExternalProps {
   post: PostsBase,
-  refetch: any,
+  refetch: ()=>void,
 }
 interface NewAnswerCommentQuestionFormProps extends ExternalProps, WithMessagesProps, WithUserProps, WithStylesProps {
 }

--- a/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
+++ b/packages/lesswrong/components/questions/NewRelatedQuestionForm.tsx
@@ -32,7 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 const NewRelatedQuestionForm = ({ post, classes, refetch }: {
   post: PostsBase,
   classes: ClassesType,
-  refetch: any,
+  refetch: ()=>void,
 }) => {
   const currentUser = useCurrentUser();
   const { flash } = useMessages();

--- a/packages/lesswrong/components/questions/PostsPageQuestionContent.tsx
+++ b/packages/lesswrong/components/questions/PostsPageQuestionContent.tsx
@@ -6,7 +6,7 @@ import withErrorBoundary from '../common/withErrorBoundary';
 
 const PostsPageQuestionContent = ({post, refetch}: {
   post: PostsWithNavigation|PostsWithNavigationAndRevision,
-  refetch: any,
+  refetch: ()=>void,
 }) => {
   const currentUser = useCurrentUser();
   const { AnswersList, NewAnswerCommentQuestionForm, CantCommentExplanation, RelatedQuestionsList } = Components

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -79,7 +79,7 @@ export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { SingleColumnSection, PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, TableOfContents, ToCColumn } = Components;
+  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useLocation } from '../../lib/routeUtil';
 import { useTagBySlug } from './useTag';
@@ -130,6 +130,10 @@ const TagPage = ({classes}: {
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tagPositionInList])
   const nextTag = otherTagsWithNavigation && (nextTagPosition !== null && nextTagPosition >= 0) && otherTagsWithNavigation[nextTagPosition]
+  
+  const expandAll = useCallback(() => {
+    setTruncated(false)
+  }, []);
 
   if (loadingTag)
     return <Loading/>
@@ -175,7 +179,11 @@ const TagPage = ({classes}: {
       tableOfContents={
         tag.tableOfContents
           ? <span className={classes.tableOfContentsWrapper}>
-              <TableOfContents sectionData={tag.tableOfContents} title={tag.name} />
+              <TableOfContents
+                sectionData={tag.tableOfContents}
+                title={tag.name}
+                onClickSection={expandAll}
+              />
             </span>
           : null
       }

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -32,6 +32,10 @@ export const styles = (theme: ThemeType): JssStyles => ({
     paddingRight: 42,
     background: "white",
   },
+  tableOfContentsWrapper: {
+    position: "relative",
+    top: 12,
+  },
   title: {
     ...theme.typography.display3,
     ...theme.typography.commentStyle,
@@ -79,7 +83,7 @@ export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn } = Components;
+  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn, TableOfContents } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;
@@ -168,8 +172,13 @@ const TagPage = ({classes}: {
       description={headTagDescription}
     />
     <ToCColumn
-      sectionData={tag.tableOfContents}
-      title={tag.name}
+      tableOfContents={
+        tag.tableOfContents
+          ? <span className={classes.tableOfContentsWrapper}>
+              <TableOfContents sectionData={tag.tableOfContents} title={tag.name} />
+            </span>
+          : null
+      }
       header={<div className={classNames(classes.header,classes.centralColumn)}>
         <div>
           {query.flagId && <span>

--- a/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
+++ b/packages/lesswrong/components/tagging/TagPageButtonRow.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { useDialog } from '../common/withDialog';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { subscriptionTypes } from '../../lib/collections/subscriptions/schema'
+import { useCurrentUser } from '../common/withUser';
+import { Link } from '../../lib/reactRouterWrapper';
+import HistoryIcon from '@material-ui/icons/History';
+import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  buttonsRow: {
+    ...theme.typography.body2,
+    ...theme.typography.uiStyle,
+    marginTop: 2,
+    marginBottom: 16,
+    color: theme.palette.grey[700],
+    display: "flex",
+    flexWrap: "wrap",
+    '& svg': {
+      height: 20,
+      width: 20,
+      marginRight: 4,
+      cursor: "pointer",
+      color: theme.palette.grey[700]
+    }
+  },
+  button: {
+    display: "flex",
+    alignItems: "center",
+    marginRight: 16
+  },
+  buttonLabel: {
+    [theme.breakpoints.down('sm')]: {
+      display: "none"
+    }
+  },
+  disabledButton: {
+    '&&': {
+      color: theme.palette.grey[500],
+      cursor: "default",
+      marginBottom: 12
+    }
+  },
+  ctaPositioning: {
+    display: "flex",
+    alignItems: "center",
+    marginLeft: "auto"
+  },
+  subscribeToWrapper: {
+    display: "flex !important",
+  },
+  subscribeTo: {
+    marginRight: 16
+  },
+  callToAction: {
+    display: "flex",
+    alignItems: "center",
+    marginLeft: "auto",
+    fontStyle: 'italic',
+    [theme.breakpoints.down('sm')]: {
+      display: "none"
+    }
+  },
+  callToActionFlagCount: {
+    position: "relative",
+    marginLeft: 4,
+    marginRight: 0
+  }
+});
+
+const TagPageButtonRow = ({tag, editing, setEditing, classes}: {
+  tag: TagPageWithRevisionFragment|TagPageFragment,
+  editing: boolean,
+  setEditing: (editing: boolean)=>void,
+  classes: ClassesType
+}) => {
+  const { openDialog } = useDialog();
+  const currentUser = useCurrentUser();
+  const { LWTooltip, SubscribeTo, TagDiscussionButton } = Components;
+  
+  const numFlags = tag.tagFlagsIds?.length
+  
+  return <div className={classes.buttonsRow}>
+    {!editing && <a className={classes.button} onClick={(ev) => {
+      if (currentUser) {
+        setEditing(true)
+      } else {
+        openDialog({
+          componentName: "LoginPopup",
+          componentProps: {}
+        });
+        ev.preventDefault();
+      }
+    } }>
+      <EditOutlinedIcon /><span className={classes.buttonLabel}>Edit</span>
+    </a>} 
+    {<Link className={classes.button} to={`/revisions/tag/${tag.slug}`}>
+      <HistoryIcon /><span className={classes.buttonLabel}>History</span>
+    </Link>}
+    {!tag.wikiOnly && !editing && <LWTooltip title="Get notifications when posts are added to this tag." className={classes.subscribeToWrapper}>
+      <SubscribeTo
+        document={tag}
+        className={classes.subscribeTo}
+        showIcon
+        hideLabelOnMobile
+        subscribeMessage="Subscribe"
+        unsubscribeMessage="Unsubscribe"
+        subscriptionType={subscriptionTypes.newTagPosts}
+      />
+    </LWTooltip>}
+    <div className={classes.button}>
+      <TagDiscussionButton tag={tag} hideLabelOnMobile />
+    </div>
+    <div className={classes.callToAction}>
+      <LWTooltip
+        title={ tag.tagFlagsIds?.length > 0 ? 
+          <div>
+            {tag.tagFlags.map((flag, i) => <span key={flag._id}>{flag.name}{(i+1) < tag.tagFlags?.length && ", "}</span>)}
+          </div> :
+          <span>
+            This tag does not currently have any improvement flags set.
+          </span>
+        }
+        >
+        <a onClick={(ev) => {
+          if (currentUser) setEditing(true);
+          openDialog({
+            componentName: currentUser ? "TagCTAPopup" : "LoginPopup",
+            componentProps: {}
+          })
+          ev.preventDefault();
+        }}>
+          <span className={classes.callToAction}> Help improve this page{/*
+          */}<span className={classes.callToActionFlagCount}>{!!numFlags&&`(${numFlags} flags)`}</span>
+          </span>
+        </a> 
+      </LWTooltip>
+    </div>
+  </div>
+}
+
+const TagPageButtonRowComponent = registerComponent("TagPageButtonRow", TagPageButtonRow, {styles});
+
+declare global {
+  interface ComponentTypes {
+    TagPageButtonRow: typeof TagPageButtonRowComponent
+  }
+}
+

--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -77,9 +77,9 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
   }
 }
 
-export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): string => {
+export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
   const fallback = forumTypeSetting.get() === 'AlignmentForum' ? "afPostCommentsTop" : "postCommentsTop"
-  return (post?.commentSortOrder) || (currentUser?.commentSorting) || fallback
+  return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
 }
 
 export const commentGetKarma = (comment: CommentsList|DbComment): number => {

--- a/packages/lesswrong/lib/collections/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/posts/custom_fields.ts
@@ -987,9 +987,8 @@ addFieldsDict(Posts, {
     viewableBy: ['guests'],
     graphQLtype: GraphQLJSON,
     resolver: async (document: DbPost, args: void, context: ResolverContext) => {
-      const { currentUser } = context;
       try {
-        return await Utils.getTableOfContentsData({document, version: null, currentUser, context});
+        return await Utils.getToCforPost({document, version: null, context});
       } catch(e) {
         captureException(e);
         return null;
@@ -1004,9 +1003,8 @@ addFieldsDict(Posts, {
     graphqlArguments: 'version: String',
     resolver: async (document: DbPost, args: {version:string}, context: ResolverContext) => {
       const { version=null } = args;
-      const { currentUser } = context;
       try {
-        return await Utils.getTableOfContentsData({document, version, currentUser, context});
+        return await Utils.getToCforPost({document, version, context});
       } catch(e) {
         captureException(e);
         return null;

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -124,6 +124,20 @@ registerFragment(`
 `);
 
 registerFragment(`
+  fragment TagPageFragment on Tag {
+    ...TagWithFlagsFragment
+    tableOfContents
+  }
+`);
+
+registerFragment(`
+  fragment TagPageWithRevisionFragment on Tag {
+    ...TagWithFlagsAndRevisionFragment
+    tableOfContents
+  }
+`);
+
+registerFragment(`
   fragment TagEditFragment on Tag {
     ...TagBasicInfo
     tagFlagsIds

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -3,7 +3,9 @@ import { arrayOfForeignKeysField, denormalizedCountOfReferences, foreignKeyField
 import SimpleSchema from 'simpl-schema';
 import { Utils, slugify } from '../../vulcan-lib/utils';
 import { getWithLoader } from '../../loaders';
+import GraphQLJSON from 'graphql-type-json';
 import moment from 'moment';
+import { captureException } from '@sentry/core';
 
 const formGroups = {
   advancedOptions: {
@@ -311,6 +313,19 @@ export const schema: SchemaType<DbTag> = {
     }
   }),
 
+  tableOfContents: resolverOnlyField({
+    type: Object,
+    viewableBy: ['guests'],
+    graphQLtype: GraphQLJSON,
+    resolver: async (document: DbTag, args: void, context: ResolverContext) => {
+      try {
+        return await Utils.getToCforTag({document, version: null, context});
+      } catch(e) {
+        captureException(e);
+        return null;
+      }
+    }
+  }),
 }
 
 export const wikiGradeDefinitions = {

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -397,6 +397,7 @@ importComponent("NewTagsList", () => require('../components/tagging/NewTagsList'
 importComponent("AddTagButton", () => require('../components/tagging/AddTagButton'));
 importComponent("CoreTagsChecklist", () => require('../components/tagging/CoreTagsChecklist'));
 importComponent("TagPage", () => require('../components/tagging/TagPage'));
+importComponent("TagPageButtonRow", () => require('../components/tagging/TagPageButtonRow'));
 importComponent("TagPageTitle", () => require('../components/tagging/TagPageTitle'));
 importComponent("AddPostsToTag", () => require('../components/tagging/AddPostsToTag'));
 importComponent("FooterTagList", () => require('../components/tagging/FooterTagList'));

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1311,6 +1311,14 @@ interface TagWithFlagsAndRevisionFragment extends TagRevisionFragment { // fragm
   readonly tagFlags: Array<TagFlagFragment>,
 }
 
+interface TagPageFragment extends TagWithFlagsFragment { // fragment on Tags
+  readonly tableOfContents: any,
+}
+
+interface TagPageWithRevisionFragment extends TagWithFlagsAndRevisionFragment { // fragment on Tags
+  readonly tableOfContents: any,
+}
+
 interface TagEditFragment extends TagBasicInfo { // fragment on Tags
   readonly tagFlagsIds: Array<string>,
   readonly description: RevisionEdit|null,
@@ -1733,6 +1741,8 @@ interface FragmentTypes {
   TagDetailedPreviewFragment: TagDetailedPreviewFragment
   TagWithFlagsFragment: TagWithFlagsFragment
   TagWithFlagsAndRevisionFragment: TagWithFlagsAndRevisionFragment
+  TagPageFragment: TagPageFragment
+  TagPageWithRevisionFragment: TagPageWithRevisionFragment
   TagEditFragment: TagEditFragment
   TagRecentDiscussion: TagRecentDiscussion
   SunshineTagFragment: SunshineTagFragment
@@ -1863,6 +1873,8 @@ interface CollectionNamesByFragmentName {
   TagDetailedPreviewFragment: "Tags"
   TagWithFlagsFragment: "Tags"
   TagWithFlagsAndRevisionFragment: "Tags"
+  TagPageFragment: "Tags"
+  TagPageWithRevisionFragment: "Tags"
   TagEditFragment: "Tags"
   TagRecentDiscussion: "Tags"
   SunshineTagFragment: "Tags"

--- a/packages/lesswrong/lib/generated/viewTypes.ts
+++ b/packages/lesswrong/lib/generated/viewTypes.ts
@@ -21,12 +21,12 @@ type RSSFeedsViewName = "usersFeed";
 type ReadStatusesViewName = never
 type ReportsViewName = "allReports"|"unclaimedReports"|"claimedReports"|"adminClaimedReports"|"sunshineSidebarReports"|"closedReports";
 type ReviewVotesViewName = "reviewVotesFromUser"|"reviewVotesForPost"|"reviewVotesForPostAndUser";
-type RevisionsViewName = "revisionsOnDocument"|"nonnegligibleTagRevisions";
+type RevisionsViewName = "revisionsOnDocument";
 type SequencesViewName = "userProfile"|"userProfileAll"|"curatedSequences"|"communitySequences";
 type SubscriptionsViewName = "subscriptionState"|"subscriptionsOfType";
 type TagFlagsViewName = "allTagFlags";
 type TagRelsViewName = "postsWithTag"|"tagsOnPost";
-type TagsViewName = "allTagsAlphabetical"|"userTags"|"allPagesByNewest"|"allTagsHierarchical"|"tagBySlug"|"coreTags"|"newTags"|"unreviewedTags"|"suggestedFilterTags"|"allLWWikiTags"|"unprocessedLWWikiTags"|"tagsByTagFlag";
+type TagsViewName = "allTagsAlphabetical"|"userTags"|"allPagesByNewest"|"allTagsHierarchical"|"tagBySlug"|"coreTags"|"newTags"|"unreviewedTags"|"suggestedFilterTags"|"allLWWikiTags"|"unprocessedLWWikiTags"|"tagsByTagFlag"|"allPublicTags";
 type UsersViewName = "usersProfile"|"LWSunshinesList"|"LWTrustLevel1List"|"LWUsersAdmin"|"usersWithBannedUsers"|"sunshineNewUsers"|"allUsers"|"usersMapLocations"|"walledGardenInvitees"|"alignmentSuggestedUsers";
 type VotesViewName = "tagVotes";
 

--- a/packages/lesswrong/lib/vulcan-lib/utils.ts
+++ b/packages/lesswrong/lib/vulcan-lib/utils.ts
@@ -10,6 +10,8 @@ import getSlug from 'speakingurl';
 import urlObject from 'url';
 import { siteUrlSetting } from '../instanceSettings';
 import { DatabasePublicSetting } from '../publicSettings';
+import type { ToCData } from '../../server/tableOfContents';
+
 export const logoUrlSetting = new DatabasePublicSetting<string | null>('logoUrl', null)
 
 interface UtilsType {
@@ -30,8 +32,8 @@ interface UtilsType {
   Connectors: any
   
   // In server/tableOfContents.ts
-  getTableOfContentsData: any
-  extractTableOfContents: any
+  getToCforPost: ({document, version, context}: { document: DbPost, version: string|null, context: ResolverContext }) => Promise<ToCData|null>
+  getToCforTag: ({document, version, context}: { document: DbTag, version: string|null, context: ResolverContext }) => Promise<ToCData|null>
   
   // In server/vulcan-lib/mutators.ts
   createMutator: any

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -11,6 +11,7 @@ import { Utils } from '../lib/vulcan-lib';
 
 export interface ToCSection {
   title?: string
+  answer?: any
   anchor: string
   level: number
   divider?: boolean,
@@ -199,7 +200,7 @@ async function getTocAnswers (document: DbPost) {
     answersTerms.af = true
   }
   const answers = await Comments.find(answersTerms, {sort:questionAnswersSort}).fetch()
-  const answerSections = answers.map((answer) => {
+  const answerSections: ToCSection[] = answers.map((answer: DbComment): ToCSection => {
     const { html = "" } = answer.contents || {}
     const highlight = truncate(html, 900)
     let shortHighlight = htmlToText.fromString(answerTocExcerptFromHTML(html), {ignoreImage:true, ignoreHref:true})


### PR DESCRIPTION
Tag pages have tables of contents. Various changes to ToC code to make it able to handle things that aren't posts. Tag descriptions aren't usually long enough to need ToCs, but this provides a place to put the contributor-list, which will come in a future PR.