### PR TITLE
Email comments on event posts to RSVPed users

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.ts
+++ b/packages/lesswrong/lib/collections/users/helpers.ts
@@ -213,6 +213,10 @@ export const userHasEmailAddress = (user: UsersCurrent|DbUser|null): boolean => 
   return !!(user?.emails && user.emails.length > 0);
 }
 
+export function getUserEmail (user: UsersCurrent | DbUser): string | undefined {
+  return user.email || user.emails?.[0]?.address
+}
+
 // Replaces Users.getProfileUrl from the vulcan-users package.
 export const userGetProfileUrl = (user: DbUser|UsersMinimumInfo|AlgoliaUser|null, isAbsolute=false): string => {
   if (!user) return "";

--- a/packages/lesswrong/lib/vulcan-users/helpers.ts
+++ b/packages/lesswrong/lib/vulcan-users/helpers.ts
@@ -38,7 +38,10 @@ export const userGetGitHubName = function(user: DbUser): string|null {
 };
 
 // Get a user's email
-export const userGetEmail = function(user: DbUser): string|null {
+export const userGetEmail = function(user: DbUser|null): string|null {
+  if (!user) {
+    return null;
+  }
   if (user.email) {
     return user.email;
   } else {

--- a/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
+++ b/packages/lesswrong/server/emailComponents/EmailWrapper.tsx
@@ -14,9 +14,8 @@ const styles = (theme: ThemeType): JssStyles => ({
 // Wrapper for top-level formatting of emails, eg controling width and
 // background color. See also the global CSS in renderEmail.js. Derived from
 // wrapper.handlebars in Vulcan-Starter.
-const EmailWrapper = ({user, unsubscribeAllLink, children, classes}: {
-  user: DbUser,
-  unsubscribeAllLink: string,
+const EmailWrapper = ({unsubscribeAllLink, children, classes}: {
+  unsubscribeAllLink: string | null,
   children: React.ReactNode,
   classes: ClassesType,
 }) => {
@@ -79,9 +78,11 @@ const EmailWrapper = ({user, unsubscribeAllLink, children, classes}: {
                     </tr>
                     <tr><td className="container-padding">
                       <br/>
-                      <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}
-                      (from all emails from {siteNameWithArticle})
-                      or <a href={accountLink}>Change your notifications settings</a>
+                      {unsubscribeAllLink && <>
+                        <a href={unsubscribeAllLink}>Unsubscribe</a>{' '}
+                        (from all emails from {siteNameWithArticle})
+                        or <a href={accountLink}>Change your notifications settings</a>
+                      </>}
                       <br/>
                     </td></tr>
                   </tbody>

--- a/packages/lesswrong/server/emails/renderEmail.tsx
+++ b/packages/lesswrong/server/emails/renderEmail.tsx
@@ -24,7 +24,7 @@ import { UnsubscribeAllToken } from '../emails/emailTokens';
 import { captureException } from '@sentry/core';
 
 export interface RenderedEmail {
-  user: DbUser,
+  user: DbUser | null,
   to: string,
   from: string,
   subject: string,
@@ -129,15 +129,15 @@ function addEmailBoilerplate({ css, title, body }: {
 
 const defaultEmailSetting = new DatabaseServerSetting<string>('defaultEmail', "hello@world.com")
 
-export async function generateEmail({user, from, subject, bodyComponent, boilerplateGenerator=addEmailBoilerplate}: {
-  user: DbUser,
+export async function generateEmail({user, to, from, subject, bodyComponent, boilerplateGenerator=addEmailBoilerplate}: {
+  user: DbUser | null,
+  to: string,
   from?: string,
   subject: string,
   bodyComponent: React.ReactNode,
   boilerplateGenerator?: (props: {css:string, title: string, body: string})=>string,
 }): Promise<RenderedEmail>
 {
-  if (!user) throw new Error("Missing required argument: user");
   if (!subject) throw new Error("Missing required argument: subject");
   if (!bodyComponent) throw new Error("Missing required argument: bodyComponent");
   
@@ -159,7 +159,7 @@ export async function generateEmail({user, from, subject, bodyComponent, boilerp
     <ApolloProvider client={apolloClient}>
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
     <MuiThemeProvider theme={forumTheme} sheetsManager={new Map()}>
-    <UserContext.Provider value={user as unknown as UsersCurrent /*FIXME*/}>
+    <UserContext.Provider value={user as unknown as UsersCurrent | null /*FIXME*/}>
     <TimezoneContext.Provider value={timezone}>
       {bodyComponent}
     </TimezoneContext.Provider>
@@ -205,8 +205,8 @@ export async function generateEmail({user, from, subject, bodyComponent, boilerp
   const taggedSubject = `[${sitename}] ${subject}`;
   
   return {
-    user: user,
-    to: user.email,
+    user,
+    to,
     from: fromAddress,
     subject: taggedSubject,
     html: emailDoctype + inlinedHTML,
@@ -214,23 +214,24 @@ export async function generateEmail({user, from, subject, bodyComponent, boilerp
   }
 }
 
-export const wrapAndRenderEmail = async ({user, from, subject, body}: {user: DbUser, from?: string, subject: string, body: React.ReactNode}): Promise<RenderedEmail> => {
-  const unsubscribeAllLink = await UnsubscribeAllToken.generateLink(user._id);
+export const wrapAndRenderEmail = async ({user, to, from, subject, body}: {user: DbUser | null, to: string, from?: string, subject: string, body: React.ReactNode}): Promise<RenderedEmail> => {
+  const unsubscribeAllLink = user ? await UnsubscribeAllToken.generateLink(user._id) : null;
   return await generateEmail({
     user,
+    to,
     from,
     subject: subject,
     bodyComponent: <Components.EmailWrapper
-      user={user} unsubscribeAllLink={unsubscribeAllLink}
+      unsubscribeAllLink={unsubscribeAllLink}
     >
       {body}
     </Components.EmailWrapper>
   });
 }
 
-export const wrapAndSendEmail = async ({user, from, subject, body}: {user: DbUser, from?: string, subject: string, body: React.ReactNode}): Promise<boolean> => {
+export const wrapAndSendEmail = async ({user, to, from, subject, body}: {user: DbUser | null, to: string, from?: string, subject: string, body: React.ReactNode}): Promise<boolean> => {
   try {
-    const email = await wrapAndRenderEmail({ user, from, subject, body });
+    const email = await wrapAndRenderEmail({ user, to, from, subject, body });
     const succeeded = await sendEmail(email);
     void logSentEmail(email, user, {succeeded});
     return succeeded;
@@ -279,18 +280,18 @@ export async function sendEmail(renderedEmail: RenderedEmail): Promise<boolean>
   }
 }
 
-export async function logSentEmail(renderedEmail: RenderedEmail, user: DbUser, additionalFields: any) {
+export async function logSentEmail(renderedEmail: RenderedEmail, user: DbUser | null, additionalFields: any) {
   // Replace user (object reference) in renderedEmail so we can log it in LWEvents
   const emailJson = {
     ...renderedEmail,
-    user: user._id,
+    user: user?._id,
   };
   // Log in LWEvents table
   await createMutator({
     collection: LWEvents,
     currentUser: user,
     document: {
-      userId: user._id,
+      userId: user?._id,
       name: "emailSent",
       properties: {
         ...emailJson,

--- a/packages/lesswrong/server/emails/tests.tsx
+++ b/packages/lesswrong/server/emails/tests.tsx
@@ -1,6 +1,7 @@
 import { testStartup } from '../../testing/testMain';
 import React from 'react';
 import { withSingle, useSingle } from '../../lib/crud/withSingle';
+import { userGetEmail } from '../../lib/vulcan-users/helpers';
 import { createDummyUser, createDummyPost } from '../../testing/utils'
 import { emailDoctype, generateEmail } from './renderEmail';
 import { withStyles, createStyles } from '@material-ui/core/styles';
@@ -19,8 +20,10 @@ async function renderTestEmail({ user=null, subject="Unit test email", bodyCompo
   bodyComponent: JSX.Element,
   boilerplateGenerator?: typeof unitTestBoilerplateGenerator
 }) {
+  const destinationUser = user || await createDummyUser();
   return await generateEmail({
-    user: user || await createDummyUser(),
+    user: destinationUser,
+    to: userGetEmail(user)!,
     subject: "Unit test email",
     bodyComponent,
     boilerplateGenerator: boilerplateGenerator||unitTestBoilerplateGenerator

--- a/packages/lesswrong/server/emails/tests.tsx
+++ b/packages/lesswrong/server/emails/tests.tsx
@@ -15,7 +15,7 @@ const unitTestBoilerplateGenerator = ({css,title,body}: {css: string, title: str
 }
 
 async function renderTestEmail({ user=null, subject="Unit test email", bodyComponent, boilerplateGenerator }: {
-  user?: any,
+  user?: DbUser|null,
   subject?: string,
   bodyComponent: JSX.Element,
   boilerplateGenerator?: typeof unitTestBoilerplateGenerator

--- a/packages/lesswrong/server/notificationBatching.tsx
+++ b/packages/lesswrong/server/notificationBatching.tsx
@@ -10,6 +10,7 @@ import { Posts } from '../lib/collections/posts';
 import { Components } from '../lib/vulcan-lib/components';
 import { addGraphQLQuery, addGraphQLSchema, addGraphQLResolvers } from '../lib/vulcan-lib/graphql';
 import { wrapAndSendEmail, wrapAndRenderEmail } from './emails/renderEmail';
+import { getUserEmail } from '../lib/collections/users/helpers';
 
 // string (notification type name) => Debouncer
 export const notificationDebouncers = toDictionary(getNotificationTypes(),
@@ -45,7 +46,7 @@ const sendNotificationBatch = async ({userId, notificationIds}: {userId: string,
   ).fetch();
   
   if (notificationsToEmail.length) {
-    const emails: any = await notificationBatchToEmails({
+    const emails = await notificationBatchToEmails({
       user, notifications: notificationsToEmail
     });
     
@@ -69,6 +70,7 @@ const notificationBatchToEmails = async ({user, notifications}: {user: DbUser, n
   } else {
     return await Promise.all(notifications.map(async (notification: DbNotification) => ({
       user,
+      to: getUserEmail(user),
       from: notificationTypeRenderer.from,
       subject: await notificationTypeRenderer.emailSubject({ user, notifications:[notification] }),
       body: await notificationTypeRenderer.emailBody({ user, notifications:[notification] }),


### PR DESCRIPTION
Makes it so that comments on event posts get emailed to people who have RSVPed to the event. Most of the complexity here is dealing with the fact that people can RSVP without logging in, and a bunch of existing email stuff had the assumption baked in that emails go to an existing user.

TODO: Unsubscribing is currently not handled if you don't have an account.