### PR TITLE
Add Random Tag link to tag page ToC sidebar

### DIFF
--- a/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
+++ b/packages/lesswrong/components/posts/TableOfContents/TableOfContentsRow.tsx
@@ -100,7 +100,7 @@ const TableOfContentsRow = ({
   highlighted?: boolean,
   href: string,
   onClick?: (ev: any)=>void,
-  children: React.ReactNode,
+  children?: React.ReactNode,
   classes: ClassesType,
   title?: boolean,
   divider?: boolean,

--- a/packages/lesswrong/components/tagging/RandomTagPage.tsx
+++ b/packages/lesswrong/components/tagging/RandomTagPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { useQuery, gql } from '@apollo/client';
+
+const RandomTagPage = () => {
+  const {PermanentRedirect, Loading, SingleColumnSection} = Components;
+  const {data, loading} = useQuery(gql`
+    query getRandomTag {
+      RandomTag {slug}
+    }
+  `, {
+    fetchPolicy: "no-cache",
+  });
+  const tag = data?.RandomTag;
+  return <SingleColumnSection>
+    {tag && <PermanentRedirect status={302} url={`/tag/${tag.slug}`}/>}
+    {loading && <Loading/>}
+  </SingleColumnSection>
+}
+
+const RandomTagPageComponent = registerComponent('RandomTagPage', RandomTagPage);
+
+declare global {
+  interface ComponentTypes {
+    RandomTagPage: typeof RandomTagPageComponent
+  }
+}
+

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -68,6 +68,14 @@ export const styles = (theme: ThemeType): JssStyles => ({
   nextLink: {
     ...theme.typography.commentStyle
   },
+  randomTagLink: {
+    ...theme.typography.commentStyle,
+    fontSize: "1.16rem",
+    color: theme.palette.grey[600],
+    display: "inline-block",
+    marginTop: 8,
+    marginBottom: 8,
+  },
 });
 
 export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
@@ -83,7 +91,7 @@ export const tagPostTerms = (tag: TagBasicInfo | null, query: any) => {
 const TagPage = ({classes}: {
   classes: ClassesType
 }) => {
-  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn, TableOfContents, TagContributorsList } = Components;
+  const { PostsListSortDropdown, PostsList2, ContentItemBody, Loading, AddPostsToTag, Error404, PermanentRedirect, HeadTags, UsersNameDisplay, TagFlagItem, TagDiscussionSection, Typography, TagPageButtonRow, ToCColumn, TableOfContents, TableOfContentsRow, TagContributorsList } = Components;
   const currentUser = useCurrentUser();
   const { query, params: { slug } } = useLocation();
   const { revision } = query;
@@ -203,6 +211,8 @@ const TagPage = ({classes}: {
                 title={tag.name}
                 onClickSection={expandAll}
               />
+              <Link to="/tags/random" className={classes.randomTagLink}>Random Tag</Link>
+              <TableOfContentsRow href="#" divider={true}/>
               <TagContributorsList onHoverUser={onHoverContributor} tag={tag}/>
             </span>
           : null

--- a/packages/lesswrong/lib/components.ts
+++ b/packages/lesswrong/lib/components.ts
@@ -405,6 +405,7 @@ importComponent("AddPostsToTag", () => require('../components/tagging/AddPostsTo
 importComponent("FooterTagList", () => require('../components/tagging/FooterTagList'));
 importComponent("FooterTag", () => require('../components/tagging/FooterTag'));
 importComponent("NewTagPage", () => require('../components/tagging/NewTagPage'));
+importComponent("RandomTagPage", () => require('../components/tagging/RandomTagPage'));
 importComponent("EditTagPage", () => require('../components/tagging/EditTagPage'));
 importComponent("EditTagsDialog", () => require('../components/tagging/EditTagsDialog'));
 importComponent("AllTagsPage", () => require('../components/tagging/AllTagsPage'));

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -310,6 +310,11 @@ addRoute(
     background: "white"
   },
   {
+    name: 'randomTag',
+    path: '/tags/random',
+    componentName: 'RandomTagPage',
+  },
+  {
     name: 'allTags',
     path: '/tags/all',
     componentName: 'AllTagsPage',

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -75,11 +75,23 @@ addGraphQLResolvers({
           removed: sumBy(relevantRevisions, r=>r.changeMetrics.removed),
         };
       });
+    },
+    
+    async RandomTag(root: void, args: void, context: ResolverContext): Promise<DbTag> {
+      const sample = await Tags.aggregate([
+        {$match: {deleted: false, adminOnly: false}},
+        {$sample: {size: 1}}
+      ]).toArray();
+      if (!sample || !sample.length)
+        throw new Error("No tags found");
+      console.log(`Random tag: ${sample[0].slug}`);
+      return sample[0];
     }
   }
 });
 
 addGraphQLQuery('TagUpdatesInTimeBlock(before: Date!, after: Date!): [TagUpdatesTimeBlock!]');
+addGraphQLQuery('RandomTag: Tag!');
 
 addFieldsDict(Tags, {
   contributors: {

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -84,7 +84,6 @@ addGraphQLResolvers({
       ]).toArray();
       if (!sample || !sample.length)
         throw new Error("No tags found");
-      console.log(`Random tag: ${sample[0].slug}`);
       return sample[0];
     }
   }

--- a/packages/lesswrong/testing/debouncer.tests.ts
+++ b/packages/lesswrong/testing/debouncer.tests.ts
@@ -14,7 +14,7 @@ describe('EventDebouncer', () => {
     
     try {
       // Clear the DebouncerEvents table
-      DebouncerEvents.remove({});
+      void DebouncerEvents.remove({});
       
       let numEventsHandled = 0;
       let numEventBatchesHandled = 0;


### PR DESCRIPTION
Adds a Random Tag link to the ToC sidebar, which takes you to a randomly selected tag or wiki page (via `/tags/random`).
![Screen Shot 2021-06-09 at 08 06 44](https://user-images.githubusercontent.com/101191/121380571-d459d100-c8f9-11eb-934e-430e8ce888ba.png)
