### PR TITLE
Tag spam defense

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "tlds": "^1.203.1",
     "turndown": "^4.0.2",
     "turndown-plugin-gfm": "^1.0.2",
+    "type-fest": "^1.1.1",
     "typescript": "^4.1.3",
     "underscore": "^1.9.1",
     "universal-cookie": "^4.0.2",

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -38,7 +38,7 @@ interface CollectionBase<
   // Meteor is maintaining backwards compatibility with an old version that returned nMatched. See:
   // https://github.com/meteor/meteor/issues/4436#issuecomment-283974686
   update: (selector?: string|MongoSelector<T>, modifier?: MongoModifier<T>, options?: MongoUpdateOptions<T>) => Promise<number>
-  remove: (idOrSelector: string|MongoSelector<T>, options?: any) => void
+  remove: (idOrSelector: string|MongoSelector<T>, options?: any) => Promise<any>
   insert: (data: any, options?: any) => string
   aggregate: (aggregationPipeline: MongoAggregationPipeline<T>, options?: any) => any
   _ensureIndex: any

--- a/packages/lesswrong/lib/types/typeUtil.ts
+++ b/packages/lesswrong/lib/types/typeUtil.ts
@@ -32,4 +32,6 @@ type ReplaceFieldsOfType<Interface, FieldType,ReplacementType> = {
   >
 }
 
+type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>
+
 }

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -371,10 +371,6 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
       const userId = currentUser._id
       const editedAt = new Date()
       const changeMetrics = htmlToChangeMetrics("", html);
