### PR TITLE
Make userId hidden on messages

### DIFF
--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -12,6 +12,7 @@ const schema: SchemaType<DbMessage> = {
     viewableBy: ['members'],
     insertableBy: ['members'],
     optional: true,
+    hidden: true,
   },
   createdAt: {
     optional: true,


### PR DESCRIPTION
Adding this to prevent a userId field from showing up on the conversation screen.

![image](https://user-images.githubusercontent.com/25752873/125530941-877a5bcb-6a26-4ddd-8b24-198dacde6fc4.png)
