### PR TITLE
Comment out all stripe stuff from BookCheckout

### DIFF
--- a/packages/lesswrong/components/review/BookCheckout.tsx
+++ b/packages/lesswrong/components/review/BookCheckout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { loadStripe } from "@stripe/stripe-js";
+// import { loadStripe } from "@stripe/stripe-js";
 import { registerComponent } from "../../lib/vulcan-lib";
 import { DatabasePublicSetting } from "../../lib/publicSettings";
 import { useTracking } from "../../lib/analyticsEvents";
@@ -56,13 +56,13 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 // Make sure to call `loadStripe` outside of a component’s render to avoid
 // recreating the `Stripe` object on every render.
-const stripePublicKey = stripePublicKeySetting.get()
-const stripePromise = stripePublicKey && loadStripe(stripePublicKey);
+// const stripePublicKey = stripePublicKeySetting.get()
+// const stripePromise = stripePublicKey && loadStripe(stripePublicKey);
 const amazonLink = "https://www.amazon.com/Map-that-Reflects-Territory-LessWrong/dp/1736128507"
 
-const ProductDisplay = ({ handleClickAmazon, handleClickStripe, text="Buy", classes }: {
+const ProductDisplay = ({ handleClickAmazon, text="Buy", classes }: {
   handleClickAmazon: (event: any)=>void,
-  handleClickStripe: (event: any)=>void,
+  // handleClickStripe: (event: any)=>void,
   text?: string,
   classes: ClassesType,
 }) => {
@@ -119,7 +119,7 @@ export default function BookCheckout({classes, ignoreMessages = false, text}: {c
     { (message && !ignoreMessages) ? (
       <Message message={message} classes={classes} />
     ) : (
-      <ProductDisplay handleClickAmazon={handleClickAmazon} handleClickStripe={handleClickStripe} text={text} classes={classes}/>
+      <ProductDisplay handleClickAmazon={handleClickAmazon}  text={text} classes={classes}/>
     ) }
   </div>
 }


### PR DESCRIPTION
The Stripe button code requires pulling the Stripe library that adds a few percent into the bundle. On the other hand, we might use the code again.

I've just commented out the Stripe stuff. It's the easiest way on net that I can see to do it.