### PR TITLE
Make it so popup and submission only occur when posting, not drafting.

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -55,7 +55,7 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
           queryFragment={getFragment('PostsEdit')}
           mutationFragment={getFragment('PostsEdit')}
           successCallback={post => {
-            afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
+            if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
             flash({ messageString: `Post "${post.title}" edited.`, type: 'success'});
             history.push({pathname: postGetPageUrl(post)});
           }}

--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -133,7 +133,7 @@ const PostsNewForm = ({classes}: {
             mutationFragment={getFragment('PostsPage')}
             prefilledProps={prefilledProps}
             successCallback={post => {
-              afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
+              if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
               history.push({pathname: postGetPageUrl(post)})
               flash({ messageString: "Post created.", type: 'success'});
             }}


### PR DESCRIPTION
Fixes the fact that saving to draft causes popup and submission.