### PR TITLE
Log field changes to LWEvents

### DIFF
--- a/packages/lesswrong/lib/collections/bans/collection.ts
+++ b/packages/lesswrong/lib/collections/bans/collection.ts
@@ -27,6 +27,7 @@ export const Bans: BansCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Bans'),
   mutations: getDefaultMutations('Bans', options),
+  logChanges: true,
 });
 
 addUniversalFields({collection: Bans})

--- a/packages/lesswrong/lib/collections/books/collection.ts
+++ b/packages/lesswrong/lib/collections/books/collection.ts
@@ -9,6 +9,7 @@ export const Books: BooksCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Books'),
   mutations: getDefaultMutations('Books'),
+  logChanges: true,
 });
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/chapters/collection.ts
+++ b/packages/lesswrong/lib/collections/chapters/collection.ts
@@ -35,6 +35,7 @@ export const Chapters: ChaptersCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Chapters'),
   mutations: getDefaultMutations('Chapters', options),
+  logChanges: true,
 })
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/collections/collection.ts
+++ b/packages/lesswrong/lib/collections/collections/collection.ts
@@ -9,6 +9,7 @@ export const Collections: CollectionsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Collections'),
   mutations: getDefaultMutations('Collections'),
+  logChanges: true,
 });
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/comments/collection.ts
+++ b/packages/lesswrong/lib/collections/comments/collection.ts
@@ -48,6 +48,7 @@ export const Comments: ExtendedCommentsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Comments'),
   mutations: getDefaultMutations('Comments', commentMutationOptions),
+  logChanges: true,
 });
 
 Comments.checkAccess = async (currentUser: DbUser|null, comment: DbComment, context: ResolverContext|null): Promise<boolean> => {

--- a/packages/lesswrong/lib/collections/gardencodes/collection.ts
+++ b/packages/lesswrong/lib/collections/gardencodes/collection.ts
@@ -193,7 +193,8 @@ export const GardenCodes: GardenCodesCollection = createCollection({
   typeName: 'GardenCode',
   schema,
   resolvers: getDefaultResolvers('GardenCodes'),
-  mutations: getDefaultMutations('GardenCodes') //, options),
+  mutations: getDefaultMutations('GardenCodes'), //, options),
+  logChanges: true,
 });
 
 addUniversalFields({collection: GardenCodes})

--- a/packages/lesswrong/lib/collections/localgroups/collection.ts
+++ b/packages/lesswrong/lib/collections/localgroups/collection.ts
@@ -31,7 +31,8 @@ export const Localgroups: LocalgroupsCollection = createCollection({
   typeName: 'Localgroup',
   schema,
   resolvers: getDefaultResolvers('Localgroups'),
-  mutations: getDefaultMutations('Localgroups', options)
+  mutations: getDefaultMutations('Localgroups', options),
+  logChanges: true,
 });
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/messages/collection.ts
+++ b/packages/lesswrong/lib/collections/messages/collection.ts
@@ -35,6 +35,9 @@ export const Messages: MessagesCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Messages'),
   mutations: getDefaultMutations('Messages', options),
+  // Don't log things related to Messages to LWEvents, to keep LWEvents relatively
+  // free of confidential stuff that admins shouldn't look at.
+  logChanges: false,
 });
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/notifications/collection.ts
+++ b/packages/lesswrong/lib/collections/notifications/collection.ts
@@ -27,6 +27,7 @@ export const Notifications: NotificationsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Notifications'),
   mutations: getDefaultMutations('Notifications', options),
+  logChanges: false,
 });
 
 addUniversalFields({collection: Notifications})

--- a/packages/lesswrong/lib/collections/postRelations/collection.ts
+++ b/packages/lesswrong/lib/collections/postRelations/collection.ts
@@ -6,7 +6,8 @@ export const PostRelations: PostRelationsCollection = createCollection({
   collectionName: 'PostRelations',
   typeName: 'PostRelation',
   schema,
-  resolvers: getDefaultResolvers('PostRelations')
+  resolvers: getDefaultResolvers('PostRelations'),
+  logChanges: true,
 });
 
 addUniversalFields({collection: PostRelations})

--- a/packages/lesswrong/lib/collections/posts/collection.ts
+++ b/packages/lesswrong/lib/collections/posts/collection.ts
@@ -38,6 +38,7 @@ export const Posts: ExtendedPostsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Posts'),
   mutations: getDefaultMutations('Posts', options),
+  logChanges: true,
 });
 
 addUniversalFields({collection: Posts})

