### PR TITLE
[EA-only] Ask users from facebook without an email for their email

### DIFF
--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -3,7 +3,7 @@ import Button from "@material-ui/core/Button";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import TextField from "@material-ui/core/TextField";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { forumTypeSetting, siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { Components, registerComponent } from "../../lib/vulcan-lib";
 import { useMessages } from "../common/withMessages";
@@ -44,7 +44,7 @@ function prefillUsername(maybeUsername: string | undefined | null): string {
 const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes }) => {
   const currentUser = useCurrentUser()
   const [username, setUsername] = useState(prefillUsername(currentUser?.displayName))
-  const [newEmail, setNewEmail] = useState('')
+  const emailInput = useRef<HTMLInputElement>(null)
   const [subscribeToDigest, setSubscribeToDigest] = useState(false)
   const [validationError, setValidationError] = useState('')
   const [updateUser] = useMutation(gql`
@@ -86,8 +86,8 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
         subscribeToDigest,
         // We do this fancy spread so we avoid setting the email to an empty
         // string in the likely event that someone already had an email and
-        // wasn't show the set email field
-        ...(newEmail && {email: newEmail})
+        // wasn't shown the set email field
+        ...(!currentUser?.email && {email: emailInput.current?.value})
       }})
     } catch (err) {
       if (/duplicate key error/.test(err.toString?.())) {
@@ -100,7 +100,7 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
   }
   
   return <SingleColumnSection>
-      <div className={classes.root}>
+    <div className={classes.root}>
       <Typography variant='display3' gutterBottom className={classes.title}>
         Thanks for registering for {siteNameWithArticleSetting.get()}
       </Typography>
@@ -139,7 +139,8 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
         </Typography>
         <TextField
           label='Email'
-          onChange={(event) => setNewEmail(event.target.value)}
+          inputRef={emailInput}
+          // onChange={(event) => setNewEmail(event.target.value)}
         />
       </div>}
       

--- a/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
+++ b/packages/lesswrong/components/users/NewUserCompleteProfile.tsx
@@ -42,14 +42,14 @@ function prefillUsername(maybeUsername: string | undefined | null): string {
 }
 
 const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes }) => {
-  // TODO: Prefill with existing username if it's not an email / new_user_N
   const currentUser = useCurrentUser()
   const [username, setUsername] = useState(prefillUsername(currentUser?.displayName))
+  const [newEmail, setNewEmail] = useState('')
   const [subscribeToDigest, setSubscribeToDigest] = useState(false)
   const [validationError, setValidationError] = useState('')
   const [updateUser] = useMutation(gql`
-    mutation NewUserCompleteProfile($username: String!, $subscribeToDigest: Boolean!) {
-      NewUserCompleteProfile(username: $username, subscribeToDigest: $subscribeToDigest) {
+    mutation NewUserCompleteProfile($username: String!, $subscribeToDigest: Boolean!, $email: String) {
+      NewUserCompleteProfile(username: $username, subscribeToDigest: $subscribeToDigest, email: $email) {
         username
         slug
         displayName
@@ -78,10 +78,17 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
   
   async function handleSave() {
     try {
-      if (validationError)return
+      if (validationError) return
       
       // TODO: loading spinner while running
-      await updateUser({variables: {username, subscribeToDigest}})
+      await updateUser({variables: {
+        username,
+        subscribeToDigest,
+        // We do this fancy spread so we avoid setting the email to an empty
+        // string in the likely event that someone already had an email and
+        // wasn't show the set email field
+        ...(newEmail && {email: newEmail})
+      }})
     } catch (err) {
       if (/duplicate key error/.test(err.toString?.())) {
         setValidationError('Username already taken')
@@ -119,6 +126,22 @@ const NewUserCompleteProfile: React.FC<NewUserCompleteProfileProps> = ({ classes
           onBlur={(_event) => validateUsername(username)}
         />
       </div>
+      
+      {/* Facebook user with no email fix (very small % of users) */}
+      {!currentUser?.email && <div className={classes.section}>
+        <Typography variant='display1' gutterBottom>Please enter your email</Typography>
+        <Typography variant='body1' className={classes.sectionHelperText} gutterBottom>
+          {/* I'd rather be honest than concise here. */}
+          To get here without an email you must have logged in with Facebook
+          and not given Facebook your email. We need your email to notify you of
+          direct messages, and having a tiny percentage of users without an
+          email makes the site harder to maintain.
+        </Typography>
+        <TextField
+          label='Email'
+          onChange={(event) => setNewEmail(event.target.value)}
+        />
+      </div>}
       
       {forumTypeSetting.get() === 'EAForum' && <div className={classes.section}>
         <Typography variant='display1' gutterBottom>Would you like to get digest emails?</Typography>

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -37,12 +37,13 @@ addGraphQLSchema(`
 
 type NewUserUpdates = {
   username: string
+  email?: string
   subscribeToDigest: boolean
 }
 
 addGraphQLResolvers({
   Mutation: {
-    async NewUserCompleteProfile(root: void, { username, subscribeToDigest }: NewUserUpdates, context: ResolverContext) {
+    async NewUserCompleteProfile(root: void, { username, email, subscribeToDigest }: NewUserUpdates, context: ResolverContext) {
       const { currentUser } = context
       if (!currentUser) {
         throw new Error('Cannot change username without being logged in')
@@ -57,6 +58,14 @@ addGraphQLResolvers({
       if (existingUser && existingUser._id !== currentUser._id) {
         throw new Error('Username already exists')
       }
+      // Check for someone setting an email when they already have one
+      if (email && currentUser.email) {
+        throw new Error('You already have an email address')
+      }
+      // Check for email uniqueness
+      if (email && await Users.findOne({email})) {
+        throw new Error('Email already taken')
+      }
       const updatedUser = (await updateMutator({
         collection: Users,
         documentId: currentUser._id,
@@ -65,6 +74,7 @@ addGraphQLResolvers({
           username,
           displayName: username,
           slug: await Utils.getUnusedSlugByCollectionName("Users", slugify(username)),
+          email,
           subscribedToDigest: subscribeToDigest
         },
         // We've already done necessary gating
@@ -77,5 +87,5 @@ addGraphQLResolvers({
 })
 
 addGraphQLMutation(
-  'NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!): NewUserCompletedProfile'
+  'NewUserCompleteProfile(username: String!, subscribeToDigest: Boolean!, email: String): NewUserCompletedProfile'
 )

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -3,6 +3,7 @@ import Users from '../../lib/collections/users/collection';
 import { augmentFieldsDict, denormalizedField } from '../../lib/utils/schemaUtils'
 import { addGraphQLMutation, addGraphQLResolvers, addGraphQLSchema, slugify, updateMutator, Utils } from '../vulcan-lib';
 import pick from 'lodash/pick';
+import SimpleSchema from 'simpl-schema';
 
 augmentFieldsDict(Users, {
   htmlBio: {
@@ -65,6 +66,10 @@ addGraphQLResolvers({
       // Check for email uniqueness
       if (email && await Users.findOne({email})) {
         throw new Error('Email already taken')
+      }
+      // Check for valid email
+      if (email && !SimpleSchema.RegEx.Email.test(email)) {
+        throw new Error('Invalid email')
       }
       const updatedUser = (await updateMutator({
         collection: Users,

--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -64,7 +64,7 @@ addGraphQLResolvers({
         throw new Error('You already have an email address')
       }
       // Check for email uniqueness
-      if (email && await Users.findOne({email})) {
+      if (email && await Users.findOne({$or: [{email}, {['emails.address']: email}]})) {
         throw new Error('Email already taken')
       }
       // Check for valid email


### PR DESCRIPTION
Already reviewed in: https://github.com/centre-for-effective-altruism/EAForum/pull/205 . Does not affect LW.

---

![image](https://user-images.githubusercontent.com/10352319/136081942-6d0c6867-8999-4eb2-a4c9-deb508116610.png)

The ways to sign up are:

Auth0 email + password
Auth0 google OAuth
Auth0 facebook OAuth
Only Facebook allows for no email to be set, so I'm confident in that text.

I've checked that this doesn't change the flow if you do have an email.

I don't do any validation of the email address on the frontend, because this is only for .5 users every month, so I don't think it's worth it. I do check on the backend though. The error propagates sensibly if you submit a malformed email address.