### PR TITLE
Add number of wiki edits to user profiles

### DIFF
--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_LOW_KARMA_THRESHOLD } from '../../lib/collections/posts/views'
 import StarIcon from '@material-ui/icons/Star'
 import DescriptionIcon from '@material-ui/icons/Description'
 import MessageIcon from '@material-ui/icons/Message'
+import ChangeHistoryIcon from '@material-ui/icons/ChangeHistory'
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -103,7 +104,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   classes: ClassesType,
 }) => {
   const [showSettings, setShowSettings] = useState(false);
-  
+
   const currentUser = useCurrentUser();
   const {loading, results} = useMulti({
     terms,
@@ -123,7 +124,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
   const renderMeta = () => {
     const document = getUserFromResults(results)
     if (!document) return null
-    const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma } = document;
+    const { karma, postCount, commentCount, afPostCount, afCommentCount, afKarma, tagRevisionCount } = document;
 
     const userKarma = karma || 0
     const userAfKarma = afKarma || 0
@@ -167,11 +168,20 @@ const UsersProfileFn = ({terms, slug, classes}: {
             </Components.MetaInfo>
           </span>
         </Tooltip>
+
+        <Tooltip title={`${tagRevisionCount} wiki edit${tagRevisionCount === 1 ? '' : 's'}`}>
+          <span className={classes.userMetaInfo}>
+            <ChangeHistoryIcon className={classNames(classes.icon, classes.specificalz)}/>
+            <Components.MetaInfo>
+              { tagRevisionCount }
+            </Components.MetaInfo>
+          </span>
+        </Tooltip>
       </div>
   }
 
   const { query } = useLocation();
-  
+
   const render = () => {
     const user = getUserFromResults(results)
     const { SunshineNewUsersProfileInfo, SingleColumnSection, SectionTitle, SequencesNewButton, PostsListSettings, PostsList2, NewConversationButton, SubscribeTo, DialogGroup, SectionButton, SettingsButton, ContentItemBody, Loading, Error404, PermanentRedirect, HeadTags, Typography } = Components
@@ -217,7 +227,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
     const currentFilter = query.filter ||  "all"
     const ownPage = currentUser?._id === user._id
     const currentShowLowKarma = (parseInt(query.karmaThreshold) !== DEFAULT_LOW_KARMA_THRESHOLD)
-    
+
     const username = userGetDisplayName(user)
     const metaDescription = `${username}'s profile on ${siteNameWithArticleSetting.get()} — ${taglineSetting.get()}`
 
@@ -327,7 +337,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
       </div>
     )
   }
-  
+
   return render();
 }
 

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_LOW_KARMA_THRESHOLD } from '../../lib/collections/posts/views'
 import StarIcon from '@material-ui/icons/Star'
 import DescriptionIcon from '@material-ui/icons/Description'
 import MessageIcon from '@material-ui/icons/Message'
-import ChangeHistoryIcon from '@material-ui/icons/ChangeHistory'
+import PencilIcon from '@material-ui/icons/Create'
 import classNames from 'classnames';
 import { useCurrentUser } from '../common/withUser';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -171,7 +171,7 @@ const UsersProfileFn = ({terms, slug, classes}: {
 
         <Tooltip title={`${tagRevisionCount} wiki edit${tagRevisionCount === 1 ? '' : 's'}`}>
           <span className={classes.userMetaInfo}>
-            <ChangeHistoryIcon className={classNames(classes.icon, classes.specificalz)}/>
+            <PencilIcon className={classNames(classes.icon, classes.specificalz)}/>
             <Components.MetaInfo>
               { tagRevisionCount }
             </Components.MetaInfo>

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1446,8 +1446,7 @@ addFieldsDict(Users, {
       foreignFieldName: "userId",
       filterFn: revision => revision.collectionName === "Tags"
     }),
-    canRead: ['guests'],
-    ...schemaDefaultValue(0)
+    canRead: ['guests']
   },
 
   abTestKey: {

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -1442,7 +1442,7 @@ addFieldsDict(Users, {
       fieldName: "tagRevisionCount",
       collectionName: "Users",
       foreignCollectionName: "Revisions",
-      foreignTypeName: "Revision",
+      foreignTypeName: "revision",
       foreignFieldName: "userId",
       filterFn: revision => revision.collectionName === "Tags"
     }),

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -291,7 +291,7 @@ addFieldsDict(Users, {
     group: formGroups.siteCustomizations,
     label: "Activate Markdown Editor"
   },
-  
+
   hideElicitPredictions: {
     order: 80,
     type: Boolean,
@@ -309,7 +309,7 @@ addFieldsDict(Users, {
     group: formGroups.default,
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
   },
-  
+
   hideNavigationSidebar: {
     type: Boolean,
     optional: true,
@@ -784,7 +784,7 @@ addFieldsDict(Users, {
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canRead: [userOwns, 'sunshineRegiment', 'admins'],
   },
-  
+
   hideSubscribePoke: {
     type: Boolean,
     optional: true,
@@ -1231,7 +1231,7 @@ addFieldsDict(Users, {
     control: 'checkbox',
     label: "Do not truncate comments (on home page)"
   },
-  
+
   shortformFeedId: {
     ...foreignKeyField({
       idFieldName: "shortformFeedId",
@@ -1436,6 +1436,20 @@ addFieldsDict(Users, {
     canRead: ['guests'],
     ...schemaDefaultValue(0)
   },
+
+  tagRevisionCount: {
+    ...denormalizedCountOfReferences({
+      fieldName: "tagRevisionCount",
+      collectionName: "Users",
+      foreignCollectionName: "Revisions",
+      foreignTypeName: "Revision",
+      foreignFieldName: "userId",
+      filterFn: revision => revision.collectionName === "Tags"
+    }),
+    canRead: ['guests'],
+    ...schemaDefaultValue(0)
+  },
+
   abTestKey: {
     type: String,
     optional: true,

--- a/packages/lesswrong/lib/collections/users/fragments.ts
+++ b/packages/lesswrong/lib/collections/users/fragments.ts
@@ -33,6 +33,7 @@ registerFragment(`
     afSequenceCount
     afSequenceDraftCount
     sequenceDraftCount
+    tagRevisionCount
     moderationStyle
     moderationGuidelines {
       ...RevisionDisplay
@@ -120,7 +121,7 @@ registerFragment(`
     bookmarkedPosts {
       ...PostsList
     }
-    
+
     auto_subscribe_to_my_posts
     auto_subscribe_to_my_comments
     autoSubscribeAsOrganizer

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -713,6 +713,7 @@ interface DbUser extends DbObject {
   maxPostCount: number
   commentCount: number
   maxCommentCount: number
+  tagRevisionCount: number
   abTestKey: string
   abTestOverrides: any /*{"definitions":[{"type":"JSON","blackbox":true}]}*/
   reenableDraftJs: boolean

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -1405,6 +1405,7 @@ interface UsersProfile extends UsersMinimumInfo, SharedUserBooleans { // fragmen
   readonly afSequenceCount: number,
   readonly afSequenceDraftCount: number,
   readonly sequenceDraftCount: number,
+  readonly tagRevisionCount: number,
   readonly moderationStyle: string,
   readonly moderationGuidelines: RevisionDisplay|null,
   readonly bannedUserIds: Array<string>,

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -156,7 +156,6 @@ export const addAuthMiddlewares = (addConnectHandler) => {
       services: {
         google: profile
       },
-      // todo;
       emails: [{address: profile.emails?.[0].value, verified: true}],
       username: await Utils.getUnusedSlugByCollectionName("Users", slugify(profile.displayName)),
       displayName: profile.displayName,

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -156,7 +156,8 @@ export const addAuthMiddlewares = (addConnectHandler) => {
       services: {
         google: profile
       },
-      emails: [{address: profile.emails[0].address, verified: true}],
+      // todo;
+      emails: [{address: profile.emails?.[0].value, verified: true}],
       username: await Utils.getUnusedSlugByCollectionName("Users", slugify(profile.displayName)),
       displayName: profile.displayName,
       emailSubscribedToCurated: true

--- a/packages/lesswrong/server/callbacks/revisionCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/revisionCallbacks.ts
@@ -5,6 +5,10 @@ import { afterCreateRevisionCallback } from '../editor/make_editable_callbacks';
 import { performVoteServer } from '../voteServer';
 import { updateDenormalizedHtmlAttributions } from '../resolvers/tagResolvers';
 
+// TODO: Now that the make_editable callbacks use createMutator to create
+// revisions, we can now add these to the regular ${collection}.create.after
+// callbacks
+
 // Users upvote their own tag-revisions
 afterCreateRevisionCallback.add(async ({revisionID}) => {
   const revision = await Revisions.findOne({_id: revisionID});

--- a/packages/lesswrong/server/editor/make_editable_callbacks.ts
+++ b/packages/lesswrong/server/editor/make_editable_callbacks.ts
@@ -14,6 +14,7 @@ import { diff } from '../vendor/node-htmldiff/htmldiff';
 import { editableCollections, editableCollectionsFields, editableCollectionsFieldOptions, sealEditableFields, MakeEditableOptions } from '../../lib/editor/make_editable';
 import { getCollection } from '../../lib/vulcan-lib/getCollection';
 import { CallbackHook } from '../../lib/vulcan-lib/callbacks';
+import { createMutator } from '../vulcan-lib/mutators';
 import TurndownService from 'turndown';
 import {gfm} from 'turndown-plugin-gfm';
 import * as _ from 'underscore';
@@ -61,7 +62,7 @@ export function mjPagePromise(html: string, beforeSerializationCallback: (dom: a
   // https://github.com/pkra/mathjax-node-page
   return new Promise((resolve, reject) => {
     let finished = false;
-    
+
     if (!isAnyTest) {
       setTimeout(() => {
         if (!finished) {
@@ -73,19 +74,19 @@ export function mjPagePromise(html: string, beforeSerializationCallback: (dom: a
           resolve(html);
         }
       }, 10000);
-    } 
-    
+    }
+
     const errorHandler = (id, wrapperNode, sourceFormula, sourceFormat, errors) => {
       // eslint-disable-next-line no-console
       console.log("Error in Mathjax handling: ", id, wrapperNode, sourceFormula, sourceFormat, errors)
       reject(`Error in $${sourceFormula}$: ${errors}`)
     }
-    
+
     const callbackAndMarkFinished = (dom: any, css: string) => {
       finished = true;
       return beforeSerializationCallback(dom, css);
     };
-    
+
     mjpage(html, { fragment: true, errorHandler, format: ["MathML", "TeX"] } , {html: true, css: true}, resolve)
       .on('beforeSerialization', callbackAndMarkFinished);
   })
@@ -95,7 +96,7 @@ export function mjPagePromise(html: string, beforeSerializationCallback: (dom: a
 const cheerioWrapAll = (toWrap: cheerio.Cheerio, wrapper: string, $: cheerio.Root) => {
   if (toWrap.length < 1) {
     return toWrap;
-  } 
+  }
 
   if (toWrap.length < 2 && ($ as any).wrap) { // wrap not defined in npm version,
     return ($ as any).wrap(wrapper);      // and git version fails testing.
@@ -108,7 +109,7 @@ const cheerioWrapAll = (toWrap: cheerio.Cheerio, wrapper: string, $: cheerio.Roo
     $(v).remove();
     section.append($(v));
   });
-  section.insertBefore(marker); 
+  section.insertBefore(marker);
   marker.remove();
   return section;                 // This is what jQuery would return, IIRC.
 }
@@ -122,7 +123,7 @@ const spoilerClass = 'spoiler-v2' // this is the second iteration of a spoiler-t
 function wrapSpoilerTags(html: string): string {
   //@ts-ignore
   const $ = cheerio.load(html, null, false)
-  
+
   // Iterate through spoiler elements, collecting them into groups. We do this
   // the hard way, because cheerio's sibling-selectors don't seem to work right.
   let spoilerBlockGroups: Array<cheerio.Element[]> = [];
@@ -140,12 +141,12 @@ function wrapSpoilerTags(html: string): string {
   if (currentBlockGroup.length > 0) {
     spoilerBlockGroups.push(currentBlockGroup);
   }
-  
+
   // Having collected the elements into groups, wrap each group.
   for (let spoilerBlockGroup of spoilerBlockGroups) {
     cheerioWrapAll($(spoilerBlockGroup), '<div class="spoilers" />', $);
   }
-  
+
   // Serialize back to HTML.
   return $.html()
 }
@@ -219,7 +220,7 @@ export function removeCKEditorSuggestions(markup: string): string {
   const markupWithoutInsertions = markupWithoutDeletionsAndModifications.replace(
     /<suggestion\s*id="([a-zA-Z0-9:]+)"\s*suggestion-type="insertion" type="start"><\/suggestion>.*<suggestion\s*id="\1"\s*suggestion-type="insertion"\s*type="end"><\/suggestion>/g,
     ''
-  ) 
+  )
   return markupWithoutInsertions
 }
 
@@ -263,7 +264,7 @@ export function dataToMarkdown(data, type) {
       try {
         const contentState = convertFromRaw(data);
         const html = draftToHTML(contentState)
-        return htmlToMarkdown(html)  
+        return htmlToMarkdown(html)
       } catch(e) {
         // eslint-disable-next-line no-console
         console.error(e)
@@ -329,7 +330,7 @@ async function buildRevision({ originalContents, currentUser }) {
   const { data, type } = originalContents;
   const html = await dataToHTML(data, type, !currentUser.isAdmin)
   const wordCount = await dataToWordCount(data, type)
-  
+
   return {
     html, wordCount, originalContents,
     editedAt: new Date(),
@@ -342,18 +343,18 @@ async function buildRevision({ originalContents, currentUser }) {
 const revisionIsChange = async (doc, fieldName: string): Promise<boolean> => {
   const id = doc._id;
   const previousVersion = await getLatestRev(id, fieldName);
-  
+
   if (!previousVersion)
     return true;
-  
+
   if (!_.isEqual(doc[fieldName].originalContents, previousVersion.originalContents)) {
     return true;
   }
-  
+
   if (doc[fieldName].commitMessage && doc[fieldName].commitMessage.length>0) {
     return true;
   }
-  
+
   return false;
 }
 
@@ -397,8 +398,12 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
       // after-create callback, passing through an intermediate state where it's
       // undefined; and it's missing _id and schemaVersion, which leads to having
       // ObjectID types in the database which can cause problems.
-      const firstRevision = await Connectors.create(Revisions, newRevision as DbRevision);
-      
+      const firstRevision = await createMutator({
+        collection: Revisions,
+        document: newRevision,
+        validate: false
+      });
+
       return {
         ...doc,
         [fieldName]: {
@@ -406,7 +411,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
           html, version, userId, editedAt, wordCount,
           updateType: 'initial'
         },
-        [`${fieldName}_latest`]: firstRevision,
+        [`${fieldName}_latest`]: firstRevision.data,
         ...(pingbacks ? {
           pingbacks: await htmlToPingbacks(html, null),
         } : null),
@@ -420,7 +425,7 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
   {
     if (docData[fieldName]?.originalContents) {
       if (!currentUser) { throw Error("Can't create document without current user") }
-      
+
       const { data, type } = docData[fieldName].originalContents
       const commitMessage = docData[fieldName].commitMessage;
       const html = await dataToHTML(data, type, !currentUser.isAdmin)
@@ -433,12 +438,12 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
       const version = await getNextVersion(document._id, updateType, fieldName, (newDocument as DbPost).draft)
       const userId = currentUser._id
       const editedAt = new Date()
-      
+
       let newRevisionId;
       if (await revisionIsChange(newDocument, fieldName)) {
         const previousRev = await getLatestRev(newDocument._id, fieldName);
         const changeMetrics = htmlToChangeMetrics(previousRev?.html || "", html);
-        
+
         const newRevision: Omit<DbRevision, '_id' | 'schemaVersion' | "voteCount" | "baseScore" | "score" | "inactive" > = {
           documentId: document._id,
           ...await buildRevision({
@@ -454,13 +459,18 @@ function addEditableCallbacks<T extends DbObject>({collection, options = {}}: {
         }
         // FIXME: See comment on the other Connectors.create call in this file.
         // Missing _id and schemaVersion.
-        newRevisionId = await Connectors.create(Revisions, newRevision as DbRevision);
+        const newRevisionDoc = await createMutator({
+          collection: Revisions,
+          document: newRevision,
+          validate: false
+        });
+        newRevisionId = newRevisionDoc.data._id;
       } else {
         newRevisionId = (await getLatestRev(newDocument._id, fieldName))!._id;
       }
-      
+
       await afterCreateRevisionCallback.runCallbacksAsync([{ revisionID: newRevisionId }]);
-      
+
       return {
         ...docData,
         [fieldName]: {
@@ -514,10 +524,10 @@ onStartup(addAllEditableCallbacks);
 const diffToChangeMetrics = (diffHtml: string): ChangeMetrics => {
   // @ts-ignore
   const parsedHtml = cheerio.load(diffHtml, null, false);
-  
+
   const insertedChars = countCharsInTag(parsedHtml, "ins");
   const removedChars = countCharsInTag(parsedHtml, "del");
-  
+
   return { added: insertedChars, removed: removedChars };
 }
 

--- a/packages/lesswrong/server/migrations/2021-06-05-fillWikiEditCount.ts
+++ b/packages/lesswrong/server/migrations/2021-06-05-fillWikiEditCount.ts
@@ -1,0 +1,11 @@
+import { registerMigration } from './migrationUtils';
+import { recomputeDenormalizedValues } from '../scripts/recomputeDenormalized';
+
+registerMigration({
+  name: "fillWikiEditCount",
+  dateWritten: "2021-06-05",
+  idempotent: true,
+  action: async () => {
+    await recomputeDenormalizedValues({collectionName: "Users", fieldName: "tagRevisionCount"});
+  }
+})

--- a/packages/lesswrong/server/migrations/index.ts
+++ b/packages/lesswrong/server/migrations/index.ts
@@ -72,3 +72,4 @@ import './2020-12-04-nominationCount2019.ts'
 import './2021-03-11-readStatusesIndex.ts'
 import './2021-04-28-populateCommentDescendentCounts';
 import './2021-05-09-selfVoteOnTagRevisions';
+import './2021-06-05-fillWikiEditCount'


### PR DESCRIPTION
To give feedback to users who make wiki edits, we wanted to showcase their contributions on their profile. @s-cheng joined us on this one.

This PR was _almost_ dead simple. It looked like she had it after figuring out that tagRevisionCount could be a denormalizedCountOfReferences. However, the way denormalizedCountOfReferences works is that it registers callbacks on the foreign collection to increment the count. Unfortunately, Revisions are created without going through the normal mutator flow that would involve running those callbacks. Instead the new revisions are directly inserted inside of make_editable_callbacks.

Which brings us to our proposed refactor: the make_editable_callbacks can very easily be refactored to call createMutator instead of Connectors.create. I've examined createMutator, and the only effects it has are to run callbacks, which is what we want. Using createMutator allows denormalizedCountOfReferences to work as normal, and would allow us to remove the special-cased afterCreateRevisionCallback's.

Here's what the UI looks like:
![image](https://user-images.githubusercontent.com/10352319/120476250-372df400-c35f-11eb-95d4-18f95ddabe98.png)