--- a/packages/lesswrong/lib/collections/readStatus/collection.ts
+++ b/packages/lesswrong/lib/collections/readStatus/collection.ts
@@ -41,7 +41,8 @@ const schema: SchemaType<DbReadStatus> = {
 export const ReadStatuses: ReadStatusesCollection = createCollection({
   collectionName: "ReadStatuses",
   typeName: "ReadStatus",
-  schema
+  schema,
+  logChanges: false,
 });
 
 addUniversalFields({collection: ReadStatuses});

--- a/packages/lesswrong/lib/collections/reports/collection.ts
+++ b/packages/lesswrong/lib/collections/reports/collection.ts
@@ -10,6 +10,7 @@ const Reports: ReportsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('Reports'),
   mutations: getDefaultMutations('Reports'),
+  logChanges: true,
 });
 
 addUniversalFields({collection: Reports})

--- a/packages/lesswrong/lib/collections/rssfeeds/collection.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/collection.ts
@@ -29,6 +29,7 @@ export const RSSFeeds: RSSFeedsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('RSSFeeds'),
   mutations: getDefaultMutations('RSSFeeds', options),
+  logChanges: true,
 });
 
 addUniversalFields({collection: RSSFeeds})

--- a/packages/lesswrong/lib/collections/rssfeeds/schema.ts
+++ b/packages/lesswrong/lib/collections/rssfeeds/schema.ts
@@ -72,6 +72,7 @@ const schema: SchemaType<DbRSSFeed> = {
     insertableBy: ['members'],
     editableBy: ['admins'],
     optional: true,
+    logChanges: false,
   },
   setCanonicalUrl: {
     type: Boolean,

--- a/packages/lesswrong/lib/collections/sequences/collection.ts
+++ b/packages/lesswrong/lib/collections/sequences/collection.ts
@@ -32,7 +32,8 @@ export const Sequences: ExtendedSequencesCollection = createCollection({
   typeName: 'Sequence',
   schema,
   resolvers: getDefaultResolvers('Sequences'),
-  mutations: getDefaultMutations('Sequences', options)
+  mutations: getDefaultMutations('Sequences', options),
+  logChanges: true,
 })
 
 makeEditable({

--- a/packages/lesswrong/lib/collections/tagFlags/collection.ts
+++ b/packages/lesswrong/lib/collections/tagFlags/collection.ts
@@ -84,6 +84,7 @@ export const TagFlags: TagFlagsCollection = createCollection({
   schema,
   resolvers: getDefaultResolvers('TagFlags'),
   mutations: getDefaultMutations('TagFlags', options),
+  logChanges: true,
 });
 
 addUniversalFields({collection: TagFlags})

--- a/packages/lesswrong/lib/collections/tags/collection.ts
+++ b/packages/lesswrong/lib/collections/tags/collection.ts
@@ -30,6 +30,7 @@ export const Tags: ExtendedTagsCollection = createCollection({
       return false;
     },
   }),
+  logChanges: true,
 });
 
 Tags.checkAccess = async (currentUser: DbUser|null, tag: DbTag, context: ResolverContext|null): Promise<boolean> => {

--- a/packages/lesswrong/lib/collections/users/collection.ts
+++ b/packages/lesswrong/lib/collections/users/collection.ts
@@ -31,6 +31,7 @@ export const Users: ExtendedUsersCollection = createCollection({
     // Nobody can delete users
     removeCheck: () => false
   }),
+  logChanges: true,
 });
 
 

