### PR TITLE
Fix Sunshines/moderators being unable to purge spam

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.ts
+++ b/packages/lesswrong/lib/collections/posts/schema.ts
@@ -180,7 +180,7 @@ const schema: SchemaType<DbPost> = {
     optional: true,
     viewableBy: ['guests'],
     insertableBy: ['admins'],
-    editableBy: ['admins'],
+    editableBy: ['admins', 'sunshineRegiment'],
     control: 'select',
     onInsert: (document, currentUser) => {
       if (!document.status) {

--- a/packages/lesswrong/lib/collections/reports/schema.ts
+++ b/packages/lesswrong/lib/collections/reports/schema.ts
@@ -81,7 +81,7 @@ const schema: SchemaType<DbReport> = {
     optional: true,
     type: Date,
     viewableBy: ['guests'],
-    editableBy: ['admins'],
+    editableBy: ['admins', 'sunshineRegiment'],
   },
   // Only set when report is closed. Indicates whether content is spam or not.
   markedAsSpam: {

--- a/packages/lesswrong/server/callbacks.ts
+++ b/packages/lesswrong/server/callbacks.ts
@@ -44,7 +44,7 @@ getCollectionHooks("Users").editAsync.add(async function userEditNullifyVotesCal
 
 
 getCollectionHooks("Users").updateAsync.add(function userEditDeleteContentCallbacksAsync({newDocument, oldDocument, currentUser}) {
-  if (newDocument.deleteContent && !oldDocument.deleteContent && currentUser?.isAdmin) {
+  if (newDocument.deleteContent && !oldDocument.deleteContent && currentUser) {
     void userDeleteContent(newDocument, currentUser);
   }
 });


### PR DESCRIPTION
Fixed a bug which made it so that Sunshines who are not also admins could not properly purge spam; ie, if they clicked the purge-user button on the Sunshine sidebar, the user would be banned but their posts would not be deleted correctly.