### PR TITLE
Hide userId field in PM form

### DIFF
--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -11,6 +11,7 @@ const schema: SchemaType<DbMessage> = {
     }),
     viewableBy: ['members'],
     insertableBy: ['members'],
+    hidden: true,
     optional: true,
   },
   createdAt: {

--- a/packages/lesswrong/lib/collections/messages/schema.ts
+++ b/packages/lesswrong/lib/collections/messages/schema.ts
@@ -10,8 +10,7 @@ const schema: SchemaType<DbMessage> = {
       nullable: true
     }),
     viewableBy: ['members'],
-    insertableBy: ['members'],
-    hidden: true,
+    insertableBy: ['admins'],
     optional: true,
   },
   createdAt: {


### PR DESCRIPTION
#4093 made it so that users could now set the `userId` of messages they were sending, which isn't intended behavior, and also makes the form look weird and broken. This fixes this.