### PR TITLE
fix-search-word-break

### DIFF
--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -11,7 +11,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   },
   snippet: {
     marginTop: theme.spacing.unit,
-    wordBreak: "break-word",
+    overflowWrap: "break-word",
     ...theme.typography.body2
   }
 })

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -13,7 +13,8 @@ const styles = (theme: ThemeType): JssStyles => ({
       borderBottomColor: grey[200],
       '&:hover': {
         backgroundColor: grey[100],
-      }
+      },
+      wordBreak: "break-word"
     },
   })
 

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -14,7 +14,7 @@ const styles = (theme: ThemeType): JssStyles => ({
       '&:hover': {
         backgroundColor: grey[100],
       },
-      wordBreak: "break-word"
+      overflowWrap: "break-word"
     },
   })
 


### PR DESCRIPTION
Fixes bug whereby search preview extends outside of div.

![image](https://user-images.githubusercontent.com/7250541/128753433-acdb659c-8384-4a98-aa46-f4b30d366963.png)
