### PR TITLE
Prevent AF-Non-Member submission handling from happening upon edit

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -42,7 +42,7 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
   
   const { mutate: updatePost } = useUpdate({
     collectionName: "Posts",
-    fragmentName: 'SuggestAlignmentComment',
+    fragmentName: 'SuggestAlignmentPost',
   })
 
   
@@ -55,7 +55,8 @@ const PostsEditForm = ({ documentId, eventForm, classes }: {
           queryFragment={getFragment('PostsEdit')}
           mutationFragment={getFragment('PostsEdit')}
           successCallback={post => {
-            if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
+            const alreadySubmittedToAF = post.suggestForAlignmentUserIds && post.suggestForAlignmentUserIds.includes(post.userId)
+            if (!post.draft && !alreadySubmittedToAF) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost})
             flash({ messageString: `Post "${post.title}" edited.`, type: 'success'});
             history.push({pathname: postGetPageUrl(post)});
           }}

--- a/packages/lesswrong/components/questions/NewQuestionDialog.tsx
+++ b/packages/lesswrong/components/questions/NewQuestionDialog.tsx
@@ -34,7 +34,7 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
   
   const {mutate: updatePost} = useUpdate({
     collectionName: "Posts",
-    fragmentName: 'PostsList',
+    fragmentName: 'SuggestAlignmentPost',
   });
   
   const QuestionSubmit = (props) => {
@@ -67,7 +67,7 @@ const NewQuestionDialog = ({ onClose, fullScreen, classes }: {
             onClose();
             history.push({pathname: postGetPageUrl(post)})
             flash({ messageString: "Post created.", type: 'success'});
-            afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
+            if (!post.draft) afNonMemberSuccessHandling({currentUser, document: post, openDialog, updateDocument: updatePost});
           }}
           formComponents={{
             FormSubmit: QuestionSubmit,

--- a/packages/lesswrong/lib/alignment-forum/posts/custom_fields.ts
+++ b/packages/lesswrong/lib/alignment-forum/posts/custom_fields.ts
@@ -93,6 +93,7 @@ addFieldsDict(Posts, {
     insertableBy: ['members', 'sunshineRegiment', 'admins'],
     editableBy: ['members', 'alignmentForum', 'alignmentForumAdmins'],
     optional: true,
+    hidden: true,
     label: "Suggested for Alignment by",
     control: "UsersListEditor",
     group: formGroups.adminOptions,


### PR DESCRIPTION
Without this PR, the AF non-member popup and submission will occur on every save. This fixes that.

Also hides "Suggested for Alignment" from the post options since it shows for non-admins but they need to be able to edit that field (as part of submitting). I'm unsure what the actual best fix for this is.