### PR TITLE
Add an uncurated filter to allPosts

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -60,6 +60,9 @@ export const filters: Record<string,any> = {
   "curated": {
     curatedDate: {$gt: new Date(0)}
   },
+  "uncurated": {
+    curatedDate: viewFieldNullOrMissing
+  },
   "nonSticky": {
     sticky: false,
   },


### PR DESCRIPTION
Added this to make it easier to query for potential posts to curate. It's currently just a secret additional filter we can enter into the allPosts url parameters.