### PR TITLE
Bugfix roundup

### DIFF
--- a/packages/lesswrong/components/localGroups/EventTime.tsx
+++ b/packages/lesswrong/components/localGroups/EventTime.tsx
@@ -38,7 +38,7 @@ const EventTime = ({post, dense=false}: {
 
   // Neither start nor end time specified
   if (!start && !end) {
-    return <>"TBD"</>;
+    return <>TBD</>;
   }
   // Start time specified, end time missing. Use
   // moment.calendar, which has a bunch of its own special

--- a/packages/lesswrong/components/users/UsersProfile.tsx
+++ b/packages/lesswrong/components/users/UsersProfile.tsx
@@ -169,11 +169,11 @@ const UsersProfileFn = ({terms, slug, classes}: {
           </span>
         </Tooltip>
 
-        <Tooltip title={`${tagRevisionCount} wiki edit${tagRevisionCount === 1 ? '' : 's'}`}>
+        <Tooltip title={`${tagRevisionCount||0} wiki edit${tagRevisionCount === 1 ? '' : 's'}`}>
           <span className={classes.userMetaInfo}>
             <PencilIcon className={classNames(classes.icon, classes.specificalz)}/>
             <Components.MetaInfo>
-              { tagRevisionCount }
+              { tagRevisionCount||0 }
             </Components.MetaInfo>
           </span>
         </Tooltip>

--- a/packages/lesswrong/lib/collections/posts/formGroups.ts
+++ b/packages/lesswrong/lib/collections/posts/formGroups.ts
@@ -51,6 +51,7 @@ export const formGroups: Partial<Record<string,FormGroup>> = {
   highlight: {
     order: 21,
     name: "highlight",
-    label: "Highlight"
+    label: "Highlight",
+    startCollapsed: true,
   }
 };

--- a/packages/lesswrong/server/emailComponents/EventInRadiusEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventInRadiusEmail.tsx
@@ -3,6 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import moment from '../../lib/moment-timezone';
+import './EmailPostDate';
 
 const eventTimeFormat = "Do MMMM YYYY h:mm A"
 
@@ -26,9 +27,10 @@ const EventInRadiusEmail = ({openingSentence, postId}: {
     <p>
       Location: {post.location}
     </p>
-    <p>
+    {!post.localStartTime && !post.localEndTime && <p>Time: TBD</p>}
+    {post.localStartTime && <p>
       Start Time: {moment(post.localStartTime).utc().format(eventTimeFormat)}
-    </p>
+    </p>}
     {post.localEndTime && <p>
       End Time: {moment(post.localEndTime).utc().format(eventTimeFormat)}
     </p>}

--- a/packages/lesswrong/server/notificationCallbacks.tsx
+++ b/packages/lesswrong/server/notificationCallbacks.tsx
@@ -27,10 +27,18 @@ import { Components } from '../lib/vulcan-lib/components';
 import { createMutator, updateMutator } from './vulcan-lib/mutators';
 import { getCollectionHooks } from './mutationCallbacks';
 import { asyncForeachSequential } from '../lib/utils/asyncUtils';
+import { CallbackHook } from '../lib/vulcan-lib/callbacks';
 
 import React from 'react';
 import keyBy from 'lodash/keyBy';
 import TagRels from '../lib/collections/tagRels/collection';
+
+// Callback for a post being published. This is distinct from being created in
+// that it doesn't fire on draft posts, and doesn't fire on posts that are awaiting
+// moderator approval because they're a user's first post (but does fire when
+// they're approved).
+export const postPublishedCallback = new CallbackHook<[DbPost]>("post.published");
+
 
 // Return a list of users (as complete user objects) subscribed to a given
 // document. This is the union of users who have subscribed to it explicitly,
@@ -546,7 +554,7 @@ async function getUsersWhereLocationIsInNotificationRadius(location): Promise<Ar
 }
 ensureIndex(Users, {nearbyEventsNotificationsMongoLocation: "2dsphere"}, {name: "users.nearbyEventsNotifications"})
 
-getCollectionHooks("Posts").createAsync.add(async function PostsNewMeetupNotifications ({document: newPost}: {document: DbPost}) {
+postPublishedCallback.add(async function PostsNewMeetupNotifications (newPost: DbPost) {
   if (newPost.isEvent && newPost.mongoLocation && !newPost.draft) {
     const usersToNotify = await getUsersWhereLocationIsInNotificationRadius(newPost.mongoLocation)
     const userIds = usersToNotify.map(user => user._id)


### PR DESCRIPTION
* Fix user pages saying "null wiki edits" instead of 0
* Event-in-radius email can show TDB date
* Delay post-in-radius notification for moderator-approval-required posts until approved
* Remove spurious quotes around "TBD" on event pages
* Highlight override (admin-only field) on event-creation form starts collapsed
