### PR TITLE
Redirect upon return from OAuth provider

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -1,6 +1,6 @@
 
 name: Run Unit Tests
-on: push
+on: [push, pull_request]
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest

--- a/packages/lesswrong/components/common/hocTypes.ts
+++ b/packages/lesswrong/components/common/hocTypes.ts
@@ -1,4 +1,5 @@
 import type { FetchResult } from '@apollo/client';
+import { RouterLocation } from '../../lib/vulcan-lib';
 
 declare global {
 
@@ -36,7 +37,7 @@ interface WithNavigationProps {
 }
 
 interface WithLocationProps {
-  location: any,
+  location: RouterLocation,
 }
 
 interface WithDialogProps {

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -63,8 +63,6 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
   render() {
     const { color, classes, location } = this.props
     const { pathname } = location
-    console.log('🚀 ~ file: UsersAccountMenu.tsx ~ line 65 ~ UsersAccountMenu ~ render ~ pathname', pathname)
-    console.log('usersaccountmenu')
 
     return (
       <div className={classes.root}>

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { Components, registerComponent, RouterLocation } from '../../lib/vulcan-lib';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
@@ -6,6 +6,7 @@ import Popover from '@material-ui/core/Popover';
 import Button from '@material-ui/core/Button';
 import { withTracking } from '../../lib/analyticsEvents';
 import { forumTypeSetting } from '../../lib/instanceSettings';
+import { withLocation } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -27,6 +28,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 interface UsersAccountMenuProps extends WithStylesProps {
   captureEvent?: any,
   color?: string,
+  location: RouterLocation
 }
 interface UsersAccountMenuState {
   open: boolean,
@@ -59,18 +61,21 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
   }
 
   render() {
-    const { color, classes } = this.props
+    const { color, classes, location } = this.props
+    const { pathname } = location
+    console.log('🚀 ~ file: UsersAccountMenu.tsx ~ line 65 ~ UsersAccountMenu ~ render ~ pathname', pathname)
+    console.log('usersaccountmenu')
 
     return (
       <div className={classes.root}>
         {forumTypeSetting.get() === 'EAForum' ? <>
-          <Button href='/auth/auth0'>
+          <Button href={`/auth/auth0?returnTo=${pathname}`}>
             <span className={classes.userButton} style={{ color: color }}>
               Login
             </span>
           </Button>
           <div className={classes.signUpButton}>
-            <Button href='/auth/auth0?screen_hint=signup'>
+            <Button href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`}>
               <span className={classes.userButton} style={{ color: color }}>
                 Sign Up
               </span>
@@ -106,7 +111,7 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
 
 const UsersAccountMenuComponent = registerComponent('UsersAccountMenu', UsersAccountMenu, {
   styles,
-  hocs: [withTracking]
+  hocs: [withTracking, withLocation]
 });
 
 declare global {

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -28,7 +28,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 interface UsersAccountMenuProps extends WithStylesProps {
   captureEvent?: any,
   color?: string,
-  location: RouterLocation
+  location?: RouterLocation
 }
 interface UsersAccountMenuState {
   open: boolean,
@@ -62,7 +62,9 @@ class UsersAccountMenu extends PureComponent<UsersAccountMenuProps,UsersAccountM
 
   render() {
     const { color, classes, location } = this.props
-    const { pathname } = location
+    // Location is always passed in by hoc. We can't make it a required prop due
+    // to a limitation in our typings
+    const { pathname } = location!
 
     return (
       <div className={classes.root}>

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -191,7 +191,6 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
 
 const WrappedLoginFormEA = ({classes}: WrappedLoginFormProps) => {
   const { pathname } = useLocation()
-  console.log('this loginform?')
   
   return <div className={classes.root}>
     <div className={classnames(classes.oAuthBlock, 'ea-forum')}>

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -7,6 +7,7 @@ import { forumTypeSetting } from '../../lib/instanceSettings';
 import { useMessages } from '../common/withMessages';
 import { getUserABTestKey, useClientId } from '../../lib/abTestImpl';
 import classnames from 'classnames'
+import { useLocation } from '../../lib/routeUtil';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -189,10 +190,13 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
 }
 
 const WrappedLoginFormEA = ({classes}: WrappedLoginFormProps) => {
+  const { pathname } = useLocation()
+  console.log('this loginform?')
+  
   return <div className={classes.root}>
     <div className={classnames(classes.oAuthBlock, 'ea-forum')}>
-      <a className={classes.oAuthLink} href="/auth/auth0">Login</a>
-      <a className={classes.oAuthLink} href="/auth/auth0?screen_hint=signup">Sign Up</a>
+      <a className={classes.oAuthLink} href={`/auth/auth0?returnTo=${pathname}`}>Login</a>
+      <a className={classes.oAuthLink} href={`/auth/auth0?screen_hint=signup&returnTo=${pathname}`}>Sign Up</a>
     </div>
   </div>
 }

--- a/packages/lesswrong/components/users/WrappedLoginForm.tsx
+++ b/packages/lesswrong/components/users/WrappedLoginForm.tsx
@@ -124,6 +124,7 @@ const WrappedLoginForm = (props: WrappedLoginFormProps) => {
 }
 
 const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLoginFormProps) => {
+  const { pathname } = useLocation()
   const { SignupSubscribeToCurated } = Components;
   const [reCaptchaToken, setReCaptchaToken] = useState<any>(null);
   const [username, setUsername] = useState<string | undefined>(undefined)
@@ -176,9 +177,9 @@ const WrappedLoginFormDefault = ({ startingState = "login", classes }: WrappedLo
       </div>
       <div className={classes.oAuthComment}>...or continue with</div>
       <div className={classes.oAuthBlock}>
-        <a className={classes.oAuthLink} href="/auth/facebook">FACEBOOK</a>
-        <a className={classes.oAuthLink} href="/auth/google">GOOGLE</a>
-        <a className={classes.oAuthLink} href="/auth/github">GITHUB</a>
+        <a className={classes.oAuthLink} href={`/auth/facebook?returnTo=${pathname}`}>FACEBOOK</a>
+        <a className={classes.oAuthLink} href={`/auth/google?returnTo=${pathname}`}>GOOGLE</a>
+        <a className={classes.oAuthLink} href={`/auth/github?returnTo=${pathname}`}>GITHUB</a>
         {/* Temporarily here for EA Forum testing */}
         {/* <a className={classes.oAuthLink} href="/auth/auth0">AUTH 0</a> */}
       </div>

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -45,17 +45,13 @@ export const AnalyticsUtil: any = {
 function getShowAnalyticsDebug() {
   if (isAnyTest)
     return false;
-  const loaded = getPublicSettingsLoaded()
-  const debug = loaded ? showAnalyticsDebug.get() : "dev";
-  if (debug==="always") {
+  const debug = getPublicSettingsLoaded() ? showAnalyticsDebug.get() : "dev";
+  if (debug==="always")
     return true;
-  }
-  else if (debug==="dev") {
+  else if (debug==="dev")
     return isDevelopment;
-  }
-  else {
+  else
     return false;
-  }
 }
 
 export function captureEvent(eventType: string, eventProps?: Record<string,any>) {
@@ -71,7 +67,6 @@ export function captureEvent(eventType: string, eventProps?: Record<string,any>)
         }
       }
       if (getShowAnalyticsDebug()) {
-        console.log('log anal')
         serverConsoleLogAnalyticsEvent(event);
       }
       if (AnalyticsUtil.serverWriteEvent) {

--- a/packages/lesswrong/lib/analyticsEvents.tsx
+++ b/packages/lesswrong/lib/analyticsEvents.tsx
@@ -9,7 +9,7 @@ import { DatabasePublicSetting } from './publicSettings';
 import { getPublicSettingsLoaded } from './settingsCache';
 import * as _ from 'underscore';
 
-const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug ", "dev");
+const showAnalyticsDebug = new DatabasePublicSetting<"never"|"dev"|"always">("showAnalyticsDebug", "dev");
 
 addGraphQLSchema(`
   type AnalyticsEvent {
@@ -45,13 +45,17 @@ export const AnalyticsUtil: any = {
 function getShowAnalyticsDebug() {
   if (isAnyTest)
     return false;
-  const debug = getPublicSettingsLoaded() ? showAnalyticsDebug.get() : "dev";
-  if (debug==="always")
+  const loaded = getPublicSettingsLoaded()
+  const debug = loaded ? showAnalyticsDebug.get() : "dev";
+  if (debug==="always") {
     return true;
-  else if (debug==="dev")
+  }
+  else if (debug==="dev") {
     return isDevelopment;
-  else
+  }
+  else {
     return false;
+  }
 }
 
 export function captureEvent(eventType: string, eventProps?: Record<string,any>) {
@@ -67,6 +71,7 @@ export function captureEvent(eventType: string, eventProps?: Record<string,any>)
         }
       }
       if (getShowAnalyticsDebug()) {
+        console.log('log anal')
         serverConsoleLogAnalyticsEvent(event);
       }
       if (AnalyticsUtil.serverWriteEvent) {

--- a/packages/lesswrong/lib/vulcan-lib/components.tsx
+++ b/packages/lesswrong/lib/vulcan-lib/components.tsx
@@ -137,6 +137,10 @@ export function registerComponent<PropType>(name: string, rawComponent: React.Co
     options,
   };
   
+  // The Omit is a hacky way of ensuring that hocs props are omitted from the
+  // ones required to be passed in by parent components. It doesn't work for
+  // hocs that share prop names that overlap with actually passed-in props, like
+  // `location`.
   return (null as any as React.ComponentType<Omit<PropType,"classes">>);
 }
 

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -34,7 +34,6 @@ import crypto from 'crypto';
 import expressSession from 'express-session';
 import MongoStore from 'connect-mongo'
 import { ckEditorTokenHandler } from './ckEditorToken';
-import { DatabaseServerSetting } from './databaseSettings';
 import { getMongoClient } from '../lib/mongoCollection';
 
 const loadClientBundle = () => {

--- a/packages/lesswrong/server/apolloServer.ts
+++ b/packages/lesswrong/server/apolloServer.ts
@@ -24,7 +24,7 @@ import path from 'path'
 import { getPublicSettingsLoaded } from '../lib/settingsCache';
 import { embedAsGlobalVar } from './vulcan-lib/apollo-ssr/renderUtil';
 import { addStripeMiddleware } from './stripeMiddleware';
-import { addAuthMiddlewares } from './authenticationMiddlewares';
+import { addAuthMiddlewares, expressSessionSecretSetting } from './authenticationMiddlewares';
 import { addSentryMiddlewares } from './logging';
 import { addClientIdMiddleware } from './clientIdMiddleware';
 import { addStaticRoute } from './vulcan-lib/staticRoutes';
@@ -36,8 +36,6 @@ import MongoStore from 'connect-mongo'
 import { ckEditorTokenHandler } from './ckEditorToken';
 import { DatabaseServerSetting } from './databaseSettings';
 import { getMongoClient } from '../lib/mongoCollection';
-
-const expressSessionSecretSetting = new DatabaseServerSetting<string | null>('expressSessionSecret', null)
 
 const loadClientBundle = () => {
   const bundlePath = path.join(__dirname, "../../client/js/bundle.js");

--- a/packages/lesswrong/server/authenticationMiddlewares.ts
+++ b/packages/lesswrong/server/authenticationMiddlewares.ts
@@ -152,7 +152,7 @@ async function syncOAuthUser(user: DbUser, profile: Profile): Promise<DbUser> {
 function saveReturnTo(req: any): void {
   if (!expressSessionSecretSetting.get()) return
   let { returnTo } = req.query
-  if (!returnTo) return
+  if (!returnTo || !req.session) return
   
   req.session.loginReturnTo = {
     path: returnTo,
@@ -169,7 +169,7 @@ function saveReturnTo(req: any): void {
  * Assumes that the initial request was made with a returnTo query parameter
  */
 function getReturnTo(req: any): string {
-  if (!expressSessionSecretSetting.get() || !req.session.loginReturnTo) return '/'
+  if (!expressSessionSecretSetting.get() || !req.session?.loginReturnTo) return '/'
   if (moment(req.session.loginReturnTo.expiration) < moment()) return '/'
   return req.session.loginReturnTo.path
 }


### PR DESCRIPTION
Currently:
 * You're looking at a great post you want to upvote
 * You upvote the post or you click the login button in the top-right
 * You log in with google/facebook/github/EA.org
 * You're redirected to the homepage, and have to navigate back to the post
 
This PR saves a desired redirect in the session, so that when you get back to /auth/[oauth]/callback, we can redirect you to the right place. It uses a query parameter in the link to /auth/[oauth] to determine the desired redirect.

The PR **does not** implement this for LW. LW does not currently use express-session, and I don't know if y'all wanted to (and it was work), so I also didn't make query parameters for y'all. If you would like to use it, you'll need to:
 * Add expressSessionSecret to your database server settings
 * Add query parameters when you send users to /auth/[oauth]