### PR TITLE
Fix "suggested for alignment user ids" showing up in AIAF edit form

### DIFF
--- a/packages/lesswrong/lib/alignment-forum/comments/custom_fields.ts
+++ b/packages/lesswrong/lib/alignment-forum/comments/custom_fields.ts
@@ -44,6 +44,7 @@ addFieldsDict(Comments, {
     label: "Suggested for Alignment by",
     control: "UsersListEditor",
     group: alignmentOptionsGroup,
+    hidden: true
   },
   'suggestForAlignmentUserIds.$': {
     type: String,


### PR DESCRIPTION
Fixes #4186 