### PR TITLE
Prevent creation of duplicate accounts with oAuth

### DIFF
--- a/packages/lesswrong/server/authentication/auth0Accounts.ts
+++ b/packages/lesswrong/server/authentication/auth0Accounts.ts
@@ -1,7 +1,5 @@
 import { Profile } from "passport-auth0";
-import Users from "../../lib/vulcan-users";
 import { slugify, Utils } from "../../lib/vulcan-lib/utils";
-import { updateMutator } from "../vulcan-lib/mutators";
 
 export async function userFromAuth0Profile(profile: Profile): Promise<Partial<DbUser>> {
   const email = profile.emails?.[0].value

--- a/packages/lesswrong/server/authentication/auth0Accounts.ts
+++ b/packages/lesswrong/server/authentication/auth0Accounts.ts
@@ -3,20 +3,6 @@ import Users from "../../lib/vulcan-users";
 import { slugify, Utils } from "../../lib/vulcan-lib/utils";
 import { updateMutator } from "../vulcan-lib/mutators";
 
-export async function mergeAccountWithAuth0(user: DbUser, profile: Profile) {
-  return await updateMutator({
-    collection: Users,
-    documentId: user._id,
-    // This is the correct way to set a nested property according to Mongo, but
-    // it's very hard to get it to type correctly. TS thinks we're setting a
-    // completely different field, `services.auth0`, not setting a nested one.
-    set: {'services.auth0': profile} as any,
-    // Normal updates are not supposed to update services
-    validate: false
-    // TODO: Soon we should delete passwords, and maybe(?) resume tokens when we do this
-  })
-}
-
 export async function userFromAuth0Profile(profile: Profile): Promise<Partial<DbUser>> {
   const email = profile.emails?.[0].value
   const displayNameMatchesEmail = email === profile.displayName

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -57,7 +57,7 @@ const passwordAuthStrategy = new GraphQLLocalStrategy(async function getUserPass
     return done(null, false, { message: 'Incorrect password.' });
   }
   
-  const match = await !!user.services.password.bcrypt && comparePasswords(password, user.services.password?.bcrypt);
+  const match = !!user.services.password.bcrypt && await comparePasswords(password, user.services.password?.bcrypt);
 
   // If no immediate match, we check whether we have a match with their legacy password
   if (!match) {

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -57,7 +57,7 @@ const passwordAuthStrategy = new GraphQLLocalStrategy(async function getUserPass
     return done(null, false, { message: 'Incorrect password.' });
   }
   
-  const match = await comparePasswords(password, user.services.password.bcrypt);
+  const match = await comparePasswords(password, user.services.password?.bcrypt);
 
   // If no immediate match, we check whether we have a match with their legacy password
   if (!match) {

--- a/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
+++ b/packages/lesswrong/server/vulcan-lib/apollo-server/authentication.tsx
@@ -57,7 +57,7 @@ const passwordAuthStrategy = new GraphQLLocalStrategy(async function getUserPass
     return done(null, false, { message: 'Incorrect password.' });
   }
   
-  const match = await comparePasswords(password, user.services.password?.bcrypt);
+  const match = await !!user.services.password.bcrypt && comparePasswords(password, user.services.password?.bcrypt);
 
   // If no immediate match, we check whether we have a match with their legacy password
   if (!match) {


### PR DESCRIPTION
This PR works to solve recent login issues by:
- not creating a duplicate account uses oAuth with an email that's already associated with an account
- not throw an error where trying to use a password to log in with an oAuth-only account