-      // TODO; (MAYBE) Should we change the direction of data flow, where, instead
-      // of it flowing from source -> revision, we instead treat the revisions
-      // table as the source of truth, then have a callback that propagates any changes
-      // to it to the source document via documentId (revision -> source)
       const newRevision: Omit<DbRevision, "documentId" | "schemaVersion" | "_id"> = {
         ...(await buildRevision({
           originalContents: doc[fieldName].originalContents,

--- a/packages/lesswrong/server/editor/utils.tests.ts
+++ b/packages/lesswrong/server/editor/utils.tests.ts
@@ -20,7 +20,6 @@ async function updatePost(user: DbUser, postId: string, newMarkup: string) {
       }
     }
   `
-  // console.log('query', query)
   await runQuery(query, {}, {currentUser: user})
 }
 

--- a/packages/lesswrong/server/editor/utils.tests.ts
+++ b/packages/lesswrong/server/editor/utils.tests.ts
@@ -1,13 +1,58 @@
-import { createDummyPost } from "../../testing/utils";
+import { createDummyPost, createDummyUser } from "../../testing/utils";
 import { testStartup } from "../../testing/testMain";
+import Revisions from "../../lib/collections/revisions/collection";
+import { Posts } from "../../lib/collections/posts";
+import { runQuery, waitUntilCallbacksFinished } from "../vulcan-lib";
+import { syncDocumentWithLatestRevision } from "./utils";
 
 testStartup();
 
+async function updatePost(user: DbUser, postId: string, newMarkup: string) {
+  const query = `
+    mutation PostsEdit {
+      updatePost(
+        selector: {_id:"${postId}"},
+        data: {contents: {originalContents: {type: "ckEditorMarkup", data: "${newMarkup}"}}}
+      ) {
+        data {
+          commentsLocked
+        }
+      }
+    }
+  `
+  // console.log('query', query)
+  await runQuery(query, {}, {currentUser: user})
+}
+
 describe("syncDocumentWithLatestRevision", () => {
   it("updates with the latest revision", async () => {
-    const post = await createDummyPost();
-    console.log('post.contents', post.contents)
-    // TODO; complete
-    expect(post._id).toBeDefined();
+    const user = await createDummyUser()
+    const post = await createDummyPost(user, {
+      contents: {
+        originalContents: {
+          type: 'ckEditorMarkup',
+          data: '<p>Post version 1</p>'
+        }
+      }
+    })
+
+    await updatePost(user, post._id, '<p>Post version 2</p>')
+    await updatePost(user, post._id, '<p>Post version 3</p>')
+
+    const revisions = await Revisions.find({documentId: post._id}, {sort: {createdAt: 1}}).fetch()
+    const lastRevision = revisions[2]
+    if (!lastRevision) {
+      throw new Error("Didn't create the expected number of revisions")
+    }
+    await Revisions.remove({_id: lastRevision._id})
+    
+    // Function we're actually testing
+    await syncDocumentWithLatestRevision(Posts, post, 'contents')
+
+    const postAfterSync = await Posts.findOne({_id: post._id})
+    if (!postAfterSync) {
+      throw new Error("Lost post")
+    }
+    expect(postAfterSync.contents.originalContents.data).toMatch(/version 2/);
   });
 });

--- a/packages/lesswrong/server/editor/utils.tests.ts
+++ b/packages/lesswrong/server/editor/utils.tests.ts
@@ -1,0 +1,12 @@
+import { createDummyPost } from "../../testing/utils";
+import { testStartup } from "../../testing/testMain";
+
+testStartup();
+
+describe("syncDocumentWithLatestRevision", () => {
+  it("updates with the latest revision", async () => {
+    const post = await createDummyPost();
+    // TODO; complete
+    expect(post._id).toBeDefined();
+  });
+});

--- a/packages/lesswrong/server/editor/utils.tests.ts
+++ b/packages/lesswrong/server/editor/utils.tests.ts
@@ -6,6 +6,7 @@ testStartup();
 describe("syncDocumentWithLatestRevision", () => {
   it("updates with the latest revision", async () => {
     const post = await createDummyPost();
+    console.log('post.contents', post.contents)
     // TODO; complete
     expect(post._id).toBeDefined();
   });

--- a/packages/lesswrong/server/editor/utils.ts
+++ b/packages/lesswrong/server/editor/utils.ts
@@ -107,7 +107,8 @@ const revisionFieldsToCopy: (keyof DbRevision)[] = [
   "editedAt",
   "wordCount",
 ];
-// TODO; document, test?
+
+// TODO; document
 export async function syncDocumentWithLatestRevision<T extends DbObject>(
   collection: CollectionBase<T>,
   document: T,

--- a/packages/lesswrong/server/scripts/debuggingScripts.ts
+++ b/packages/lesswrong/server/scripts/debuggingScripts.ts
@@ -198,7 +198,7 @@ Vulcan.createStyledAFPost = async () => {
     },
     af: true,
     frontpageDate: new Date(),
-    curateDate: new Date(),
+    curatedDate: new Date(),
   })
 
   await createDummyComment(user, {

--- a/packages/lesswrong/testing/moderation/moderation.server.tests.ts
+++ b/packages/lesswrong/testing/moderation/moderation.server.tests.ts
@@ -74,12 +74,12 @@ describe('userIsAllowedToComment --', () => {
   //})
   it('returns true if passed a user AND post does NOT contain bannedUserIds OR user', async () => {
     const user = await createDummyUser()
-    const post = await createDummyPost({userId:undefined})
+    const post = await createDummyPost()
     expect(userIsAllowedToComment(user, post, null)).to.equal(true)
   })
   it('returns true if passed a user AND post contains bannedUserIds but NOT user', async () => {
     const user = await createDummyUser()
-    const post = await createDummyPost({bannedUserIds:[user._id], userId: undefined})
+    const post = await createDummyPost(undefined, {bannedUserIds:[user._id]})
     expect(userIsAllowedToComment(user, post, null)).to.equal(true)
   })
   it('returns false if passed a user AND post contains bannedUserIds BUT post-user is NOT in trustLevel1', async () => {

--- a/packages/lesswrong/testing/moderation/moderation.server.tests.ts
+++ b/packages/lesswrong/testing/moderation/moderation.server.tests.ts
@@ -79,7 +79,7 @@ describe('userIsAllowedToComment --', () => {
   })
   it('returns true if passed a user AND post contains bannedUserIds but NOT user', async () => {
     const user = await createDummyUser()
-    const post = await createDummyPost(undefined, {bannedUserIds:[user._id]})
+    const post = await createDummyPost(null, {bannedUserIds:[user._id]})
     expect(userIsAllowedToComment(user, post, null)).to.equal(true)
   })
   it('returns false if passed a user AND post contains bannedUserIds BUT post-user is NOT in trustLevel1', async () => {

--- a/packages/lesswrong/testing/utils.ts
+++ b/packages/lesswrong/testing/utils.ts
@@ -249,18 +249,6 @@ export const createDummyMessage = async (user: any, data?: any) => {
   return newMessageResponse.data
 }
 
-// export const createDummyRevision = async (user?: {_id: string}, data?: Partial<DbRevision>) => {
-//   const defaultData = {
-//     originalContents: {
-//       type: "ckEditorMarkup",
-//       data: "<p>Dummy Revision Content</p>"
-//     },
-//     userId: user?._id
-//   }
-//   const revisionData = {...defaultData, ...data}
-//   // const
-// }
-
 export const clearDatabase = async () => {
   (await Users.find().fetch()).forEach((i)=>{
     Users.remove(i._id)

--- a/packages/lesswrong/testing/utils.ts
+++ b/packages/lesswrong/testing/utils.ts
@@ -156,6 +156,7 @@ export const createDefaultUser = async() => {
   }
 }
 
+// Posts can be created pretty flexibly
 type TestPost = Omit<PartialDeep<DbPost>, 'postedAt'> & {postedAt?: Date | number}
 
 export const createDummyPost = async (user?: AtLeast<DbUser, '_id'> | null, data?: TestPost) => {
@@ -168,7 +169,7 @@ export const createDummyPost = async (user?: AtLeast<DbUser, '_id'> | null, data
   const newPostResponse = await createMutator({
     collection: Posts,
     // Not the best, createMutator should probably be more flexible about what
-    // it accepts
+    // it accepts, as long as validate is false
     document: postData as DbPost,
     // As long as user has a _id it should be fine
     currentUser: user_ as DbUser,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12769,6 +12769,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.1.tgz#210251e7f57357a1457269e6b34837fed067ac2c"
+  integrity sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==
+
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz"


### PR DESCRIPTION
Purging users now deletes their tags, and removes their revisions. This isn't everything you'd want from tag spam defense — ideally users who'd created tags would show up for review. But it's a start.

Naively deleting revisions would be bad because then you'd have tags that were holding pointers to missing revisions. We fix that problem by syncing tags to their most recent revision.

This PR additionally adds my first new test in way too long, and fixes some typings. 

I'm adding type-fest for its PartialDeep type. I know the developer by reputation and the repository looks generally useful.