### PR TITLE
Fix google auth emails field populating

### DIFF
--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -111,7 +111,7 @@ export const addAuthMiddlewares = (addConnectHandler) => {
       services: {
         google: profile
       },
-      emails: profile.emails,
+      emails: [{address: profile.emails[0].address, verified: true}],
       username: await Utils.getUnusedSlugByCollectionName("Users", slugify(profile.displayName)),
       displayName: profile.displayName,
       emailSubscribedToCurated: true


### PR DESCRIPTION
I think this is the right way to prepopulate the email field. The old way was definitely wrong and caused terrible bugs.