### PR TITLE
Customize Social Preview Description for Comment Permalinks

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -29,10 +29,10 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const getCommentDescription = (comment: CommentWithRepliesFragment) => {
-  return `Comment ${comment?.user ? 
+  return `Comment ${comment.user ? 
     `by ${comment.user.displayName} ` : 
     ''
-  }- ${comment?.contents?.plaintextMainText}`
+  }- ${comment.contents?.plaintextMainText}`
 }
 
 const CommentPermalink = ({ documentId, post, classes }: {
@@ -52,7 +52,6 @@ const CommentPermalink = ({ documentId, post, classes }: {
 
   if (!documentId) return null
 
-  const description = getCommentDescription(comment)
   const ogUrl = postGetPageUrl(post, true) // open graph
   const canonicalUrl = post.canonicalSource || ogUrl
   // For imageless posts this will be an empty string
@@ -60,10 +59,10 @@ const CommentPermalink = ({ documentId, post, classes }: {
 
   // NB: classes.root is not in the above styles, but is used by eaTheme
   return <div className={classes.root}>
-      <HeadTags ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl} 
-      description={description} noIndex={true} />
       <div className={classes.permalinkLabel}>Comment Permalink</div>
       {loading ? <Loading /> : <div>
+        <HeadTags ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl} 
+        description={getCommentDescription(comment)} noIndex={true} />
         <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
       </div>}

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -37,7 +37,7 @@ const getCommentDescription = (comment: CommentWithRepliesFragment) => {
 
 const CommentPermalink = ({ documentId, post, classes }: {
   documentId: string,
-  post: PostsWithNavigation | PostsWithNavigationAndRevision,
+  post: PostsDetails,
   classes: ClassesType,
 }) => {
   const { document: comment, data, loading, error } = useSingle({

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -63,7 +63,7 @@ const PostsPage = ({post, refetch, classes}: {
     return false;
   }
 
-  const getDescription = (post: PostsWithNavigation|PostsWithNavigationAndRevision) => {
+  const getPostDescription = (post: PostsWithNavigation|PostsWithNavigationAndRevision) => {
     if (post.contents?.plaintextDescription) return post.contents.plaintextDescription
     if (post.shortform) return `A collection of shorter posts ${post.user ? `by ${forumTitleSetting.get()} user ${post.user.displayName}` : ''}`
     return null
@@ -99,7 +99,7 @@ const PostsPage = ({post, refetch, classes}: {
 
   const commentId = query.commentId || params.commentId
 
-  const description = getDescription(post)
+  const description = getPostDescription(post)
   const ogUrl = postGetPageUrl(post, true) // open graph
   const canonicalUrl = post.canonicalSource || ogUrl
   // For imageless posts this will be an empty string
@@ -113,14 +113,14 @@ const PostsPage = ({post, refetch, classes}: {
           : null
       }
       header={<>
-        <HeadTags
+        {!commentId && <HeadTags
           ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl}
-          title={post.title} description={description} noIndex={post.noIndex || !!commentId}
-        />
+          title={post.title} description={description} noIndex={post.noIndex}
+        />}
         {/* Header/Title */}
         <AnalyticsContext pageSectionContext="postHeader"><div className={classes.title}>
           <div className={classes.centralColumn}>
-            {commentId && <CommentPermalink documentId={commentId} post={post}/>}
+            {commentId && <CommentPermalink documentId={commentId} post={post} />}
             <PostsPagePostHeader post={post}/>
           </div>
         </div></AnalyticsContext>


### PR DESCRIPTION
This PR updates the head tags used by social previews (e.g. on Facebook or Twitter) for comment permalinks, such that the description displayed comes from the comment rather than the post. At present the format of the description is "Comment by {username} - {comment text}", though I'm very open to suggestions on that if people would prefer a different syntax.