### PR TITLE
Fix styling on the Concepts page

### DIFF
--- a/packages/lesswrong/server/vulcan-lib/utils.ts
+++ b/packages/lesswrong/server/vulcan-lib/utils.ts
@@ -10,6 +10,22 @@ export const sanitizeAllowedTags = [
   'span', 'sub', 'sup', 'ins', 'del', 'iframe'
 ]
 
+const allowedTableStyles = {
+  'background-color': [/^.*$/],
+  'border-bottom': [/^.*$/],
+  'border-left': [/^.*$/],
+  'border-right': [/^.*$/],
+  'border-top': [/^.*$/],
+  'border': [/^.*$/],
+  'border-color': [/^.*$/],
+  'border-style': [/^.*$/],
+  'width': [/^(?:\d|\.)+(?:px|em|%)$/],
+  'height': [/^(?:\d|\.)+(?:px|em|%)$/],
+  'text-align': [/^.*$/],
+  'vertical-align': [/^.*$/],
+  'padding': [/^.*$/],
+};
+
 export const sanitize = function(s: string): string {
   return sanitizeHtml(s, {
     allowedTags: sanitizeAllowedTags,
@@ -46,38 +62,13 @@ export const sanitize = function(s: string): string {
         'padding': [/^.*$/],
       },
       table: {
-        'background-color': [/^.*$/],
-        'border-bottom': [/^.*$/],
-        'border-left': [/^.*$/],
-        'border-right': [/^.*$/],
-        'border-top': [/^.*$/],
-        'text-align': [/^.*$/],
-        'vertical-align': [/^.*$/],
-        'padding': [/^.*$/],
+        ...allowedTableStyles,
       },
       td: {
-        'background-color': [/^.*$/],
-        'border-bottom': [/^.*$/],
-        'border-left': [/^.*$/],
-        'border-right': [/^.*$/],
-        'border-top': [/^.*$/],
-        'width': [/^(?:\d|\.)+(?:px|em|%)$/],
-        'height': [/^(?:\d|\.)+(?:px|em|%)$/],
-        'text-align': [/^.*$/],
-        'vertical-align': [/^.*$/],
-        'padding': [/^.*$/],
+        ...allowedTableStyles,
       },
       th: {
-        'background-color': [/^.*$/],
-        'border-bottom': [/^.*$/],
-        'border-left': [/^.*$/],
-        'border-right': [/^.*$/],
-        'border-top': [/^.*$/],
-        'width': [/^(?:\d|\.)+(?:px|em|%)$/],
-        'height': [/^(?:\d|\.)+(?:px|em|%)$/],
-        'text-align': [/^.*$/],
-        'vertical-align': [/^.*$/],
-        'padding': [/^.*$/],
+        ...allowedTableStyles,
       },
       span: {
         // From: https://gist.github.com/olmokramer/82ccce673f86db7cda5e#gistcomment-3119899


### PR DESCRIPTION
This got broken by a CkEditor upgrade, which changed the way it expresses the `style` attribute on `table`, `td` etc to use a different subset of the CSS `border-*` attributes. The new styling would generate the same appearance, except that some of the attributes aren't in the HTML validator whitelist, so they got strippedo ut on save. So add `border`, `border-color`, and `border-style` to the HTML validator whitelist so they go through. The appearance of the Concepts page will be fixed on the next edit-and-resave after this merges.


