### PR TITLE
Fix How Tag Edits Don't Show Until refresh

### DIFF
--- a/packages/lesswrong/components/tagging/EditTagPage.tsx
+++ b/packages/lesswrong/components/tagging/EditTagPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigation } from '../../lib/routeUtil'
 import { Tags } from '../../lib/collections/tags/collection';
 import { tagGetUrl } from '../../lib/collections/tags/helpers';
 import { useTagBySlug } from './useTag';
+import { useApolloClient } from "@apollo/client";
 
 export const EditTagForm = ({tag, successCallback, cancelCallback}: {
   tag: TagFragment,
@@ -26,6 +27,7 @@ const EditTagPage = () => {
   const { slug } = params;
   const { tag, loading } = useTagBySlug(slug, "TagFragment");
   const { history } = useNavigation();
+  const client = useApolloClient()
 
   if (loading)
     return <Components.Loading/>
@@ -37,7 +39,10 @@ const EditTagPage = () => {
       <Components.SectionTitle title={`Edit Tag #${tag.name}`}/>
       <EditTagForm 
         tag={tag} 
-        successCallback={tag => history.push({pathname: tagGetUrl(tag)})}
+        successCallback={ async (tag) => {
+          await client.resetStore()
+          history.push({pathname: tagGetUrl(tag)})
+        }}
       />
     </Components.SingleColumnSection>
   );

--- a/packages/lesswrong/components/tagging/TagPage.tsx
+++ b/packages/lesswrong/components/tagging/TagPage.tsx
@@ -12,6 +12,7 @@ import { useMulti } from '../../lib/crud/withMulti';
 import { EditTagForm } from './EditTagPage';
 import { MAX_COLUMN_WIDTH } from '../posts/PostsPage/PostsPage';
 import classNames from 'classnames';
+import { useApolloClient } from "@apollo/client";
 
 // Also used in TagCompareRevisions, TagDiscussionPage
 export const styles = (theme: ThemeType): JssStyles => ({
@@ -115,6 +116,7 @@ const TagPage = ({classes}: {
   const [editing, setEditing] = useState(!!query.edit)
   const [hoveredContributorId, setHoveredContributorId] = useState<string|null>(null);
   const { captureEvent } =  useTracking()
+  const client = useApolloClient()
 
   const multiTerms = {
     allPages: {view: "allPagesByNewest"},
@@ -246,7 +248,10 @@ const TagPage = ({classes}: {
           </div>}
           {editing ? <EditTagForm
             tag={tag}
-            successCallback={() => setEditing(false)}
+            successCallback={ async () => {
+              setEditing(false)
+              await client.resetStore()
+            }}
             cancelCallback={() => setEditing(false)}
           /> :
           <div onClick={clickReadMore}>


### PR DESCRIPTION

Just add in resetStore as suggested.

Note, this quick PR has turned up other issues with editing on the Tag Dashboard page, not addressed here.