### PR TITLE
Run lint on Github CI

### DIFF
--- a/.github/workflows/unitTests.yaml
+++ b/.github/workflows/unitTests.yaml
@@ -20,6 +20,8 @@ jobs:
     - name: yarn install
       run: yarn install
 
+    - name: yarn run lint
+      run: yarn run lint
+
     - name: yarn run test-ci
       run: yarn run test-ci
-


### PR DESCRIPTION
Add a step for running lint to the Github test yaml. Was discussed on slack. It adds about 100s to the testing time, which is unfortunately, but in my view worth it.