### PR TITLE
Include post recommendations at end of curation email

### DIFF
--- a/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
-import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import { registerComponent } from '../../lib/vulcan-lib/components';
 import './EmailFormatDate';
 import './EmailPostAuthors';
 import './EmailContentItemBody';

--- a/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailFooterRecommendations.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { postGetPageUrl } from '../../lib/collections/posts/helpers';
+import { Components, registerComponent } from '../../lib/vulcan-lib/components';
+import './EmailFormatDate';
+import './EmailPostAuthors';
+import './EmailContentItemBody';
+import './EmailPostDate';
+import { useRecommendations } from '../../components/recommendations/withRecommendations';
+import { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
+
+const styles = (theme: ThemeType): JssStyles => ({
+  recommendedPostsHeader: {
+    fontSize: '1rem'
+  }
+});
+
+const EmailFooterRecommendations = ({classes}: {
+  classes: ClassesType,
+}) => {
+  const algorithm: RecommendationsAlgorithm = {
+    method: "sample",
+    count: 5,
+    scoreOffset: 0,
+    scoreExponent: 3,
+    personalBlogpostModifier: 0,
+    includePersonal: false,
+    includeMeta: false,
+    frontpageModifier: 10,
+    curatedModifier: 50,
+    onlyUnread: true,
+  }
+  const {recommendationsLoading, recommendations} = useRecommendations(algorithm)
+  if (recommendationsLoading) return null
+  return <>
+    <h2 className={classes.recommendedPostsHeader}>Other Recommended Posts</h2>
+    <ul>
+      {/* TODO: Watch for this referrer */}
+      {recommendations?.map(post => <li key={post._id}><a href={`${postGetPageUrl(post, true)}?referrer=emailfooter`}>{post.title}</a></li>)}
+    </ul>
+  </>
+}
+
+const EmailFooterRecommendationsComponent = registerComponent("EmailFooterRecommendations", EmailFooterRecommendations, {styles});
+
+declare global {
+  interface ComponentTypes {
+    EmailFooterRecommendations: typeof EmailFooterRecommendationsComponent
+  }
+}

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -78,11 +78,11 @@ const EmailWrapper = ({user, unsubscribeAllLink, children, classes}: {
                       </td>
                     </tr>
                     <tr><td className="container-padding">
-                      <br/><br/>
+                      <br/>
                       <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}
                       (from all emails from {siteNameWithArticle})
                       or <a href={accountLink}>Change your notifications settings</a>
-                      <br/><br/>
+                      <br/>
                     </td></tr>
                   </tbody>
                 </table>

--- a/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/NewPostEmail.tsx
@@ -6,6 +6,7 @@ import './EmailFormatDate';
 import './EmailPostAuthors';
 import './EmailContentItemBody';
 import './EmailPostDate';
+import './EmailFooterRecommendations';
 
 const styles = (theme: ThemeType): JssStyles => ({
   heading: {
@@ -25,6 +26,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginTop: 50,
     marginBottom: 35,
   },
+  hr: {
+    marginTop: 30,
+    marginBottom: 30,
+  },
 });
 
 const NewPostEmail = ({documentId, classes, reason}: {
@@ -41,7 +46,7 @@ const NewPostEmail = ({documentId, classes, reason}: {
       version: 'String'
     }
   });
-  const { EmailPostAuthors, EmailContentItemBody, EmailPostDate } = Components;
+  const { EmailPostAuthors, EmailContentItemBody, EmailPostDate, EmailFooterRecommendations } = Components;
   if (!document) return null;
   return (<React.Fragment>
     <div className={classes.heading}>
@@ -71,7 +76,13 @@ const NewPostEmail = ({documentId, classes, reason}: {
       __html: document.contents.html
     }} />}
     
-    <a href={postGetPageUrl(document, true)}>Discuss</a><br/><br/>
+    <a href={postGetPageUrl(document, true)}>Discuss</a>
+    
+    <hr className={classes.hr}/>
+    
+    <EmailFooterRecommendations />
+    
+    <hr className={classes.hr}/>
     
     {reason && `You are receiving this email because ${reason}.`}
   </React.Fragment>);


### PR DESCRIPTION
Developed while pairing with @jimrandomh . Jim's preferred problem, my driving.

If you read a post in your email client, and you reach the end, you're currently offered to view the discussion, but if you're not a "view discussion" kinda person, there's no further call to engagement. This PR adds a list of recommended posts to further read if the reader is interested in continuing.

We use the same recommendations logic that powers the frontpage and /recommendations. We apply some styling updates to get consistent vertical spacing.

![image](https://user-images.githubusercontent.com/10352319/122465758-53d84780-cf6d-11eb-824e-723f1fe50b35.png)

We did *not* send ourselves an actual email this way, which should probably be done before deploying.

Future work could involve:
 * Prioritizing the list better, perhaps by using the motivation tag
 * Using the referrer to count clicks
 * Building email AB testing