### PR TITLE
Hover-highlight for link to a section in a post shows excerpt starting at that section

### DIFF
--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -192,6 +192,8 @@ const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, id, error}: {
 }) => {
   const { PostsPreviewTooltip, LWPopper } = Components
   const { anchorEl, hover, eventHandlers } = useHover();
+  
+  const hash = (href.indexOf("#")>=0) ? (href.split("#")[1]) : null;
 
   if (!post) {
     return <span {...eventHandlers}>
@@ -211,7 +213,7 @@ const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, id, error}: {
           }
         }}
       >
-        <PostsPreviewTooltip post={post} />
+        <PostsPreviewTooltip post={post} hash={hash} />
       </LWPopper>
       <Link className={classes.link} to={href} dangerouslySetInnerHTML={{__html: innerHTML}} id={id} smooth/>
     </span>

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -430,3 +430,13 @@ registerFragment(`
     voteCount
   }
 `);
+
+registerFragment(`
+  fragment HighlightWithHash on Post {
+    _id
+    contents {
+      htmlHighlightStartingAtHash(hash: $hash)
+    }
+  }
+`);
+

--- a/packages/lesswrong/lib/collections/revisions/schema.ts
+++ b/packages/lesswrong/lib/collections/revisions/schema.ts
@@ -97,6 +97,11 @@ const schema: SchemaType<DbRevision> = {
     viewableBy: ['guests'],
     // resolveAs defined in resolvers.js
   },
