### PR TITLE
Community page fixes

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityMap.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityMap.tsx
@@ -11,13 +11,10 @@ import { mapboxAPIKeySetting } from '../../lib/publicSettings';
 import { forumTypeSetting } from '../../lib/instanceSettings';
 import PersonIcon from '@material-ui/icons/PersonPin';
 
-export const mapsHeight = 440
-const mapsWidth = "100vw"
-
 const styles = createStyles((theme: ThemeType): JssStyles => ({
   root: {
-    width: mapsWidth,
-    height: mapsHeight,
+    width: "100%",
+    height: 440,
     // We give this a negative margin to make sure that the map is flush with the top
     marginTop: -50,
     [theme.breakpoints.down('sm')]: {

--- a/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
+++ b/packages/lesswrong/components/localGroups/LocalGroupsList.tsx
@@ -8,9 +8,9 @@ const styles = createStyles((theme: ThemeType): JssStyles => ({
     flexGrow: 1,
     textAlign: "left",
     '&:after': {
-      content: "''",
-      marginLeft: 0,
-      marginRight: 0,
+      content: "'' !important",
+      marginLeft: "0 !important",
+      marginRight: "0 !important",
     }
   },
   localGroups: {

--- a/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
+++ b/packages/lesswrong/components/localGroups/StyledMapPopup.tsx
@@ -22,7 +22,7 @@ export const styles = createStyles((theme: ThemeType): JssStyles => ({
     marginTop: 10,
     marginBottom: 10,
     maxHeight: 150,
-    overflowY: 'scroll'
+    overflowY: 'auto'
   },
   contactInfo: {
     marginBottom: "10px",

--- a/packages/lesswrong/components/posts/PostsItemDate.tsx
+++ b/packages/lesswrong/components/posts/PostsItemDate.tsx
@@ -52,7 +52,10 @@ const PostsItemDate = ({post, classes}: {
       </span>}
     >
       <PostsItem2MetaInfo className={classes.startTime}>
-        <FormatDate date={post.startTime} format={"MMM Do"} tooltip={false}/>
+        {moment(post.startTime).format("YYYY")===moment().format("YYYY")
+          ? <FormatDate date={post.startTime} format={"MMM Do"} tooltip={false}/>
+          : <FormatDate date={post.startTime} format={"YYYY MMM Do"} tooltip={false}/>
+        }
       </PostsItem2MetaInfo>
     </LWTooltip>
   }


### PR DESCRIPTION
* On event postitems, show year if it's not the current year
* Fix there being a horizontal scrollbar on the community page
* Fix spurious scrollbars on Mapbox click popups
* Remove a spurious bullet after the Load More link on the local groups list