### PR TITLE
Remove extra space from analytics-debug database setting

### DIFF
--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -9,7 +9,7 @@ import { DatabasePublicSetting } from './publicSettings';
 import { getPublicSettingsLoaded } from './settingsCache';
 import * as _ from 'underscore';
 
-const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug ", "dev");
+const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug", "dev");
 
 addGraphQLSchema(`
   type AnalyticsEvent {


### PR DESCRIPTION
It does in fact force the database setting to need to have a space in it.