+  htmlHighlightStartingAtHash: {
+    type: String, 
+    viewableBy: ['guests'],
+    // resolveAs defined in resolvers.js
+  },
   plaintextDescription: {
     type: String, 
     viewableBy: ['guests'],

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -240,6 +240,7 @@ interface RevisionsDefaultFragment { // fragment on Revisions
   readonly ckEditorMarkup: string,
   readonly wordCount: number,
   readonly htmlHighlight: string,
+  readonly htmlHighlightStartingAtHash: string,
   readonly plaintextDescription: string,
   readonly plaintextMainText: string,
   readonly changeMetrics: any /*{"definitions":[{"blackbox":true}]}*/,
@@ -566,6 +567,15 @@ interface WithVotePost { // fragment on Posts
   readonly score: number,
   readonly afBaseScore: number,
   readonly voteCount: number,
+}
+
+interface HighlightWithHash { // fragment on Posts
+  readonly _id: string,
+  readonly contents: HighlightWithHash_contents|null,
+}
+
+interface HighlightWithHash_contents { // fragment on Revisions
+  readonly htmlHighlightStartingAtHash: string,
 }
 
 interface CommentsList { // fragment on Comments
@@ -1712,6 +1722,7 @@ interface FragmentTypes {
   UsersBannedFromPostsModerationLog: UsersBannedFromPostsModerationLog
   SunshinePostsList: SunshinePostsList
   WithVotePost: WithVotePost
+  HighlightWithHash: HighlightWithHash
   CommentsList: CommentsList
   ShortformComments: ShortformComments
   CommentWithRepliesFragment: CommentWithRepliesFragment
@@ -1846,6 +1857,7 @@ interface CollectionNamesByFragmentName {
   UsersBannedFromPostsModerationLog: "Posts"
   SunshinePostsList: "Posts"
   WithVotePost: "Posts"
+  HighlightWithHash: "Posts"
   CommentsList: "Comments"
   ShortformComments: "Comments"
   CommentWithRepliesFragment: "Comments"

--- a/packages/lesswrong/server/extractHighlights.ts
+++ b/packages/lesswrong/server/extractHighlights.ts
@@ -1,0 +1,26 @@
+import cheerio from 'cheerio';
+
+export function htmlStartingAtHash(html: string, hash: string): string {
+  try {
+    // Find the given anchor, if present
+    // @ts-ignore DefinitelyTyped annotation is wrong, and cheerio's own annotations aren't ready yet
+    const $ = cheerio.load(html, null, false);
+    const matchesWithID = $(`#${hash}`);
+    if (matchesWithID.length==0)
+      return html;
+    const sectionElement = matchesWithID[0];
+    
+    // Drop everything that precedes the anchor
+    // @ts-ignore DefinitelyTyped annotation is wrong, and cheerio's own annotations aren't ready yet
+    while (sectionElement.previousSibling) {
+      // @ts-ignore DefinitelyTyped annotation is wrong, and cheerio's own annotations aren't ready yet
+      $(sectionElement.previousSibling).remove();
+    }
+    
+    return $.html();
+  } catch(e) {
+    // eslint-disable-next-line no-console
+    console.error(`Error extracting HTML highlight: ${e}`);
+    return html;
+  }
+}

--- a/packages/lesswrong/server/resolvers/revisionResolvers.ts
+++ b/packages/lesswrong/server/resolvers/revisionResolvers.ts
@@ -3,11 +3,14 @@ import { htmlToDraft } from '../draftConvert';
 import { convertToRaw } from 'draft-js';
 import { markdownToHtmlNoLaTeX, dataToMarkdown } from '../editor/make_editable_callbacks'
 import { highlightFromHTML, truncate } from '../../lib/editor/ellipsize';
+import { htmlStartingAtHash } from '../extractHighlights';
 import { augmentFieldsDict } from '../../lib/utils/schemaUtils'
 import { JSDOM } from 'jsdom'
 import { sanitize, sanitizeAllowedTags } from '../vulcan-lib/utils';
 import htmlToText from 'html-to-text'
 import sanitizeHtml, {IFrame} from 'sanitize-html';
+import { defineQuery } from '../utils/serverGraphqlUtil';
+import { extractTableOfContents } from '../tableOfContents';
 import * as _ from 'underscore';
 
 const PLAINTEXT_HTML_TRUNCATION_LENGTH = 4000
@@ -100,6 +103,26 @@ augmentFieldsDict(Revisions, {
     resolveAs: {
       type: 'String',
       resolver: ({html}) => highlightFromHTML(html)
+    }
+  },
+  htmlHighlightStartingAtHash: {
+    type: String,
+    resolveAs: {
+      type: 'String',
+      arguments: 'hash: String',
+      resolver: async (revision: DbRevision, args: {hash: string}, context: ResolverContext): Promise<string> => {
+        const {hash} = args;
+        const rawHtml = revision?.html;
+        
+        // Process the HTML through the table of contents generator (which has
+        // the byproduct of marking section headers with anchors)
+        const toc = extractTableOfContents(rawHtml);
+        const html = toc?.html || rawHtml;
+        
+        const startingFromHash = htmlStartingAtHash(html, hash);
+        const highlight = highlightFromHTML(startingFromHash);
+        return highlight;
+      },
     }
   },
   plaintextDescription: {

--- a/packages/lesswrong/server/utils/serverGraphqlUtil.ts
+++ b/packages/lesswrong/server/utils/serverGraphqlUtil.ts
@@ -18,7 +18,13 @@ import { addGraphQLResolvers, addGraphQLSchema, addGraphQLQuery } from '../../li
 //     add to the schema, provided for convenience so you can define the types
 //     referenced in resultType and argTypes in the same place.
 //   fn: ((root,args,context)=>resultType). The GraphQL resolver.
-export const defineQuery = ({name, resultType, argTypes=null, schema, fn}) => {
+export const defineQuery = ({name, resultType, argTypes=null, schema, fn}: {
+  name: string,
+  resultType: string,
+  argTypes?: string|null,
+  schema?: string,
+  fn: any,
+}) => {
   if (schema) {
     if (typeof(schema) !== 'string') {
       throw new Error(`Incorrect type for schema in defineQuery: expected string, was ${typeof(schema)}. (Don't use graphql-tag here)`);

--- a/packages/lesswrong/testing/extractHighlights.tests.ts
+++ b/packages/lesswrong/testing/extractHighlights.tests.ts
@@ -1,0 +1,26 @@
+import { testStartup } from './testMain';
+import chai from 'chai';
+import { htmlStartingAtHash } from '../server/extractHighlights';
+
+testStartup();
+
+describe('extractHighlights', () => {
+  it('finds the indicated section', () => {
+    chai.assert.equal(
+      htmlStartingAtHash(
+        '<div><p>Asdf ghjk</p><p id="section1">Lorem ipsum</p></div>',
+        "section1"
+      ),
+      '<div><p id="section1">Lorem ipsum</p></div>'
+    );
+  });
+  it("is a no-op if the requested section doesn't exist", () => {
+    chai.assert.equal(
+      htmlStartingAtHash(
+        '<div><p>Asdf ghjk</p><p id="section1">Lorem ipsum</p></div>',
+        "section2"
+      ),
+      '<div><p>Asdf ghjk</p><p id="section1">Lorem ipsum</p></div>'
+    );
+  });
+});


### PR DESCRIPTION
This makes it so that if a link to a post includes the anchor of a section heading, the excerpt that you see when you hover over it starts at that section, rather than at the top of the post. Partially addresses https://github.com/LessWrong2/Lesswrong2/issues/4072 . Current limitations:

 * Currently only section headings have anchors (the anchors are inserted by the table of contents code), so you can only point this at sections that start with a large-font header, not at arbitrary paragraphs
 * You'll get a brief loading spinner while it roundtrips to the server, before seeing the excerpt
 * The excerpt is clipped by length in the same way as an excerpt from the start of the post, so if the section is short enough, it'll be followed by the start of the next section