### PR TITLE
Fix ToC scrollbar styling; fix clickability of the + button next to New Tag

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/ToCColumn.tsx
@@ -49,38 +49,50 @@ export const styles = (theme: ThemeType): JssStyles => ({
     width: MAX_TOC_WIDTH,
     left: -DEFAULT_TOC_MARGIN,
   },
-  stickyBlock: {
+  stickyBlockScroller: {
     position: "sticky",
     fontSize: 12,
     top: 92,
     lineHeight: 1.0,
-    marginLeft:1,
-    paddingLeft:theme.spacing.unit*2,
-    textAlign:"left",
-    height:"80vh",
-    overflowY:"scroll",
+    marginLeft: 1,
+    paddingLeft: theme.spacing.unit*2,
+    textAlign: "left",
+    height: "80vh",
+    overflowY: "auto",
+    
+    // Moves the scrollbar to the left side. Cancelled out by a matching
+    // direction:ltr on the next div in.
+    direction: "rtl",
+    
+    // Nonstandard WebKit-specific scrollbar styling.
     "&::-webkit-scrollbar": {
       width: 1,
     },
-
-    /* Track */
+    // Track
     "&::-webkit-scrollbar-track": {
-        background: "none",
+      background: "none",
     },
 
-    /* Handle */
+    // Handle
     "&::-webkit-scrollbar-thumb": {
-        background: theme.palette.grey[300],
-    },
-
-    /* Handle on hover */
-    "&::-webkit-scrollbar-thumb:hover": {
+      background: theme.palette.grey[300],
+      "&:hover": {
         background: theme.palette.grey[700],
+      },
     },
+    
+    // Pre-standard Firefox-specific scrollbar styling. See
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scrollbars.
+    scrollbarWidth: "thin",
+    scrollbarColor: `rgba(255,255,255,0) ${theme.palette.grey[300]}`,
 
     [theme.breakpoints.down('sm')]:{
       display:'none'
     }
+  },
+  stickyBlock: {
+    // Cancels the direction:rtl in stickyBlockScroller
+    direction: "ltr",
   },
   content: { gridArea: 'content' },
   gap1: { gridArea: 'gap1'},
@@ -99,8 +111,10 @@ export const ToCColumn = ({tableOfContents, header, children, classes}: {
         {header}
       </div>
       {tableOfContents && <div className={classes.toc}>
-        <div className={classes.stickyBlock}>
-          {tableOfContents}
+        <div className={classes.stickyBlockScroller}>
+          <div className={classes.stickyBlock}>
+            {tableOfContents}
+          </div>
         </div>
       </div>}
       <div className={classes.gap1}/>

--- a/packages/lesswrong/components/tagging/AllTagsPage.tsx
+++ b/packages/lesswrong/components/tagging/AllTagsPage.tsx
@@ -46,7 +46,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     float: "right",
     marginRight: 5,
     color: theme.palette.grey[600],
-  }
+  },
+  addTagButton: {
+    verticalAlign: "middle",
+  },
 })
 
 
@@ -57,7 +60,6 @@ const AllTagsPage = ({classes}: {
   const currentUser = useCurrentUser()
   const { tag } = useTagBySlug("portal", "TagFragment");
   const [ editing, setEditing ] = useState(false)
-  // Type hack because MenuItem is too narrowly typed and doesn't properly take into account props-forwarding
 
   const { AllTagsAlphabetical, SectionButton, SectionTitle, ContentItemBody } = Components;
 
@@ -68,16 +70,21 @@ const AllTagsPage = ({classes}: {
           <AnalyticsContext pageSectionContext="tagPortal">
             <SectionTitle title="Concepts Portal">
               <SectionButton>
-                <AddBoxIcon/>
-                {currentUser ? 
-                  <Link to="/tag/create">New Tag</Link> :
-                  <a onClick={(ev) => {
-                    openDialog({
-                      componentName: "LoginPopup",
-                      componentProps: {}
-                    });
-                    ev.preventDefault();
-                  }}>New Tag</a>
+                {currentUser
+                  ? <Link to="/tag/create">
+                      <AddBoxIcon className={classes.addTagButton}/>
+                      New Tag
+                    </Link>
+                  : <a onClick={(ev) => {
+                      openDialog({
+                        componentName: "LoginPopup",
+                        componentProps: {}
+                      });
+                      ev.preventDefault();
+                    }}>
+                      <AddBoxIcon className={classes.addTagButton}/>
+                      New Tag
+                    </a>
                 }
               </SectionButton>
             </SectionTitle>


### PR DESCRIPTION
Moves the scrollbar for tables of contents back to the left. Adds some Firefox-specific styling to pair with the preexisting WebKit-specific styling. Makes the [+] button next to the words New Tag clickable on the Concepts page.