### PR TITLE
Tag contributor score has hover-over with vote count, num commits

### DIFF
--- a/packages/lesswrong/components/tagging/TagContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/TagContributorsList.tsx
@@ -63,6 +63,7 @@ const TagContributorsList = ({tag, onHoverUser, classes}: {
     {tag.contributors && contributorsList.map(contributor => <div key={contributor.user._id} className={classes.contributorRow} >
       <LWTooltip
         className={classes.contributorScore}
+        placement="left"
         title={<span>
           {contributor.contributionScore} total points from {contributor.voteCount} votes on {contributor.numCommits} edits
         </span>}

--- a/packages/lesswrong/components/tagging/TagContributorsList.tsx
+++ b/packages/lesswrong/components/tagging/TagContributorsList.tsx
@@ -40,7 +40,7 @@ const TagContributorsList = ({tag, onHoverUser, classes}: {
   onHoverUser: (userId: string|null)=>void,
   classes: ClassesType,
 }) => {
-  const { UsersNameDisplay, Loading } = Components;
+  const { UsersNameDisplay, Loading, LWTooltip } = Components;
   const [expandLoadMore,setExpandLoadMore] = useState(false);
   
   const {document: tagWithExpandedList, loading: loadingMore} = useSingle({
@@ -61,9 +61,14 @@ const TagContributorsList = ({tag, onHoverUser, classes}: {
     </div>
     
     {tag.contributors && contributorsList.map(contributor => <div key={contributor.user._id} className={classes.contributorRow} >
-      <span className={classes.contributorScore}>
+      <LWTooltip
+        className={classes.contributorScore}
+        title={<span>
+          {contributor.contributionScore} total points from {contributor.voteCount} votes on {contributor.numCommits} edits
+        </span>}
+      >
         {contributor.contributionScore}
-      </span>
+      </LWTooltip>
       <span className={classes.contributorName}
         onMouseEnter={ev => {
           onHoverUser(contributor.user._id);

--- a/packages/lesswrong/lib/collections/tags/fragments.ts
+++ b/packages/lesswrong/lib/collections/tags/fragments.ts
@@ -134,6 +134,8 @@ registerFragment(`
           ...UsersMinimumInfo
         }
         contributionScore
+        numCommits
+        voteCount
       }
     }
   }
@@ -150,6 +152,8 @@ registerFragment(`
           ...UsersMinimumInfo
         }
         contributionScore
+        numCommits
+        voteCount
       }
     }
   }
@@ -164,6 +168,8 @@ registerFragment(`
           ...UsersMinimumInfo
         }
         contributionScore
+        numCommits
+        voteCount
       }
     }
   }

--- a/packages/lesswrong/lib/collections/tags/schema.ts
+++ b/packages/lesswrong/lib/collections/tags/schema.ts
@@ -21,6 +21,8 @@ addGraphQLSchema(`
   type TagContributor {
     user: User!
     contributionScore: Int!
+    numCommits: Int!
+    voteCount: Int!
   }
   type TagContributorsList {
     contributors: [TagContributor!]
@@ -357,8 +359,11 @@ export const schema: SchemaType<DbTag> = {
     optional: true,
   },
   
-  // Denormalized copy of contribution-scores, for the latest revision.
-  contributionScores: {
+  // Denormalized copy of contribution-stats, for the latest revision.
+  // Replaces contributionScores, which was the same denormalized thing but for
+  // contribution scores only, without number of commits and vote count, and
+  // which is no longer on the schema.
+  contributionStats: {
     type: Object,
     optional: true,
     blackbox: true,

--- a/packages/lesswrong/lib/generated/databaseTypes.d.ts
+++ b/packages/lesswrong/lib/generated/databaseTypes.d.ts
@@ -591,7 +591,7 @@ interface DbTag extends DbObject {
   lesswrongWikiImportSlug: string
   lesswrongWikiImportCompleted: boolean
   htmlWithContributorAnnotations: string
-  contributionScores: any /*{"definitions":[{"blackbox":true}]}*/
+  contributionStats: any /*{"definitions":[{"blackbox":true}]}*/
   description: EditableFieldContents
 }
 

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -218,7 +218,7 @@ interface TagsDefaultFragment { // fragment on Tags
   readonly lesswrongWikiImportCompleted: boolean,
   readonly htmlWithContributorAnnotations: string,
   readonly contributors: any /*TagContributorsList*/,
-  readonly contributionScores: any /*{"definitions":[{"blackbox":true}]}*/,
+  readonly contributionStats: any /*{"definitions":[{"blackbox":true}]}*/,
 }
 
 interface RevisionsDefaultFragment { // fragment on Revisions

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -215,7 +215,6 @@ async function buildContributorsList(tag: DbTag, version: string|null): Promise<
       };
     }
   );
-  console.log(contributionStatsByUserId);
   return contributionStatsByUserId;
 }
 


### PR DESCRIPTION
The score in contributor lists has a hover-over which shows the total score, number of votes included in that score (ie with only one self-vote), and number of edits.

![Screen Shot 2021-06-21 at 10 23 12](https://user-images.githubusercontent.com/101191/122802842-b9cd1380-d27a-11eb-8648-f8d8cec41753.png)