--- a/packages/lesswrong/lib/collections/users/custom_fields.ts
+++ b/packages/lesswrong/lib/collections/users/custom_fields.ts
@@ -317,6 +317,7 @@ addFieldsDict(Users, {
     canUpdate: userOwns,
     canCreate: 'guests',
     hidden: true,
+    logChanges: false,
   },
 
   // Bio (Markdown version)
@@ -683,6 +684,7 @@ addFieldsDict(Users, {
     canCreate: ['guests'],
     canUpdate: [userOwns, 'admins'],
     canRead: [userOwns, 'admins'],
+    logChanges: false,
   },
 
   // If, the last time you opened the karma-change notifier, you saw more than
@@ -695,6 +697,7 @@ addFieldsDict(Users, {
     canCreate: ['guests'],
     canUpdate: [userOwns, 'admins'],
     canRead: [userOwns, 'admins'],
+    logChanges: false,
   },
 
   // Email settings

--- a/packages/lesswrong/lib/editor/make_editable.tsx
+++ b/packages/lesswrong/lib/editor/make_editable.tsx
@@ -125,6 +125,7 @@ export const makeEditable = <T extends DbObject>({collection, options = {}}: {
     [fieldName || "contents"]: {
       type: RevisionStorageType,
       optional: true,
+      logChanges: false, //Logged via Revisions rather than LWEvents
       typescriptType: "EditableFieldContents",
       group: formGroup,
       ...permissions,
@@ -207,6 +208,7 @@ export const makeEditable = <T extends DbObject>({collection, options = {}}: {
         viewableBy: 'guests',
         optional: true,
         hidden: true,
+        denormalized: true,
       },
       "pingbacks.$": {
         type: Array,

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -53,6 +53,7 @@ interface CollectionOptions {
   resolvers: any
   interfaces: Array<string>
   description: string
+  logChanges: boolean
 }
 
 interface FindResult<T> {

--- a/packages/lesswrong/lib/types/schemaTypes.ts
+++ b/packages/lesswrong/lib/types/schemaTypes.ts
@@ -32,6 +32,7 @@ interface CollectionFieldSpecification<T extends DbObject> {
   needsUpdate?: (doc: Partial<T>) => boolean,
   getValue?: (doc: T, context: ResolverContext) => any,
   foreignKey?: any,
+  logChanges?: boolean,
   
   min?: number,
   max?: number,

--- a/packages/lesswrong/lib/utils/schemaUtils.ts
+++ b/packages/lesswrong/lib/utils/schemaUtils.ts
@@ -222,6 +222,11 @@ SimpleSchema.extendOptions(['getValue'])
 // `Vulcan.recomputeDenormalizedValues` in the Meteor shell
 SimpleSchema.extendOptions(['canAutoDenormalize'])
 
+// Whether to log changes to this field to the LWEvents collection. If undefined
+// (neither true nor false), will be logged if the logChanges option is set on
+// the collection and the denormalized option is false.
+SimpleSchema.extendOptions(['logChanges'])
+
 
 // Helper function to add all the correct callbacks and metadata for a field
 // which is denormalized, where its denormalized value is a function only of

--- a/packages/lesswrong/lib/vulcan-lib/collections.ts
+++ b/packages/lesswrong/lib/vulcan-lib/collections.ts
@@ -58,6 +58,7 @@ export const createCollection = <
   collection?: any,
   resolvers?: any,
   mutations?: any,
+  logChanges?: boolean,
 }): any => {
   const {
     typeName,

--- a/packages/lesswrong/server/fieldChanges.ts
+++ b/packages/lesswrong/server/fieldChanges.ts
@@ -1,0 +1,56 @@
+import { LWEvents } from '../lib/collections/lwevents/collection';
+import { getSchema } from '../lib/utils/getSchema';
+import { Utils } from '../lib/vulcan-lib/utils';
+
+export const logFieldChanges = async <T extends DbObject>({currentUser, collection, oldDocument, data}: {
+  currentUser: DbUser|null,
+  collection: CollectionBase<T>,
+  oldDocument: T,
+  data: Partial<T>,
+}) => {
+  let loggedChangesBefore: any = {};
+  let loggedChangesAfter: any = {};
+  let schema = getSchema(collection);
+  
+  for (let key of Object.keys(data)) {
+    let before = oldDocument[key], after = data[key];
+    // Don't log if:
+    //  * The field didn't change
+    //  * It's a denormalized field
+    //  * The logChanges option is present on the field, and false
+    //  * The logChanges option is undefined on the field, and is false on the collection
+    if (before===after) continue;
+    if (schema[key].denormalized) continue;
+    if (schema[key].logChanges != undefined && !schema[key].logChanges)
+      continue;
+    if (!schema[key].logChanges && !collection.options.logChanges)
+      continue;
+    
+    // As a special case, don't log changes from null to undefined (or vise versa).
+    // This special case is necessary because some upstream code (updateMutator) is
+    // sloppy about the distinction.
+    if (before===undefined && after===null) continue;
+    if (after===undefined && before===null) continue;
+    
+    loggedChangesBefore[key] = before;
+    loggedChangesAfter[key] = after;
+  }
+  
+  if (Object.keys(loggedChangesAfter).length > 0) {
+    void Utils.createMutator({
+      collection: LWEvents,
+      currentUser,
+      document: {
+        name: 'fieldChanges',
+        documentId: oldDocument._id,
+        userId: currentUser?._id,
+        important: true,
+        properties: {
+          before: loggedChangesBefore,
+          after: loggedChangesAfter,
+        }
+      },
+      validate: false,
+    })
+  }
+}


### PR DESCRIPTION
This is motivated by occasionally seeing things in weird states, and wanting to know the history of user/moderator actions. Eg, was this post moved back to drafts by the user, or by a moderator, and if a moderator then which one? Has this user had their name/slug changed? Did this wiki-tag used to have a different name, and who renamed it?

This solves the problem in general, by logging most changes (that go through mutators) to fieldChange events in the LWEvents collection. Fields that are marked as denormalized are excluded, as are content fields (which are already versioned through the Revisions collection) as are a few other miscellaneous things.

No user interface is provided for viewing this information, it's just database logging (for now).