### PR TITLE
Fix bugs in user handling

### DIFF
--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -142,7 +142,12 @@ const WrappedLoginForm = ({ startingState = "login", classes }: {
       {["signup", "pwReset"].includes(currentAction) && <input value={email} type="text" name="email" placeholder="email" className={classes.input} onChange={event => setEmail(event.target.value)} />}
       {["signup", "login"].includes(currentAction) && <>
         <input value={username} type="text" name="username" placeholder={currentAction === "signup" ? "username" : "username or email"} className={classes.input} onChange={event => setUsername(event.target.value)}/>
-        <input value={password} type="password" name="password" placeholder="create password" className={classes.input} onChange={event => setPassword(event.target.value)}/>
+        <input
+          value={password} type="password" name="password"
+          placeholder={(currentAction==="signup") ? "create password" : "password"}
+          className={classes.input}
+          onChange={event => setPassword(event.target.value)}
+        />
       </>}
       <input type="submit" className={classes.submit} value={currentActionToButtonText[currentAction]} />
       

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -736,8 +736,8 @@ addFieldsDict(Users, {
     optional: true,
     control: "KarmaChangeNotifierSettings",
     canRead: [userOwns, 'admins'],
-    canUpdate: [userOwns, 'admins', 'sunshineRegiment'],
-    canCreate: [userOwns, 'admins', 'sunshineRegiment'],
+    canUpdate: [userOwns, 'admins'],
+    canCreate: [userOwns, 'admins'],
     ...schemaDefaultValue(karmaChangeNotifierDefaultSettings)
   },
 

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -212,7 +212,7 @@ addFieldsDict(Users, {
     optional: true,
     defaultValue: false,
     hidden: true,
-    canRead: ['guests'],
+    canRead: [userOwns, 'admins'],
     canUpdate: [userOwns, 'sunshineRegiment', 'admins'],
     canCreate: ['members'],
   },


### PR DESCRIPTION
Fixes the password field on the login form being mislabeled. Fixes the terrible internal-error message you get when you attempt to sign up with a username or email that's already taken. Fixes crash when a Sunshine who isn't an Admin attempts to edit a user. Fix incorrect permissions on the Legacy field, which leaked all imported password hashes.