### PR TITLE
Fix material-UI being imported in a way that breaks tree-shaking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
     "no-restricted-imports": ["error", {"paths": [
       { name: "lodash", message: "Don't import all of lodash, import a specific lodash function, eg lodash/sumBy" },
       { name: "@material-ui", message: "Don't import all of material-ui/icons" },
+      { name: "@material-ui/core", message: "Don't import all of material-ui/core" },
       { name: "@material-ui/icons", message: "Don't import all of material-ui/icons" },
       { name: "@material-ui/core/Hidden", message: "Don't use material-UI's Hidden component, it's subtly broken; use breapoints and JSS styles instead" },
       { name: "@material-ui/core/Typography", message: "Don't use material-UI's Typography component; use Components.LWTypography or JSS styles" },

--- a/packages/lesswrong/components/common/Typography.tsx
+++ b/packages/lesswrong/components/common/Typography.tsx
@@ -17,6 +17,10 @@ const styles = (theme: ThemeType): JssStyles => ({
   subheading: theme.typography.subheading,
   body2: theme.typography.body2,
   body1: theme.typography.body1,
+  
+  gutterBottom: {
+    marginBottom: "0.35em",
+  },
 });
 
 type VariantString = "display4"|"display3"|"display2"|"display1"|"headline"|"title"|"subheading"|"body2"|"body1"
@@ -33,17 +37,18 @@ const variantToDefaultComponent: Record<VariantString, string> = {
   body1: 'p',
 };
 
-const Typography = ({children, variant, component, className, onClick, classes}: {
+const Typography = ({children, variant, component, className, onClick, gutterBottom=false, classes}: {
   children: React.ReactNode,
   variant: VariantString,
   component?: "div"|"span"|"label"|"aside",
   className?: string,
   onClick?: any,
+  gutterBottom?: boolean,
   classes: ClassesType,
 }) => {
   const Component: any = component || variantToDefaultComponent[variant] || "span";
   
-  return <Component className={classNames(classes.root, classes[variant], className)} onClick={onClick}>
+  return <Component className={classNames(classes.root, classes[variant], className, {[classes.gutterBottom]: gutterBottom})} onClick={onClick}>
     {children}
   </Component>
 }

--- a/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
+++ b/packages/lesswrong/components/ea-forum/EASequencesHome.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { postBodyStyles } from '../../themes/stylePiping';
 import { AnalyticsContext } from "../../lib/analyticsEvents";
-import { Typography } from '@material-ui/core';
 
 const styles = (theme: ThemeType): JssStyles => ({
   description: {
@@ -14,7 +13,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 const EASequencesHome = ({classes}) => {
 
-  const { SingleColumnSection, SectionTitle, SequencesNewButton } = Components
+  const { SingleColumnSection, SectionTitle, SequencesNewButton, Typography } = Components
   return <AnalyticsContext pageContext="eaSequencesHome">
     <SingleColumnSection>
       <SectionTitle  title="Sequences" >

--- a/packages/lesswrong/components/recommendations/RecommendationsList.tsx
+++ b/packages/lesswrong/components/recommendations/RecommendationsList.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useRecommendations } from './withRecommendations';
-import { Typography } from '@material-ui/core'
 import type { RecommendationsAlgorithm } from '../../lib/collections/users/recommendationSettings';
 
 const RecommendationsList = ({algorithm}: {
   algorithm: RecommendationsAlgorithm,
 }) => {
-  const { PostsItem2, PostsLoading } = Components;
+  const { PostsItem2, PostsLoading, Typography } = Components;
   const {recommendationsLoading, recommendations} = useRecommendations(algorithm);
 
   if (recommendationsLoading || !recommendations)
@@ -17,7 +16,7 @@ const RecommendationsList = ({algorithm}: {
     {recommendations.map(post =>
       <PostsItem2 post={post} key={post._id}/>)}
     {recommendations.length===0 &&
-      <Typography><small>There are no more recommendations left.</small></Typography>}
+      <Typography variant="body1"><small>There are no more recommendations left.</small></Typography>}
   </div>
 }
 

--- a/packages/lesswrong/components/review/ReviewVotingPage.tsx
+++ b/packages/lesswrong/components/review/ReviewVotingPage.tsx
@@ -6,7 +6,7 @@ import { useUpdate } from '../../lib/crud/withUpdate';
 import { updateEachQueryResultOfType, handleUpdateMutation } from '../../lib/crud/cacheUpdates';
 import { useMulti } from '../../lib/crud/withMulti';
 import { useMutation, gql } from '@apollo/client';
-import { Paper } from '@material-ui/core';
+import Paper from '@material-ui/core/Paper';
 import { useCurrentUser } from '../common/withUser';
 import classNames from 'classnames';
 import * as _ from "underscore"

--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUsersInfo.tsx
@@ -19,7 +19,8 @@ import Button from '@material-ui/core/Button';
 import EditIcon from '@material-ui/icons/Edit';
 import * as _ from 'underscore';
 import { DatabasePublicSetting } from '../../lib/publicSettings';
-import { Select, MenuItem } from '@material-ui/core';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 import Input from '@material-ui/core/Input';
 import { userCanDo } from '../../lib/vulcan-users/permissions';
 

--- a/packages/lesswrong/components/tagging/TagFilterSettings.tsx
+++ b/packages/lesswrong/components/tagging/TagFilterSettings.tsx
@@ -9,7 +9,7 @@ import { useCurrentUser } from '../common/withUser';
 import { tagStyle } from './FooterTag';
 import { filteringStyles } from './FilterMode';
 import { commentBodyStyles } from '../../themes/stylePiping';
-import { Card } from '@material-ui/core';
+import Card from '@material-ui/core/Card';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {

--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -1,5 +1,8 @@
 import { gql, useMutation } from "@apollo/client";
-import { Button, Checkbox, FormControlLabel, TextField, Typography } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import TextField from "@material-ui/core/TextField";
 import React, { useState } from "react";
 import { forumTypeSetting, siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
@@ -54,7 +57,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
     }
   `, {refetchQueries: ['getCurrentUser']})
   const {flash} = useMessages();
-  const {SingleColumnSection} = Components
+  const {SingleColumnSection, Typography} = Components
 
   function validateUsername(username: string): void {
     if (username.length === 0) {

--- a/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
+++ b/packages/lesswrong/components/walledGarden/GardenCodeWidget.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { registerComponent, Components, getFragment } from '../../lib/vulcan-lib';
 import { GardenCodes } from "../../lib/collections/gardencodes/collection";
-import {Button, TextField} from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import {commentBodyStyles} from "../../themes/stylePiping";
 import { useTracking } from "../../lib/analyticsEvents";

--- a/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenHome.tsx
@@ -1,4 +1,3 @@
-import { Typography } from '@material-ui/core';
 import React from 'react';
 import { useMulti } from '../../lib/crud/withMulti';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
@@ -27,7 +26,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 })
 
 const WalledGardenHome = ({classes}:{classes:ClassesType}) => {
-  const { SingleColumnSection, Error404 } = Components
+  const { SingleColumnSection, Error404, Typography } = Components
   const currentUser = useCurrentUser()
   const { results: users, totalCount } = useMulti({
     terms: {

--- a/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
+++ b/packages/lesswrong/components/walledGarden/WalledGardenPortalBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { registerComponent, Components } from '../../lib/vulcan-lib';
-import { Typography } from "@material-ui/core";
 import {commentBodyStyles } from "../../themes/stylePiping";
 import { useCurrentUser } from '../common/withUser';
 import { gatherTownURL } from "./GatherTownIframeWrapper";
@@ -74,7 +73,7 @@ const styles = (theme: ThemeType): JssStyles => ({
 
 
 export const WalledGardenPortalBar = ({iframeRef, classes}:{iframeRef:React.RefObject<HTMLIFrameElement|null>, classes:ClassesType}) => {
-  const { GardenCodeWidget, GardenCodesList, PomodoroWidget, } = Components
+  const { GardenCodeWidget, GardenCodesList, PomodoroWidget, Typography } = Components
 
   const currentUser =  useCurrentUser()
 


### PR DESCRIPTION
Importing `@material-ui/core` causes unused parts of material-UI to get included in the bundle. Don't do that. Reduces (uncompressed, unminified) bundle size from 12.37 to 12.15MB (~2%).