### PR TITLE
add a curated posts subscription reminder to the Recent Discussion feed

### DIFF
--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -20,7 +20,7 @@ const styles = (theme: ThemeType): JssStyles => ({
     marginBottom: theme.spacing.unit*4,
     position: "relative",
     backgroundColor: "rgba(253,253,253)",
-
+    
     padding: 16,
     ...theme.typography.body2,
     boxShadow: theme.boxShadow,
@@ -32,7 +32,7 @@ const styles = (theme: ThemeType): JssStyles => ({
   adminNotice: {
     fontStyle: "italic",
     textAlign: "left",
-    marginTop: 8,
+    marginTop: 22,
     fontSize: 12,
     lineHeight: 1.3,
   },
@@ -45,6 +45,10 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "flex-start",
     fontSize: 18,
     lineHeight: 1.75,
+  },
+  messageDescription: {
+    fontSize: 12,
+    marginTop: 8
   },
   mailIcon: {
     marginTop: 4,
@@ -62,7 +66,8 @@ const styles = (theme: ThemeType): JssStyles => ({
     margin: "18px auto 0",
     display: "block",
     background: theme.palette.primary.main,
-    color: "white"
+    color: "white",
+    fontSize: 15
   },
   buttons: {
     marginTop: 16,
@@ -87,8 +92,9 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   const [loading, setLoading] = useState(false);
   const { flash } = useMessages();
   const {WrappedLoginForm, SignupSubscribeToCurated, Loading, AnalyticsInViewTracker } = Components;
+  const subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)';
   const { captureEvent } = useTracking({eventProps: {pageElementContext: "subscribeReminder"}});
-
+  
   // Show admins a random version of the widget. Makes sure we notice if it's intrusive/bad.
   const [adminBranch, setAdminBranch] = useState(-1);
   const adminUiMessage = currentUser?.isAdmin ? <div className={classes.adminNotice}>
@@ -96,26 +102,27 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     subscribe-reminder even if they're already subscribed, to make sure it still works and isn't
     annoying.
   </div>: null
-
+  
   useEffect(() => {
     if (adminBranch === -1 && currentUser?.isAdmin) {
       setAdminBranch(randInt(5));
     }
   }, [adminBranch, currentUser?.isAdmin]);
 
-  // adjust functionality based on forum type
-  let forumType = 'LessWrong';
-  let subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)';
-  let currentUserSubscribed = currentUser?.emailSubscribedToCurated;
-  if (forumTypeSetting.get() === 'EAForum') {
-    forumType = 'the EA Forum';
-    subscriptionDescription = '';
-    currentUserSubscribed = currentUser?.subscribedToDigest;
+  // disable on AlignmentForum
+  if (forumTypeSetting.get() === 'AlignmentForum') {
+    return null;
   }
 
   // Placeholder to prevent SSR mismatch, changed on load.
   if (adminBranch === -1 && currentUser?.isAdmin)
     return <div/>
+
+  // adjust functionality based on forum type
+  let currentUserSubscribed = currentUser?.emailSubscribedToCurated;
+  if (forumTypeSetting.get() === 'EAForum') {
+    currentUserSubscribed = currentUser?.subscribedToDigest;
+  }
 
   const maybeLaterButton = <Button
     className={classes.maybeLaterButton}
@@ -126,7 +133,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   >
     Maybe Later
   </Button>
-
+  
   const dontAskAgainButton = <span>
     {currentUser && <Button
       className={classes.dontAskAgainButton}
@@ -139,11 +146,11 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       Don't Ask Again
     </Button>}
   </span>
-
+  
   if (hide || currentUser?.hideSubscribePoke) {
     return null;
   }
-
+  
   const updateAndMaybeVerifyEmail = async () => {
     setLoading(true);
 
@@ -167,7 +174,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
 
     setLoading(false);
   }
-
+  
   const AnalyticsWrapper = ({children, branch}: {children: React.ReactNode, branch: string}) => {
     return <AnalyticsContext pageElementContext="subscribeReminder" branch={branch}>
       <AnalyticsInViewTracker eventProps={{inViewType: "subscribeReminder"}}>
@@ -177,16 +184,36 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       </AnalyticsInViewTracker>
     </AnalyticsContext>
   }
-
+  
+  // the EA Forum uses this prompt in most cases
+  const eaForumSubscribePrompt = (
+    <>
+      <div className={classes.message}>
+        <MailOutline className={classes.mailIcon} />
+        Sign up for the Forum's email digest
+      </div>
+      <div className={classes.messageDescription}>
+        Want a weekly email containing the best posts from the past week?
+        Our moderator Aaron sends out a weekly digest of recent posts that
+        have a lot of karma/discussion or seemed really good to him, as well
+        as question posts that could use more answers.
+      </div>
+    </>
+  );
+  
   if (loading) {
     return <div className={classes.root}>
       <Loading/>
     </div>
   } else if (subscriptionConfirmed) {
+    // Show the confirmation after the user subscribes
+    const confirmText = forumTypeSetting.get() === 'EAForum' ?
+      "You're subscribed to the EA Forum Digest!" :
+      "You are subscribed to the best posts of LessWrong!"
     return <AnalyticsWrapper branch="already-subscribed">
       <div className={classes.message}>
         <CheckRounded className={classes.checkIcon} />
-        You are subscribed to the best posts of {forumType}!
+        {confirmText}
       </div>
     </AnalyticsWrapper>
   } else if (verificationEmailSent) {
@@ -200,11 +227,13 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     </AnalyticsWrapper>
   } else if (!currentUser || adminBranch===0) {
     // Not logged in. Show a create-account form and a brief pitch.
-    return <AnalyticsWrapper branch="logged-out">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
         To get the best posts emailed to you, create an account! {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="logged-out">
+      {subscribeTextNode}
       <div className={classes.loginForm}>
         <WrappedLoginForm startingState="signup" />
       </div>
@@ -219,10 +248,10 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       <div className={classes.message}>
         Your account does not have an email address associated. Add an email address to subscribe to {emailType} and enable notifications.
       </div>
-
+      
       <Input placeholder="Email address" inputRef={emailAddressInput} className={classes.emailInput} />
       <SignupSubscribeToCurated defaultValue={true} onChange={(checked: boolean) => setSubscribeChecked(true)}/>
-
+      
       <div className={classes.buttons}>
         <Button className={classes.subscribeButton} onClick={async (ev) => {
           const emailAddress = emailAddressInput.current;
@@ -269,11 +298,14 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // on re-subscribing. A big Subscribe button, which clears the
     // unsubscribe-from-all option, activates curation emails (if not already
     // activated), and sends a confirmation email (if needed).
-    return <AnalyticsWrapper branch="previously-unsubscribed">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
-        You previously unsubscribed from all emails from {forumType}. Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
+        You previously unsubscribed from all emails from LessWrong.
+        Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="previously-unsubscribed">
+      {subscribeTextNode}
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();
         captureEvent("subscribeReminderButtonClicked", {buttonType: "subscribeButton"});
@@ -289,14 +321,13 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // account, but is not subscribed to curated posts. A Subscribe button which
     // sets the subscribe-to-curated option, and (if their email address isn't
     // verified) resends the verification email.
-    const subscribeText = forumTypeSetting.get() === 'EAForum' ?
-      'Subscribe to our weekly EA Forum Digest email!' :
-      `Subscribe to get the best of LessWrong emailed to you. ${subscriptionDescription}`;
-    return <AnalyticsWrapper branch="logged-in-not-subscribed">
+    const subscribeTextNode = forumTypeSetting.get() === 'EAForum' ? eaForumSubscribePrompt : (
       <div className={classes.message}>
-        <MailOutline className={classes.mailIcon} />
-        {subscribeText}
+        Subscribe to get the best of LessWrong emailed to you. {subscriptionDescription}
       </div>
+    );
+    return <AnalyticsWrapper branch="logged-in-not-subscribed">
+      {subscribeTextNode}
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();
         captureEvent("subscribeReminderButtonClicked", {buttonType: "subscribeButton"});

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -45,7 +45,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     alignItems: "flex-start",
     fontSize: 18,
     lineHeight: 1.75,
-    // marginBottom: 18,
   },
   mailIcon: {
     marginTop: 4,
@@ -62,7 +61,6 @@ const styles = (theme: ThemeType): JssStyles => ({
   subscribeButton: {
     margin: "18px auto 0",
     display: "block",
-    // background: "#d2e8d2",
     background: theme.palette.primary.main,
     color: "white"
   },
@@ -100,7 +98,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   </div>: null
 
   useEffect(() => {
-    if (adminBranch == -1 && currentUser?.isAdmin) {
+    if (adminBranch === -1 && currentUser?.isAdmin) {
       setAdminBranch(randInt(5));
     }
   }, [adminBranch, currentUser?.isAdmin]);
@@ -116,7 +114,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   }
 
   // Placeholder to prevent SSR mismatch, changed on load.
-  if (adminBranch == -1 && currentUser?.isAdmin)
+  if (adminBranch === -1 && currentUser?.isAdmin)
     return <div/>
 
   const maybeLaterButton = <Button
@@ -155,6 +153,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // since they chose to subscribe to an email, make sure this is false
     userSubscriptionData.unsubscribeFromAll = false;
 
+    // EA Forum does not care about email verification
     if (forumTypeSetting.get() !== 'EAForum' && !userEmailAddressIsVerified(currentUser)) {
       userSubscriptionData.whenConfirmationEmailSent = new Date();
     }
@@ -210,10 +209,6 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
         <WrappedLoginForm startingState="signup" />
       </div>
       {adminUiMessage}
-      {/*<div className={classes.buttons}>
-        {maybeLaterButton}
-        {dontAskAgainButton}
-      </div>*/}
     </AnalyticsWrapper>
   } else if (!userHasEmailAddress(currentUser) || adminBranch===1) {
     const emailType = forumTypeSetting.get() === 'EAForum' ? 'our weekly digest email' : 'curated posts';

--- a/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
+++ b/packages/lesswrong/components/recentDiscussion/RecentDiscussionSubscribeReminder.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useCurrentUser } from '../common/withUser';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
@@ -9,6 +9,8 @@ import { randInt } from '../../lib/random';
 import SimpleSchema from 'simpl-schema';
 import Button from '@material-ui/core/Button';
 import Input from '@material-ui/core/Input';
+import MailOutline from '@material-ui/icons/MailOutline'
+import CheckRounded from '@material-ui/icons/CheckRounded'
 import withErrorBoundary from '../common/withErrorBoundary'
 import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents";
 import { forumTypeSetting } from '../../lib/instanceSettings';
@@ -17,16 +19,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   root: {
     marginBottom: theme.spacing.unit*4,
     position: "relative",
-    minHeight: 58,
     backgroundColor: "rgba(253,253,253)",
-    
+
     padding: 16,
     ...theme.typography.body2,
-    
-    border: "1px solid #aaa",
-    borderRadius: 10,
-    boxShadow: "5px 5px 5px rgba(0,0,0,20%)",
-    
+    boxShadow: theme.boxShadow,
+
     marginLeft: "auto",
     marginRight: "auto",
     maxWidth: 500,
@@ -43,15 +41,30 @@ const styles = (theme: ThemeType): JssStyles => ({
     maxWidth: 252,
   },
   message: {
+    display: "flex",
+    alignItems: "flex-start",
     fontSize: 18,
-    marginBottom: 18,
+    lineHeight: 1.75,
+    // marginBottom: 18,
+  },
+  mailIcon: {
+    marginTop: 4,
+    marginRight: 12
+  },
+  checkIcon: {
+    color: "#4caf50",
+    marginTop: 4,
+    marginRight: 12
   },
   emailInput: {
+    marginTop: 18
   },
   subscribeButton: {
-    margin: "0 auto",
+    margin: "18px auto 0",
     display: "block",
-    background: "#d2e8d2",
+    // background: "#d2e8d2",
+    background: theme.palette.primary.main,
+    color: "white"
   },
   buttons: {
     marginTop: 16,
@@ -72,13 +85,12 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   const [subscribeChecked, setSubscribeChecked] = useState(true);
   const [verificationEmailSent, setVerificationEmailSent] = useState(false);
   const [subscriptionConfirmed, setSubscriptionConfirmed] = useState(false);
-  const [emailAddressInput, setEmailAddressInput] = useState("");
+  const emailAddressInput = useRef(null);
   const [loading, setLoading] = useState(false);
   const { flash } = useMessages();
   const {WrappedLoginForm, SignupSubscribeToCurated, Loading, AnalyticsInViewTracker } = Components;
-  const subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)'
   const { captureEvent } = useTracking({eventProps: {pageElementContext: "subscribeReminder"}});
-  
+
   // Show admins a random version of the widget. Makes sure we notice if it's intrusive/bad.
   const [adminBranch, setAdminBranch] = useState(-1);
   const adminUiMessage = currentUser?.isAdmin ? <div className={classes.adminNotice}>
@@ -86,19 +98,27 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     subscribe-reminder even if they're already subscribed, to make sure it still works and isn't
     annoying.
   </div>: null
-  
+
   useEffect(() => {
     if (adminBranch == -1 && currentUser?.isAdmin) {
       setAdminBranch(randInt(5));
     }
   }, [adminBranch, currentUser?.isAdmin]);
-  
-  if (forumTypeSetting.get() === 'EAForum') return null
-  
+
+  // adjust functionality based on forum type
+  let forumType = 'LessWrong';
+  let subscriptionDescription = '(2-3 posts per week, selected by the LessWrong moderation team.)';
+  let currentUserSubscribed = currentUser?.emailSubscribedToCurated;
+  if (forumTypeSetting.get() === 'EAForum') {
+    forumType = 'the EA Forum';
+    subscriptionDescription = '';
+    currentUserSubscribed = currentUser?.subscribedToDigest;
+  }
+
   // Placeholder to prevent SSR mismatch, changed on load.
-  if (adminBranch == -1)
+  if (adminBranch == -1 && currentUser?.isAdmin)
     return <div/>
-  
+
   const maybeLaterButton = <Button
     className={classes.maybeLaterButton}
     onClick={() => {
@@ -108,7 +128,7 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
   >
     Maybe Later
   </Button>
-  
+
   const dontAskAgainButton = <span>
     {currentUser && <Button
       className={classes.dontAskAgainButton}
@@ -121,37 +141,34 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       Don't Ask Again
     </Button>}
   </span>
-  
+
   if (hide || currentUser?.hideSubscribePoke) {
     return null;
   }
-  
+
   const updateAndMaybeVerifyEmail = async () => {
     setLoading(true);
+
+    // subscribe to different emails based on forum type
+    const userSubscriptionData: Partial<MakeFieldsNullable<DbUser>> = forumTypeSetting.get() === 'EAForum' ?
+      {subscribedToDigest: true} : {emailSubscribedToCurated: true};
+    // since they chose to subscribe to an email, make sure this is false
+    userSubscriptionData.unsubscribeFromAll = false;
+
     if (!userEmailAddressIsVerified(currentUser)) {
-      try {
-        await updateCurrentUser({
-          whenConfirmationEmailSent: new Date(),
-          emailSubscribedToCurated: true,
-          unsubscribeFromAll: false,
-        });
-        setVerificationEmailSent(true);
-      } catch(e) {
-        flash(getGraphQLErrorMessage(e));
-      }
-    } else {
-      try {
-        await updateCurrentUser({
-          emailSubscribedToCurated: true,
-        });
-        setSubscriptionConfirmed(true);
-      } catch(e) {
-        flash(getGraphQLErrorMessage(e));
-      }
+      userSubscriptionData.whenConfirmationEmailSent = new Date();
     }
+
+    try {
+      await updateCurrentUser(userSubscriptionData);
+      setSubscriptionConfirmed(true);
+    } catch(e) {
+      flash(getGraphQLErrorMessage(e));
+    }
+
     setLoading(false);
   }
-  
+
   const AnalyticsWrapper = ({children, branch}: {children: React.ReactNode, branch: string}) => {
     return <AnalyticsContext pageElementContext="subscribeReminder" branch={branch}>
       <AnalyticsInViewTracker eventProps={{inViewType: "subscribeReminder"}}>
@@ -161,14 +178,17 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
       </AnalyticsInViewTracker>
     </AnalyticsContext>
   }
-  
+
   if (loading) {
-    return <div>
+    return <div className={classes.root}>
       <Loading/>
     </div>
   } else if (subscriptionConfirmed) {
     return <AnalyticsWrapper branch="already-subscribed">
-      You are subscribed to the best posts of LessWrong!
+      <div className={classes.message}>
+        <CheckRounded className={classes.checkIcon} />
+        You are subscribed to the best posts of {forumType}!
+      </div>
     </AnalyticsWrapper>
   } else if (verificationEmailSent) {
     // Clicked Subscribe in one of the other branches, and a confirmation email
@@ -183,39 +203,43 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // Not logged in. Show a create-account form and a brief pitch.
     return <AnalyticsWrapper branch="logged-out">
       <div className={classes.message}>
+        <MailOutline className={classes.mailIcon} />
         To get the best posts emailed to you, create an account! {subscriptionDescription}
       </div>
       <div className={classes.loginForm}>
         <WrappedLoginForm startingState="signup" />
       </div>
       {adminUiMessage}
-      <div className={classes.buttons}>
+      {/*<div className={classes.buttons}>
         {maybeLaterButton}
         {dontAskAgainButton}
-      </div>
+      </div>*/}
     </AnalyticsWrapper>
   } else if (!userHasEmailAddress(currentUser) || adminBranch===1) {
+    const emailType = forumTypeSetting.get() === 'EAForum' ? 'our weekly digest email' : 'curated posts';
     // Logged in, but no email address associated. Probably a legacy account.
     // Show a text box for an email address, with a submit button and a subscribe
     // checkbox.
     return <AnalyticsWrapper branch="missing-email">
       <div className={classes.message}>
-        Your account does not have an email address associated. Add an email address to subscribe to curated posts and enable notifications.
+        Your account does not have an email address associated. Add an email address to subscribe to {emailType} and enable notifications.
       </div>
-      
-      <Input placeholder="Email address" onChange={(ev)=>setEmailAddressInput(ev.target.value)} value={emailAddressInput} className={classes.emailInput} />
+
+      <Input placeholder="Email address" inputRef={emailAddressInput} className={classes.emailInput} />
       <SignupSubscribeToCurated defaultValue={true} onChange={(checked: boolean) => setSubscribeChecked(true)}/>
-      
+
       <div className={classes.buttons}>
         <Button className={classes.subscribeButton} onClick={async (ev) => {
-          if (SimpleSchema.RegEx.Email.test(emailAddressInput)) {
+          if (SimpleSchema.RegEx.Email.test(emailAddressInput.current)) {
             setLoading(true);
             try {
-              await updateCurrentUser({
-                email: emailAddressInput,
-                emailSubscribedToCurated: subscribeChecked,
-                unsubscribeFromAll: false,
-              });
+              // subscribe to different emails based on forum type
+              const userSubscriptionData = forumTypeSetting.get() === 'EAForum' ?
+                {subscribedToDigest: subscribeChecked} : {emailSubscribedToCurated: subscribeChecked};
+              userSubscriptionData.email = emailAddressInput.current;
+              userSubscriptionData.unsubscribeFromAll = false;
+
+              await updateCurrentUser(userSubscriptionData);
               // Confirmation-email mutation is separate from the send-verification-email
               // mutation because otherwise it goes to the old email address (aka null)
               await updateCurrentUser({
@@ -249,7 +273,8 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
     // activated), and sends a confirmation email (if needed).
     return <AnalyticsWrapper branch="previously-unsubscribed">
       <div className={classes.message}>
-        You previously unsubscribed from all emails from LessWrong. Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
+        <MailOutline className={classes.mailIcon} />
+        You previously unsubscribed from all emails from {forumType}. Re-subscribe to get the best posts emailed to you! {subscriptionDescription}
       </div>
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();
@@ -261,14 +286,18 @@ const RecentDiscussionSubscribeReminder = ({classes}: {
         {dontAskAgainButton}
       </div>
     </AnalyticsWrapper>
-  } else if (!currentUser.emailSubscribedToCurated || adminBranch===3) {
+  } else if (!currentUserSubscribed || adminBranch===3) {
     // User is logged in, and has an email address associated with their
     // account, but is not subscribed to curated posts. A Subscribe button which
     // sets the subscribe-to-curated option, and (if their email address isn't
     // verified) resends the verification email.
+    const subscribeText = forumTypeSetting.get() === 'EAForum' ?
+      'Subscribe to our weekly EA Forum Digest email!' :
+      `Subscribe to get the best of LessWrong emailed to you. ${subscriptionDescription}`;
     return <AnalyticsWrapper branch="logged-in-not-subscribed">
       <div className={classes.message}>
-        Subscribe to get the best of LessWrong emailed to you. {subscriptionDescription}
+        <MailOutline className={classes.mailIcon} />
+        {subscribeText}
       </div>
       <Button className={classes.subscribeButton} onClick={async (ev) => {
         await updateAndMaybeVerifyEmail();

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -3,6 +3,7 @@ import { registerComponent } from '../../lib/vulcan-lib';
 import Checkbox from '@material-ui/core/Checkbox';
 import Info from '@material-ui/icons/Info';
 import Tooltip from '@material-ui/core/Tooltip';
+import { forumTypeSetting } from '../../lib/instanceSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -34,6 +35,10 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
   classes: ClassesType,
 }) => {
   const [checked, setChecked] = useState(defaultValue);
+
+  const emailType = forumTypeSetting.get() === 'EAForum' ?
+    'the EA Forum weekly digest email' : 'Curated posts';
+
   return <div className={classes.root}>
     <Checkbox
       checked={checked}
@@ -43,10 +48,12 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
         onChange(newChecked)
       }}
     />
-    Subscribe to Curated posts
-    <Tooltip title="Emails 2-3 times per week with the best posts, chosen by the LessWrong moderation team.">
-      <Info className={classes.infoIcon}/>
-    </Tooltip>
+    Subscribe to {emailType}
+    {forumTypeSetting.get() !== 'EAForum' && (
+      <Tooltip title="Emails 2-3 times per week with the best posts, chosen by the LessWrong moderation team.">
+        <Info className={classes.infoIcon}/>
+      </Tooltip>
+    )}
   </div>
 }
 

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -37,7 +37,7 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
   const [checked, setChecked] = useState(defaultValue);
 
   // this component is not used in the EA Forum signup flow,
-  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.jsx
+  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.tsx
   const emailType = forumTypeSetting.get() === 'EAForum' ?
     'the EA Forum weekly digest email' : 'Curated posts';
 

--- a/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
+++ b/packages/lesswrong/components/users/SignupSubscribeToCurated.tsx
@@ -36,6 +36,8 @@ const SignupSubscribeToCurated = ({ defaultValue, onChange, classes }: {
 }) => {
   const [checked, setChecked] = useState(defaultValue);
 
+  // this component is not used in the EA Forum signup flow,
+  // but it does appear on the EA Forum via RecentDiscussionSubscribeReminder.jsx
   const emailType = forumTypeSetting.get() === 'EAForum' ?
     'the EA Forum weekly digest email' : 'Curated posts';
 


### PR DESCRIPTION
<img width="500" alt="Screen Shot 2021-09-09 at 10 39 39 PM" src="https://user-images.githubusercontent.com/9057804/133459133-26549d40-42a3-40f7-a0f5-80dd667f7b11.png">

This PR makes some updates to the CTA in the Recent Discussion feed that reminds users to subscribe to the curated posts email (it's hidden on the Alignment Forum and uses the weekly digest email on the EA Forum). Mostly this is to make sure it appears to users who are not admins, and I also made some UI tweaks.

Original EA Forum PR: https://github.com/centre-for-effective-altruism/EAForum/pull/187