### PR TITLE
Fix feedback button saving

### DIFF
--- a/packages/lesswrong/components/Layout.tsx
+++ b/packages/lesswrong/components/Layout.tsx
@@ -298,7 +298,7 @@ class Layout extends PureComponent<LayoutProps,LayoutState> {
                 standaloneNavigationPresent={standaloneNavigation}
                 toggleStandaloneNavigation={this.toggleStandaloneNavigation}
               />
-              {renderPetrovDay && <PetrovDayWrapper/>}
+              {/*{renderPetrovDay && <PetrovDayWrapper/>}*/}
               <div className={shouldUseGridLayout ? classes.gridActivated : null}>
                 {standaloneNavigation && <div className={classes.navSidebar}>
                   <NavigationStandalone sidebarHidden={hideNavigationSidebar}/>

--- a/packages/lesswrong/components/posts/PostSubmit.tsx
+++ b/packages/lesswrong/components/posts/PostSubmit.tsx
@@ -84,17 +84,19 @@ const PostSubmit = ({
         </div>
       }
       <div className={classes.submitButtons}>
-        {currentUser.karma >= 100 && document.draft!==false && <Button //treat as draft when draft is null
+        {currentUser.karma >= 100 && document.draft!==false && <Button type="submit"//treat as draft when draft is null
                 className={classNames(classes.formButton, classes.secondaryButton, classes.feedback)}
                 onClick={() => {
                   captureEvent("feedbackRequestButtonClicked")
-                  updateCurrentValues({draft: true});
-                  // eslint-disable-next-line
-                  (window as any).Intercom(
-                    'trackEvent', 
-                    'requested-feedback', 
-                    {title: document.title, _id: document._id, url: "https://www.lesswrong.com/" + document._id}
-                  )
+                  if (!!document.title) {
+                    updateCurrentValues({draft: true});
+                    // eslint-disable-next-line
+                    (window as any).Intercom(
+                      'trackEvent',
+                      'requested-feedback',
+                      {title: document.title, _id: document._id, url: "https://www.lesswrong.com/posts/" + document._id}
+                    )
+                  }
                 }}
         >
           {feedbackLabel}


### PR DESCRIPTION
Makes it so requesting feedback saves the draft. I wanted it that it would save without taking you out of the editor, but I haven't figured out our forms enough to do that.