### PR TITLE
Fully disable the collaborative editor

### DIFF
--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -22,7 +22,7 @@ const disabled = (user: UsersCurrent|DbUser|null): boolean => false; // eslint-d
 
 export const userCanEditTagPortal = adminOnly;
 export const userHasCkEditor = shippedFeature;
-export const userHasCkCollaboration = adminOnly;
+export const userHasCkCollaboration = disabled;
 export const userHasBoldPostItems = disabled
 export const userHasEAHomeHandbook = adminOnly
 export const userCanCreateCommitMessages = moderatorOnly;


### PR DESCRIPTION
We had an unfinished integration with CkEditor collaborative editing, enabled for admins only. Which was bad for admins who accidentally stumbled their way into it, because it wasn't ready to ship even to admins.