### PR TITLE
New Auth0 users are checked against existing users by a case-insensitive email search

### DIFF
--- a/packages/lesswrong/lib/collections/users/views.ts
+++ b/packages/lesswrong/lib/collections/users/views.ts
@@ -41,6 +41,9 @@ ensureIndex(Users, {isAdmin:1});
 ensureIndex(Users, {"services.github.id":1}, {unique:true,sparse:1});
 ensureIndex(Users, {createdAt:-1,_id:-1});
 
+// Case-insensitive email index
+ensureIndex(Users, {'emails.address': 1}, {sparse: 1, unique: true, collation: { locale: 'en', strength: 2 }})
+
 const termsToMongoSort = (terms: UsersViewTerms) => {
   if (!terms.sort)
     return undefined;


### PR DESCRIPTION
When users sign in/up for the first time using the new login system, we take their email address and attempt to match it against an existing user in the DB. In the case of a match, we merge the accounts. Historically, the Forum used case-sensitive email address, like LW, probably because it was easier. Un(?)fortunately Auth0 downcases the users email address. So even if the users puts their uppercase email into Auth0, we'll always get a lowercase email from Auth0 once their authenticated. So now comes the time where we need to do case-insensitive email lookups.

The way to do case-insensitive lookups is to specify the collation option to the mongodb find command. You could use a regex for it, but there's no way to create an index (see below) for the regex search. The strength of the collation is telling mongo what types of character differences to pay attention to. Strength 1 would be the maximally indifferent option, not even caring about the difference between é and e. Strength 2 cares about accents, but not case. 3, 4 and 5 are stricter still, and mostly apply to other languages.

We add an index on users, to make the case-insensitive lookups efficient. The index is the same as the existing email index, but organizes them with our specified collation.

Note for LessWrong (@Discordius, @darkruby501, @jimrandomh), you might want to implement something like this. Case sensitive emails were never a good idea.