### PR TITLE
Fix imported wiki/tag revisions being hidden from non-admins

### DIFF
--- a/packages/lesswrong/lib/collections/revisions/collection.ts
+++ b/packages/lesswrong/lib/collections/revisions/collection.ts
@@ -48,8 +48,8 @@ Revisions.checkAccess = async (user: DbUser|null, revision: DbRevision, context:
   // But on wiki/tag pages, major version 0 means "imported from old wiki" rather
   // than "draft" (since there is no concept of wiki pages being drafts).
   if (majorVersion < 1
-    && document.userId !== (user && user._id)
-    && document.collectionName!=="Tags")
+    && revision.userId !== (user && user._id)
+    && revision.collectionName!=="Tags")
   {
     return false
   }


### PR DESCRIPTION
There was an unsuccessful fix attempt for this same bug previously: https://github.com/LessWrong2/Lesswrong2/commit/8d669cb967bb32d184ede3070d1a93930e8d1e27.