### PR TITLE
Give Stickied posts their own status on the frontpage

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -12,7 +12,7 @@ const showHandbookBannerSetting = new DatabasePublicSetting<boolean>('showHandbo
 const EAHome = () => {
   const currentUser = useCurrentUser();
   const {
-    RecentDiscussionFeed, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated, SmallpoxBanner
+    RecentDiscussionFeed, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated, SmallpoxBanner, StickiedPosts
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;
@@ -25,6 +25,7 @@ const EAHome = () => {
       
       {shouldRenderSmallpox && <SmallpoxBanner/>}
 
+      <StickiedPosts />
       <HomeLatestPosts />
 
       <RecommendationsAndCurated configName="frontpageEA" />

--- a/packages/lesswrong/components/ea-forum/EAHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EAHome.tsx
@@ -12,7 +12,7 @@ const showHandbookBannerSetting = new DatabasePublicSetting<boolean>('showHandbo
 const EAHome = () => {
   const currentUser = useCurrentUser();
   const {
-    RecentDiscussionFeed, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated, SmallpoxBanner, StickiedPosts
+    RecentDiscussionFeed, HomeLatestPosts, EAHomeHandbook, RecommendationsAndCurated, SmallpoxBanner, StickiedPosts,
   } = Components
 
   const recentDiscussionCommentsPerPost = (currentUser && currentUser.isAdmin) ? 4 : 3;

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -25,7 +25,7 @@ const StickiedPosts = ({
       </Typography>}>
     </SectionTitle>
     <PostsList2
-      terms={{view:"stickied", limit: 100}}
+      terms={{view:"stickied"}}
       showNoResults={false}
       showLoadMore={false}
       hideLastUnread={true}

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -25,10 +25,10 @@ const StickiedPosts = ({
       </Typography>}>
     </SectionTitle>
     <PostsList2
-      terms={{view:"stickied"}}
+      terms={{view:"stickied", limit:100}}
       showNoResults={false}
       showLoadMore={false}
-      hideLastUnread={true}
+      hideLastUnread={false}
       boxShadow={false}
       curatedIconLeft={true}
     />

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { sectionTitleStyle } from "../common/SectionTitle";
+export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
+
+const styles = (theme: ThemeType): JssStyles => ({
+  title: {
+    ...sectionTitleStyle(theme),
+    display: "inline",
+    marginRight: "auto"
+  },
+});
+
+const StickiedPosts = ({
+  classes,
+}: {
+  classes: ClassesType,
+}) => {
+  const { SingleColumnSection, PostsList2, SectionTitle, Typography } = Components;
+
+  return <SingleColumnSection className={classes.section}>
+    <SectionTitle title={
+      <Typography variant='display1' className={classes.title}>
+          Pinned Posts
+      </Typography>}>
+    </SectionTitle>
+    <PostsList2
+      terms={{view:"stickied", limit: 100}}
+      showNoResults={false}
+      showLoadMore={false}
+      hideLastUnread={true}
+      boxShadow={false}
+      curatedIconLeft={true}
+    />
+  </SingleColumnSection>;
+}
+
+const StickiedPostsComponent = registerComponent("StickiedPosts", StickiedPosts, {styles});
+
+declare global {
+  interface ComponentTypes {
+    StickiedPosts: typeof StickiedPostsComponent
+  }
+}

--- a/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
+++ b/packages/lesswrong/components/ea-forum/StickiedPosts.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { sectionTitleStyle } from "../common/SectionTitle";
-export const curatedUrl = "/allPosts?filter=curated&sortedBy=new&timeframe=allTime"
 
 const styles = (theme: ThemeType): JssStyles => ({
   title: {
     ...sectionTitleStyle(theme),
     display: "inline",
-    marginRight: "auto"
+    marginRight: "auto",
   },
 });
 
@@ -30,7 +29,7 @@ const StickiedPosts = ({
       showLoadMore={false}
       hideLastUnread={false}
       boxShadow={false}
-      curatedIconLeft={true}
+      curatedIconLeft={false}
     />
   </SingleColumnSection>;
 }

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -11,12 +11,15 @@ import classNames from 'classnames';
 import { useRecordPostView } from '../common/withRecordPostView';
 import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
-import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
-import { startHere, stickyPostCategories } from "../../lib/collections/posts/constants";
+import { cloudinaryCloudNameSetting, DatabasePublicSetting } from '../../lib/publicSettings';
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
 
 const COMMENTS_BACKGROUND_COLOR = "#fafafa"
+
+const amaTagIdSetting = new DatabasePublicSetting<string | null>('amaTagId', null)
+const openThreadTagIdSetting = new DatabasePublicSetting<string | null>('openThreadTagId', null)
+const startHerePostIdSetting = new DatabasePublicSetting<string | null>('startHerePostId', null)
 
 export const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -281,15 +284,18 @@ const isSticky = (post: PostsList, terms: PostsViewTerms) => {
 }
 
 const isAMA = (post: PostsList) => {
-  return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.AMA).length > 0);
+  if (!amaTagIdSetting.get()) return false
+  return !!(post.sticky && post.tags.filter(tag => tag._id === amaTagIdSetting.get()).length > 0);
 };
 
 const isOpenThread = (post: PostsList) => {
-  return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.openThread).length > 0);
+  if (!openThreadTagIdSetting.get()) return false
+  return !!(post.sticky && post.tags.filter(tag => tag._id === openThreadTagIdSetting.get()).length > 0);
 };
 
 const isStartHerePost = (post: PostsList) => {
-  return !!(post.sticky && new RegExp(`${startHere}`, "i").test(post.title));
+  if (!startHerePostIdSetting.get()) return false
+  return !!(post.sticky && post._id === startHerePostIdSetting.get());
 };
 
 const PostsItem2 = ({

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -12,7 +12,7 @@ import { useRecordPostView } from '../common/withRecordPostView';
 import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
-import {startHere, stickyPostCategories} from "../../lib/collections/posts/constants";
+import { startHere, stickyPostCategories } from "../../lib/collections/posts/constants";
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
 
@@ -282,15 +282,15 @@ const isSticky = (post: PostsList, terms: PostsViewTerms) => {
 
 const isAMA = (post: PostsList) => {
   return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.AMA).length > 0);
-}
+};
 
 const isOpenThread = (post: PostsList) => {
   return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.openThread).length > 0);
-}
+};
 
 const isStartHerePost = (post: PostsList) => {
   return !!(post.sticky && new RegExp(`${startHere}`, "i").test(post.title));
-}
+};
 
 const PostsItem2 = ({
   // post: The post displayed.
@@ -463,9 +463,9 @@ const PostsItem2 = ({
                       post={post}
                       read={isRead}
                       sticky={isSticky(post, terms)}
-                      ama={isAMA(post)}
-                      openThread={isOpenThread(post)}
-                      startHerePost={isStartHerePost(post)}
+                      isAMA={isAMA(post)}
+                      isOpenThread={isOpenThread(post)}
+                      isStartHerePost={isStartHerePost(post)}
                       showQuestionTag={showQuestionTag}
                       showDraftTag={showDraftTag}
                       curatedIconLeft={curatedIconLeft}

--- a/packages/lesswrong/components/posts/PostsItem2.tsx
+++ b/packages/lesswrong/components/posts/PostsItem2.tsx
@@ -12,6 +12,7 @@ import { useRecordPostView } from '../common/withRecordPostView';
 import { NEW_COMMENT_MARGIN_BOTTOM } from '../comments/CommentsListSection'
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { cloudinaryCloudNameSetting } from '../../lib/publicSettings';
+import {startHere, stickyPostCategories} from "../../lib/collections/posts/constants";
 export const MENU_WIDTH = 18
 export const KARMA_WIDTH = 42
 
@@ -279,6 +280,18 @@ const isSticky = (post: PostsList, terms: PostsViewTerms) => {
   }
 }
 
+const isAMA = (post: PostsList) => {
+  return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.AMA).length > 0);
+}
+
+const isOpenThread = (post: PostsList) => {
+  return !!(post.sticky && post.tags.filter(tag => tag.name === stickyPostCategories.openThread).length > 0);
+}
+
+const isStartHerePost = (post: PostsList) => {
+  return !!(post.sticky && new RegExp(`${startHere}`, "i").test(post.title));
+}
+
 const PostsItem2 = ({
   // post: The post displayed.
   post,
@@ -450,6 +463,9 @@ const PostsItem2 = ({
                       post={post}
                       read={isRead}
                       sticky={isSticky(post, terms)}
+                      ama={isAMA(post)}
+                      openThread={isOpenThread(post)}
+                      startHerePost={isStartHerePost(post)}
                       showQuestionTag={showQuestionTag}
                       showDraftTag={showDraftTag}
                       curatedIconLeft={curatedIconLeft}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -6,6 +6,9 @@ import { useLocation } from '../../lib/routeUtil';
 import { Link } from '../../lib/reactRouterWrapper';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { userHasBoldPostItems } from '../../lib/betas';
+import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
+import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import AllInclusiveIcon from '@material-ui/icons/AllInclusive';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -35,6 +38,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     paddingRight: theme.spacing.unit,
     position: "relative",
     top: 2
+  },
+  primaryIcon: {
+    color: "#01839b"
   },
   read: {
     color: "rgba(0,0,0,.55)",
@@ -75,11 +81,14 @@ const stickyIcon = <svg fill="#000000" height="15" viewBox="0 0 10 15" width="10
   <path d="M 0.62965 7.43734C 0.504915 7.43692 0.383097 7.40021 0.279548 7.33183C 0.175999 7.26345 0.0953529 7.16646 0.0477722 7.05309C 0.000191541 6.93972 -0.0121941 6.81504 0.0121763 6.69475C 0.0365467 6.57447 0.0965826 6.46397 0.184718 6.37719L 1.77312 4.81248L 1.77312 1.75013L 1.32819 1.75013C 1.20359 1.75073 1.08025 1.72558 0.966163 1.67633C 0.852072 1.62708 0.749771 1.55483 0.665885 1.46423C 0.581999 1.37364 0.518398 1.26674 0.479198 1.15045C 0.439999 1.03415 0.426075 0.91106 0.438329 0.789139C 0.466198 0.56792 0.576593 0.364748 0.748122 0.218993C 0.919651 0.0732386 1.1401 -0.00472087 1.36675 0.000221379L 8.00217 0.000221379C 8.12677 -0.000372526 8.25011 0.0247692 8.3642 0.0740189C 8.47829 0.123269 8.58059 0.195528 8.66448 0.286119C 8.74837 0.37671 8.81197 0.483614 8.85117 0.599907C 8.89037 0.716201 8.90429 0.839293 8.89204 0.961214C 8.86417 1.18243 8.75377 1.38561 8.58224 1.53136C 8.41071 1.67711 8.19026 1.75507 7.96361 1.75013L 7.55724 1.75013L 7.55724 4.81248L 9.14861 6.37719C 9.23675 6.46397 9.29679 6.57447 9.32116 6.69475C 9.34553 6.81504 9.33314 6.93972 9.28556 7.05309C 9.23798 7.16646 9.15733 7.26345 9.05378 7.33183C 8.95023 7.40021 8.82842 7.43692 8.70368 7.43734L 0.62965 7.43734ZM 4.16834 13.562C 4.18174 13.6824 4.23985 13.7937 4.33154 13.8745C 4.42323 13.9553 4.54204 14 4.66518 14C 4.78833 14 4.90713 13.9553 4.99882 13.8745C 5.09051 13.7937 5.14863 13.6824 5.16202 13.562L 5.73747 8.74977L 3.5929 8.74977L 4.16834 13.562Z"/>
 </svg>
 
-const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true, showLinkTag=true, showDraftTag=true, wrap=false, showIcons=true, isLink=true, curatedIconLeft=true}: {
+const PostsTitle = ({post, postLink, classes, sticky, ama, openThread, startHerePost, read, showQuestionTag=true, showLinkTag=true, showDraftTag=true, wrap=false, showIcons=true, isLink=true, curatedIconLeft=true}: {
   post: PostsBase,
   postLink?: string,
   classes: ClassesType,
   sticky?: boolean,
+  ama?: boolean,
+  openThread?: boolean,
+  startHerePost?: boolean,
   read?: boolean,
   showQuestionTag?: boolean,
   showLinkTag?: boolean,
@@ -101,6 +110,9 @@ const PostsTitle = ({post, postLink, classes, sticky, read, showQuestionTag=true
   const url = postLink || postGetPageUrl(post)
 
   const title = <span>
+    {ama && <span className={classes.sticky}><QuestionAnswerIcon className={classes.primaryIcon}/></span>}
+    {openThread && <span className={classes.sticky}><AllInclusiveIcon className={classes.primaryIcon}/></span>}
+    {startHerePost && <span className={classes.sticky}><PlayCircleOutlineIcon className={classes.primaryIcon}/></span>}
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}
 
     {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -40,7 +40,12 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 2
   },
   primaryIcon: {
-    color: "#01839b"
+    color: theme.palette.primary.light,
+    paddingRight: theme.spacing.unit,
+    top: -2,
+    width: "auto",
+    position: "relative",
+    verticalAlign: "middle",
   },
   read: {
     color: "rgba(0,0,0,.55)",
@@ -110,9 +115,9 @@ const PostsTitle = ({post, postLink, classes, sticky, ama, openThread, startHere
   const url = postLink || postGetPageUrl(post)
 
   const title = <span>
-    {ama && <span className={classes.sticky}><QuestionAnswerIcon className={classes.primaryIcon}/></span>}
-    {openThread && <span className={classes.sticky}><AllInclusiveIcon className={classes.primaryIcon}/></span>}
-    {startHerePost && <span className={classes.sticky}><PlayCircleOutlineIcon className={classes.primaryIcon}/></span>}
+    {ama && <QuestionAnswerIcon className={classes.primaryIcon}/>}
+    {openThread && <AllInclusiveIcon className={classes.primaryIcon}/>}
+    {startHerePost && <PlayCircleOutlineIcon className={classes.primaryIcon}/>}
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}
 
     {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -86,14 +86,14 @@ const stickyIcon = <svg fill="#000000" height="15" viewBox="0 0 10 15" width="10
   <path d="M 0.62965 7.43734C 0.504915 7.43692 0.383097 7.40021 0.279548 7.33183C 0.175999 7.26345 0.0953529 7.16646 0.0477722 7.05309C 0.000191541 6.93972 -0.0121941 6.81504 0.0121763 6.69475C 0.0365467 6.57447 0.0965826 6.46397 0.184718 6.37719L 1.77312 4.81248L 1.77312 1.75013L 1.32819 1.75013C 1.20359 1.75073 1.08025 1.72558 0.966163 1.67633C 0.852072 1.62708 0.749771 1.55483 0.665885 1.46423C 0.581999 1.37364 0.518398 1.26674 0.479198 1.15045C 0.439999 1.03415 0.426075 0.91106 0.438329 0.789139C 0.466198 0.56792 0.576593 0.364748 0.748122 0.218993C 0.919651 0.0732386 1.1401 -0.00472087 1.36675 0.000221379L 8.00217 0.000221379C 8.12677 -0.000372526 8.25011 0.0247692 8.3642 0.0740189C 8.47829 0.123269 8.58059 0.195528 8.66448 0.286119C 8.74837 0.37671 8.81197 0.483614 8.85117 0.599907C 8.89037 0.716201 8.90429 0.839293 8.89204 0.961214C 8.86417 1.18243 8.75377 1.38561 8.58224 1.53136C 8.41071 1.67711 8.19026 1.75507 7.96361 1.75013L 7.55724 1.75013L 7.55724 4.81248L 9.14861 6.37719C 9.23675 6.46397 9.29679 6.57447 9.32116 6.69475C 9.34553 6.81504 9.33314 6.93972 9.28556 7.05309C 9.23798 7.16646 9.15733 7.26345 9.05378 7.33183C 8.95023 7.40021 8.82842 7.43692 8.70368 7.43734L 0.62965 7.43734ZM 4.16834 13.562C 4.18174 13.6824 4.23985 13.7937 4.33154 13.8745C 4.42323 13.9553 4.54204 14 4.66518 14C 4.78833 14 4.90713 13.9553 4.99882 13.8745C 5.09051 13.7937 5.14863 13.6824 5.16202 13.562L 5.73747 8.74977L 3.5929 8.74977L 4.16834 13.562Z"/>
 </svg>
 
-const PostsTitle = ({post, postLink, classes, sticky, ama, openThread, startHerePost, read, showQuestionTag=true, showLinkTag=true, showDraftTag=true, wrap=false, showIcons=true, isLink=true, curatedIconLeft=true}: {
+const PostsTitle = ({post, postLink, classes, sticky, isAMA, isOpenThread, isStartHerePost, read, showQuestionTag=true, showLinkTag=true, showDraftTag=true, wrap=false, showIcons=true, isLink=true, curatedIconLeft=true}: {
   post: PostsBase,
   postLink?: string,
   classes: ClassesType,
   sticky?: boolean,
-  ama?: boolean,
-  openThread?: boolean,
-  startHerePost?: boolean,
+  isAMA?: boolean,
+  isOpenThread?: boolean,
+  isStartHerePost?: boolean,
   read?: boolean,
   showQuestionTag?: boolean,
   showLinkTag?: boolean,
@@ -115,9 +115,9 @@ const PostsTitle = ({post, postLink, classes, sticky, ama, openThread, startHere
   const url = postLink || postGetPageUrl(post)
 
   const title = <span>
-    {ama && <QuestionAnswerIcon className={classes.primaryIcon}/>}
-    {openThread && <AllInclusiveIcon className={classes.primaryIcon}/>}
-    {startHerePost && <PlayCircleOutlineIcon className={classes.primaryIcon}/>}
+    {isAMA && <QuestionAnswerIcon className={classes.primaryIcon}/>}
+    {isOpenThread && <AllInclusiveIcon className={classes.primaryIcon}/>}
+    {isStartHerePost && <PlayCircleOutlineIcon className={classes.primaryIcon}/>}
     {sticky && <span className={classes.sticky}>{stickyIcon}</span>}
 
     {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -40,7 +40,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 2
   },
   primaryIcon: {
-    color: theme.palette.primary.light,
+    color: "rgba(0,0,0,.55)",
     paddingRight: theme.spacing.unit,
     top: -2,
     width: "auto",

--- a/packages/lesswrong/lib/collections/posts/constants.ts
+++ b/packages/lesswrong/lib/collections/posts/constants.ts
@@ -31,10 +31,3 @@ export const postStatusLabels = [
     label: 'deleted'
   }
 ];
-
-export const stickyPostCategories = {
-  AMA: 'Ask Me Anything',
-  openThread:  'Open Thread',
-}
-
-export const startHere = 'start here';

--- a/packages/lesswrong/lib/collections/posts/constants.ts
+++ b/packages/lesswrong/lib/collections/posts/constants.ts
@@ -31,3 +31,10 @@ export const postStatusLabels = [
     label: 'deleted'
   }
 ];
+
+export const stickyPostCategories = {
+  AMA: 'Ask Me Anything',
+  openThread:  'Open Thread',
+}
+
+export const startHere = 'start here';

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1183,3 +1183,16 @@ ensureIndex(Posts,
     name: "posts.users_tagged_posts",
   }
 );
+
+Posts.addView("stickied", (terms: PostsViewTerms) => {
+  return {
+    selector: {
+      sticky: true,
+    },
+    options: {
+      sort: {
+        stickyPriority: -1,
+      },
+    }
+  }
+})

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1197,6 +1197,7 @@ Posts.addView("stickied", (terms: PostsViewTerms) => {
       sticky: true,
     },
     options: {
+      limit: 100,
       sort: {
         stickyPriority: -1,
       },

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -61,7 +61,7 @@ export const filters: Record<string,any> = {
     curatedDate: {$gt: new Date(0)}
   },
   "nonSticky": {
-    sticky: false
+    sticky: false,
   },
   "frontpage": {
     frontpageDate: {$gt: new Date(0)}
@@ -365,7 +365,7 @@ Posts.addView("magic", (terms: PostsViewTerms) => {
   const selector = forumTypeSetting.get() === 'EAForum' ? filters.nonSticky : undefined;
   return {
     selector,
-    options: {sort: setStickies(sortings.magic, terms)}
+    options: {sort: setStickies(sortings.magic, terms)},
   };
 });
 ensureIndex(Posts,
@@ -1200,6 +1200,6 @@ Posts.addView("stickied", (terms: PostsViewTerms) => (
       sort: {
         stickyPriority: -1,
       },
-    }
+    },
   }
 ));

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -60,6 +60,9 @@ export const filters: Record<string,any> = {
   "curated": {
     curatedDate: {$gt: new Date(0)}
   },
+  "nonSticky": {
+    sticky: false
+  },
   "frontpage": {
     frontpageDate: {$gt: new Date(0)}
   },
@@ -358,9 +361,13 @@ const stickiesIndexPrefix = {
 };
 
 
-Posts.addView("magic", (terms: PostsViewTerms) => ({
-  options: {sort: setStickies(sortings.magic, terms)}
-}))
+Posts.addView("magic", (terms: PostsViewTerms) => {
+  const selector = forumTypeSetting.get() === 'EAForum' ? filters.nonSticky : undefined;
+  return {
+    selector,
+    options: {sort: setStickies(sortings.magic, terms)}
+  };
+});
 ensureIndex(Posts,
   augmentForDefaultView({ score:-1 }),
   {

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1191,16 +1191,15 @@ ensureIndex(Posts,
   }
 );
 
-Posts.addView("stickied", (terms: PostsViewTerms) => {
-  return {
+Posts.addView("stickied", (terms: PostsViewTerms) => (
+  {
     selector: {
       sticky: true,
     },
     options: {
-      limit: 100,
       sort: {
         stickyPriority: -1,
       },
     }
   }
-})
+));

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -21,6 +21,7 @@ if (forumTypeSetting.get() === 'EAForum') {
   importComponent("EAHomeHandbook", () => require('../components/ea-forum/EAHomeHandbook'));
   importComponent("SmallpoxBanner", () => require('../components/ea-forum/SmallpoxBanner'));
   importComponent("SiteLogo", () => require('../components/ea-forum/SiteLogo'));
+  importComponent("StickiedPosts", () => require('../components/ea-forum/StickiedPosts'))
 }
 
 importComponent("ConversationTitleEditForm", () => require('../components/messaging/ConversationTitleEditForm'));

--- a/packages/lesswrong/themes/eaTheme.ts
+++ b/packages/lesswrong/themes/eaTheme.ts
@@ -33,7 +33,8 @@ const sansSerifStack = [
 
 const palette = {
   primary: {
-    main: '#0c869b', // Maybe replace with: 00b2be
+    main: '#0c869b',
+    light: '#00b2be',
   },
   secondary: {
     main: '#0c869b',


### PR DESCRIPTION
Also by @jcmustin. Should only affect the EA Forum. Allows us to pin more posts without it feeling too crowded, and also adds a decoration to pinned AMAs, Open Threads, and the Start Here post.