### PR TITLE
Allow Admins to Edit Author ID

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -273,7 +273,6 @@ const schema: SchemaType<DbPost> = {
     viewableBy: ['guests'],
     editableBy: ['admins'],
     insertableBy: ['admins'],
-    hidden: true,
     
     group: formGroups.adminOptions,
   },


### PR DESCRIPTION
Aaron uses this extensively. It's unfortunate that it's not a better user experience, but it's important that he can do it.

The capability to do so was (inadvertently?) removed in this PR: https://github.com/LessWrong2/Lesswrong2/pull/4093/files .

I've tested that the editing works.