### PR TITLE
Correctly type return of useSingle

### DIFF
--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -49,8 +49,10 @@ const CommentPermalink = ({ documentId, post, classes }: {
   const { Loading, Divider, CommentWithReplies, HeadTags } = Components;
 
   if (error || (!comment && !loading)) return <div>Comment not found</div>
+  
+  if (loading) return <Loading />
 
-  if (loading || !comment) {return null}
+  if (!comment) {return null}
 
   if (!documentId) return null
 
@@ -62,12 +64,12 @@ const CommentPermalink = ({ documentId, post, classes }: {
   // NB: classes.root is not in the above styles, but is used by eaTheme
   return <div className={classes.root}>
       <div className={classes.permalinkLabel}>Comment Permalink</div>
-      {loading ? <Loading /> : <div>
+      <div>
         <HeadTags ogUrl={ogUrl} canonicalUrl={canonicalUrl} image={socialPreviewImageUrl} 
         description={getCommentDescription(comment)} noIndex={true} />
         <CommentWithReplies key={comment._id} post={post} comment={comment} refetch={refetch} expandByDefault showTitle={false}/>
         <div className={classes.seeInContext}><a href={`#${documentId}`}>See in context</a></div>
-      </div>}
+      </div>
       {forumTypeSetting.get() !== 'EAForum' && <div className={classes.dividerMargins}><Divider /></div>}
     </div>
 }

--- a/packages/lesswrong/components/comments/CommentPermalink.tsx
+++ b/packages/lesswrong/components/comments/CommentPermalink.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { postGetPageUrl } from '../../lib/collections/posts/helpers';
 import { useSingle } from '../../lib/crud/withSingle';
 import { forumTypeSetting } from '../../lib/instanceSettings';
-import { postGetPageUrl } from '../../lib/collections/posts/helpers';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   dividerMargins: {
@@ -49,6 +49,8 @@ const CommentPermalink = ({ documentId, post, classes }: {
   const { Loading, Divider, CommentWithReplies, HeadTags } = Components;
 
   if (error || (!comment && !loading)) return <div>Comment not found</div>
+
+  if (loading || !comment) {return null}
 
   if (!documentId) return null
 

--- a/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
+++ b/packages/lesswrong/components/comments/ModerationGuidelines/ModerationGuidelinesBox.tsx
@@ -100,7 +100,7 @@ const ModerationGuidelinesBox = ({classes, post}: {
     fragmentName: "PostsList",
   });
   
-  if (!post)
+  if (!post || !postWithDetails)
     return null
   if (loading)
     return <Components.Loading/>

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -1,15 +1,15 @@
+import { gql, useQuery } from '@apollo/client';
+import Card from '@material-ui/core/Card';
+import SupervisorAccountIcon from '@material-ui/icons/SupervisorAccount';
 import React from 'react';
-import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { useSingle } from '../../lib/crud/withSingle';
 import { Link } from '../../lib/reactRouterWrapper';
-import { usePostBySlug, usePostByLegacyId } from '../posts/usePost';
+import { looksLikeDbIdString } from '../../lib/routeUtil';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { commentBodyStyles, metaculusBackground, postHighlightStyles } from '../../themes/stylePiping';
 import { useCommentByLegacyId } from '../comments/useComment';
 import { useHover } from '../common/withHover';
-import { useQuery, gql } from '@apollo/client';
-import Card from '@material-ui/core/Card';
-import { looksLikeDbIdString } from '../../lib/routeUtil';
-import SupervisorAccountIcon from '@material-ui/icons/SupervisorAccount';
-import { postHighlightStyles, metaculusBackground, commentBodyStyles } from '../../themes/stylePiping';
+import { usePostByLegacyId, usePostBySlug } from '../posts/usePost';
 
 const PostLinkPreview = ({href, targetLocation, innerHTML, id}: {
   href: string,
@@ -26,6 +26,8 @@ const PostLinkPreview = ({href, targetLocation, innerHTML, id}: {
 
     documentId: postID,
   });
+
+  if (!post) return null;
 
   return <Components.PostLinkPreviewVariantCheck post={post} targetLocation={targetLocation} error={error} href={href} innerHTML={innerHTML} id={id} />
 }
@@ -45,6 +47,7 @@ const PostLinkPreviewSequencePost = ({href, targetLocation, innerHTML, id}: {
     fetchPolicy: 'cache-then-network' as any, //TODO
     documentId: postID,
   });
+  if (!post) {return null;}
 
   return <Components.PostLinkPreviewVariantCheck post={post} targetLocation={targetLocation} error={error} href={href} innerHTML={innerHTML} id={id} />
 }
@@ -112,6 +115,8 @@ const PostCommentLinkPreviewGreaterWrong = ({href, targetLocation, innerHTML, id
 
     documentId: postId,
   });
+
+  if (!post) {return null;}
 
   return <Components.PostLinkCommentPreview href={href} innerHTML={innerHTML} commentId={commentId} post={post} id={id}/>
 }

--- a/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
+++ b/packages/lesswrong/components/notifications/TagRelNotificationItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSingle } from '../../lib/crud/withSingle';
-import { registerComponent, Components } from '../../lib/vulcan-lib';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 
 const styles = (theme: ThemeType): JssStyles => ({
   meta: {
@@ -27,6 +27,7 @@ export const TagRelNotificationItem = ({classes, tagRelId}: {
   });
 
   if (loading) return <Loading/>
+  if (!tagRel) {return null;}
 
   return <div className={classes.root}>
     <div className={classes.meta}>New post tagged <em>{tagRel.tag?.name}</em>:</div>

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -142,7 +142,7 @@ const PostsAnalyticsPage = ({ classes }) => {
         <PostsAnalyticsInner post={post} />
       </NoSsr>
         <Typography variant="body1" className={classes.viewingNotice} component='div'>
-        <p>This feature is new. <Link to='/contact-us'>Let us know what you think.</Link></p>
+        <p>This feature is new. <Link to='/contact'>Let us know what you think.</Link></p>
         <p><em>Post statistics are only viewable by {isEAForum && "authors and"} admins</em></p>
       </Typography>
     </SingleColumnSection>

--- a/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsAnalyticsPage.tsx
@@ -1,18 +1,18 @@
+import NoSsr from '@material-ui/core/NoSsr'
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import TableCell from '@material-ui/core/TableCell'
+import TableRow from '@material-ui/core/TableRow'
+import classNames from 'classnames'
 import React from 'react'
-import { Components, registerComponent } from '../../lib/vulcan-lib'
-import { useLocation, useServerRequestStatus } from '../../lib/routeUtil'
 import { useSingle } from '../../lib/crud/withSingle'
-import { useCurrentUser } from '../common/withUser'
-import { userOwns } from '../../lib/vulcan-users'
-import { usePostAnalytics } from './usePostAnalytics'
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
-import { Link } from '../../lib/reactRouterWrapper'
 import { forumTypeSetting } from '../../lib/instanceSettings'
-import NoSsr from '@material-ui/core/NoSsr';
-import classNames from 'classnames';
+import { Link } from '../../lib/reactRouterWrapper'
+import { useLocation, useServerRequestStatus } from '../../lib/routeUtil'
+import { Components, registerComponent } from '../../lib/vulcan-lib'
+import { userOwns } from '../../lib/vulcan-users'
+import { useCurrentUser } from '../common/withUser'
+import { usePostAnalytics } from './usePostAnalytics'
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -78,7 +78,8 @@ declare global {
 
 const PostsAnalyticsPage = ({ classes }) => {
   const { query } = useLocation()
-  const { document: post } = useSingle({
+  // Cannot destructure and retain return type typing due to TS version
+  const postReturn = useSingle({
     documentId: query.postId,
     collectionName: "Posts",
     fragmentName: 'PostsPage',
@@ -89,12 +90,22 @@ const PostsAnalyticsPage = ({ classes }) => {
     SingleColumnSection, WrappedLoginForm, PostsAnalyticsInner, HeadTags, Typography
   } = Components
 
+
   if (!query.postId) {
     if (serverRequestStatus) serverRequestStatus.status = 400
     return <SingleColumnSection>
       Bad URL: Must specify a post ID
     </SingleColumnSection>
   }
+
+  if (postReturn.loading) {
+    return null
+  }
+
+  if (postReturn.error) {
+    throw postReturn.error;
+  }
+
   if (!currentUser) {
     if (serverRequestStatus) serverRequestStatus.status = 401
     return <SingleColumnSection>
@@ -102,8 +113,10 @@ const PostsAnalyticsPage = ({ classes }) => {
       <WrappedLoginForm />
     </SingleColumnSection>
   }
+
+
   if (
-    !userOwns(currentUser, post) &&
+    !userOwns(currentUser, postReturn.document) &&
     !currentUser.isAdmin &&
     !currentUser.groups?.includes('sunshineRegiment')
   ) {
@@ -112,10 +125,11 @@ const PostsAnalyticsPage = ({ classes }) => {
       You don't have permission to view this page.
     </SingleColumnSection>
   }
-  
+
+  const post = postReturn.document
   const isEAForum = forumTypeSetting.get() === 'EAForum'
   const title = `Analytics for "${post.title}"`
-  
+
   // Analytics query can still be very expensive despire indexes, and we don't
   // want 30 seconds before TTFB
   return <>

--- a/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
+++ b/packages/lesswrong/components/posts/PostsPreviewTooltipSingle.tsx
@@ -1,6 +1,6 @@
-import { Components, registerComponent } from '../../lib/vulcan-lib';
-import { useSingle } from '../../lib/crud/withSingle';
 import React from 'react';
+import { useSingle } from '../../lib/crud/withSingle';
+import { Components, registerComponent } from '../../lib/vulcan-lib';
 import { POST_PREVIEW_WIDTH } from './PostsPreviewTooltip';
 
 const styles = (theme: ThemeType): JssStyles => ({
@@ -29,7 +29,9 @@ const PostsPreviewTooltipSingle = ({ classes, postId, truncateLimit=600, postsLi
   if (postLoading) return <div className={classes.loading}>
       <Loading/>
     </div>
-  
+
+  if (!post) {return null;}
+
   return <PostsPreviewTooltip post={post} postsList={postsList}/>
 }
 
@@ -60,6 +62,8 @@ const PostsPreviewTooltipSingleWithComment = ({ classes, postId, commentId, trun
   if (postLoading || commentLoading) return <div className={classes.loading}>
       <Loading/>
     </div>
+
+  if (!post) {return null;}
   
   return <PostsPreviewTooltip post={post} comment={commentId && comment} />
 }
@@ -85,6 +89,7 @@ const TaggedPostTooltipSingle = ({tagRelId, classes}:{
   if (tagRelLoading) return <div className={classes.loading}>
     <Loading/>
   </div>
+  if (!tagRel) {return null;}
   return <PostsPreviewTooltip post={tagRel.post} />
 }
 

--- a/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
@@ -43,7 +43,7 @@ const PostsRevisionSelect = ({ classes }: {
   if (!post) {return null;}
   
   return <SingleColumnSection>
-    <h1>{post && post.title}</h1>
+    <h1>{post.title}</h1>
     
     {(loadingPost || loadingRevisions) && <Loading/>}
     

--- a/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
+++ b/packages/lesswrong/components/revisions/PostsRevisionSelect.tsx
@@ -39,6 +39,8 @@ const PostsRevisionSelect = ({ classes }: {
     if (!post) return;
     history.push(`/compare/post/${post._id}/${post.slug}?before=${before.version}&after=${after.version}`);
   }, [post, history]);
+
+  if (!post) {return null;}
   
   return <SingleColumnSection>
     <h1>{post && post.title}</h1>

--- a/packages/lesswrong/components/tagging/AllPostsPageTagRevisionItem.tsx
+++ b/packages/lesswrong/components/tagging/AllPostsPageTagRevisionItem.tsx
@@ -35,6 +35,8 @@ const AllPostsPageTagRevisionItem = ({tag, revisionId, documentId, classes}: {
   if (loading)
     return <Loading/>
   
+  if (!revision) {return null;}
+  
   return <div className={classes.root}>
     <div><TagRevisionItemShortMetadata tag={tag} revision={revision}/></div>
     

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -100,6 +100,8 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
     fragmentName: "TagPreviewFragment",
   })
 
+  if (!tag) {return null;}
+
   const tagLabel = <span className={classNames(classes.tag, {[classes.noTag]: !tagId})}>
     {label}
     <span className={classes.filterScore}>

--- a/packages/lesswrong/components/tagging/FilterMode.tsx
+++ b/packages/lesswrong/components/tagging/FilterMode.tsx
@@ -111,8 +111,8 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
 
   const otherValue = ["Hidden", -25,-10,0,10,25,"Required"].includes(mode) ? "" : (mode || "")
   return <span {...eventHandlers}>
-    <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag?._id} tagName={tag?.name}>
-      {(tag && !isMobile()) ? <Link to={`tag/${tag.slug}`}>
+    <AnalyticsContext pageElementContext="tagFilterMode" tagId={tag._id} tagName={tag.name}>
+      {(!isMobile()) ? <Link to={`tag/${tag.slug}`}>
         {tagLabel}
       </Link>
       : tagLabel
@@ -172,7 +172,7 @@ const FilterModeRawComponent = ({tagId="", label, mode, canRemove=false, onChang
 
               onChange={ev => onChangeMode(parseInt(ev.target.value || "0"))}
             />
-            {canRemove && !tag?.suggestedAsFilter &&
+            {canRemove && !tag.suggestedAsFilter &&
               <div className={classes.removeLabel} onClick={ev => {if (onRemove) onRemove()}}>
                 <LWTooltip title={<div><div>This filter will no longer appear in Latest Posts.</div><div>You can add it back later if you want</div></div>}>
                   <a>Remove</a>

--- a/packages/lesswrong/components/tagging/TagRevisionItemWrapper.tsx
+++ b/packages/lesswrong/components/tagging/TagRevisionItemWrapper.tsx
@@ -17,6 +17,7 @@ const TagRevisionItemWrapper = ({tag, headingStyle, revisionId, documentId}: {
   });
   
   if (loading) return null;
+  if (!document) {return null;}
   return <TagRevisionItem tag={tag} headingStyle={headingStyle} revision={document} documentId={documentId}/>
 }
 

--- a/packages/lesswrong/components/users/BannedNotice.tsx
+++ b/packages/lesswrong/components/users/BannedNotice.tsx
@@ -28,7 +28,7 @@ const BannedNotice = ({classes}: {
       </Typography>
 
       <Typography variant='body2'>
-        If you believe this is a mistake, please <Link to='/contact-us'>contact us.</Link>
+        If you believe this is a mistake, please <Link to='/contact'>contact us.</Link>
       </Typography>
     </div>
   </SingleColumnSection>

--- a/packages/lesswrong/lib/crud/withSingle.ts
+++ b/packages/lesswrong/lib/crud/withSingle.ts
@@ -1,8 +1,8 @@
+import { ApolloError, gql, useQuery, WatchQueryFetchPolicy } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
+import * as _ from 'underscore';
 import { extractCollectionInfo, extractFragmentInfo, getCollection } from '../vulcan-lib';
 import { camelCaseify } from '../vulcan-lib/utils';
-import * as _ from 'underscore';
-import { WatchQueryFetchPolicy, useQuery, gql } from '@apollo/client';
 
 // Single query used on the client
 //
@@ -124,6 +124,17 @@ export function withSingle({
   });
 }
 
+type TSuccessReturn<FragmentTypeName extends keyof FragmentTypes> = {loading: false, error: undefined, document: FragmentTypes[FragmentTypeName]};
+type TErrorReturn = {loading: false, error: ApolloError, document: undefined};
+type TLoadingReturn = {loading: true, error: undefined, document: undefined};
+
+type TReturn<FragmentTypeName extends keyof FragmentTypes> = (TSuccessReturn<FragmentTypeName> | TErrorReturn | TLoadingReturn) & {
+  refetch: any,
+  data?: {
+    refetch: any,
+  }
+}
+
 export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
   collectionName,
   fragmentName, fragment,
@@ -145,19 +156,11 @@ export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
   documentId: string|undefined,
   extraVariablesValues?: any,
   skip?: boolean,
-}): {
-  // Document should be optional
-  document: FragmentTypes[FragmentTypeName],
-  loading: boolean,
-  error?: any,
-  refetch: any,
-  data: {
-    refetch: any,
-  },
-} {
+}): TReturn<FragmentTypeName> {
   const collection = getCollection(collectionName);
   const query = getGraphQLQueryFromOptions({ extraVariables, extraQueries, collection, fragment, fragmentName })
   const resolverName = getResolverNameFromOptions(collection)
+  // TODO: Properly type this generic query
   const { data, error, ...rest } = useQuery(query, {
     variables: {
       input: {
@@ -176,8 +179,9 @@ export function useSingle<FragmentTypeName extends keyof FragmentTypes>({
     // eslint-disable-next-line no-console
     console.error(error.message)
   }
-  const document = data && data[resolverName] && data[resolverName].result
-  return { document, data, error, ...rest }
+  const document: FragmentTypes[FragmentTypeName] | undefined = data && data[resolverName] && data[resolverName].result
+  // TS can't deduce that either the document or the error are set and thus loading is inferred to be of type boolean always (instead of either true or false)
+  return { document, data, error, ...rest } as TReturn<FragmentTypeName>
 }
 
 export default withSingle;

--- a/packages/lesswrong/server/emailComponents/EventInRadiusEmail.tsx
+++ b/packages/lesswrong/server/emailComponents/EventInRadiusEmail.tsx
@@ -17,6 +17,7 @@ const EventInRadiusEmail = ({openingSentence, postId}: {
     fragmentName: "PostsRevision",
   });
   if (loading) return null;
+  if (!post) {return null;}
   
   const link = postGetPageUrl(post, true);
   

--- a/packages/lesswrong/server/resolvers/analyticsResolvers.ts
+++ b/packages/lesswrong/server/resolvers/analyticsResolvers.ts
@@ -1,8 +1,8 @@
-import { userOwns } from "../../lib/vulcan-users"
-import { addGraphQLQuery, addGraphQLResolvers, addGraphQLSchema } from "../vulcan-lib"
-import { getAnalyticsConnection } from "../analytics/postgresConnection"
-import { forumTypeSetting } from "../../lib/instanceSettings"
-import { PostAnalyticsResult } from "../../components/posts/usePostAnalytics"
+import { PostAnalyticsResult } from "../../components/posts/usePostAnalytics";
+import { forumTypeSetting } from "../../lib/instanceSettings";
+import { userOwns } from "../../lib/vulcan-users";
+import { getAnalyticsConnection } from "../analytics/postgresConnection";
+import { addGraphQLQuery, addGraphQLResolvers, addGraphQLSchema } from "../vulcan-lib";
 
 // TODO: Result column means you can't have a single query return multiple
 // results. But getting everything to work with columns plural was tricky and I
@@ -10,27 +10,27 @@ import { PostAnalyticsResult } from "../../components/posts/usePostAnalytics"
 /**
  * Based on an analytics query, returns a function that runs that query
  */
-function makePgAnalyticsQuery (query: string, resultColumn: string) {
+function makePgAnalyticsQuery(query: string, resultColumn: string) {
   return async (post: DbPost) => {
-    const postgres = getAnalyticsConnection()
-    if (!postgres) throw new Error("Unable to connect to analytics database - no database configured")
+    const postgres = getAnalyticsConnection();
+    if (!postgres) throw new Error("Unable to connect to analytics database - no database configured");
 
-    const queryVars = [post._id]
+    const queryVars = [post._id];
 
-    const pgResult = await postgres.query(query, queryVars)
-    
+    const pgResult = await postgres.query(query, queryVars);
+
     if (!pgResult.length) {
-      throw new Error(`No data found for post ${post.title}`)
+      throw new Error(`No data found for post ${post.title}`);
     }
     if (pgResult.length > 1) {
-      throw new Error(`Multiple rows found for post ${post.title}`)
+      throw new Error(`Multiple rows found for post ${post.title}`);
     }
-    const result = pgResult[0][resultColumn]
-    return result
-  }
+    const result = pgResult[0][resultColumn];
+    return result;
+  };
 }
 
-type QueryFunc = (post: DbPost) => Promise<Partial<PostAnalyticsResult>>
+type QueryFunc = (post: DbPost) => Promise<Partial<PostAnalyticsResult>>;
 
 const queries: Record<keyof PostAnalyticsResult, QueryFunc> = {
   uniqueClientViews: makePgAnalyticsQuery(
@@ -40,7 +40,7 @@ const queries: Record<keyof PostAnalyticsResult, QueryFunc> = {
       WHERE post_id = $1
         AND client_id IS NOT NULL
     `,
-    'unique_client_views'
+    "unique_client_views"
   ),
   // TODO: implement median function and change avg call to use it
   uniqueClientViews10Sec: makePgAnalyticsQuery(
@@ -58,45 +58,49 @@ const queries: Record<keyof PostAnalyticsResult, QueryFunc> = {
         GROUP BY client_id
       ) a
     `,
-    'unique_client_views_10_sec'
+    "unique_client_views_10_sec"
   ),
-}
+};
 
 addGraphQLResolvers({
   Query: {
-    async PostAnalytics(root: void, { postId }: { postId: string }, context: ResolverContext): Promise<PostAnalyticsResult> {
-      const { currentUser } = context
-      if (!currentUser) throw new Error(`No user`)
-      const post = await context.loaders.Posts.load(postId)
+    async PostAnalytics(
+      root: void,
+      { postId }: { postId: string },
+      context: ResolverContext
+    ): Promise<PostAnalyticsResult> {
+      const { currentUser } = context;
+      if (!currentUser) throw new Error(`No user`);
+      const post = await context.loaders.Posts.load(postId);
       // check that the current user has permission to view post metrics
       // LW doesn't want to show this to authors, but we'll let admins see it
       if (forumTypeSetting.get() !== "EAForum" && !currentUser.isAdmin) {
-        throw new Error("Permission denied")
+        throw new Error("Permission denied");
       }
       // Maybe check for karma level here?
       if (!userOwns(currentUser, post) && !currentUser.isAdmin && !currentUser.groups.includes("sunshineRegiment")) {
-        throw new Error("Permission denied")
+        throw new Error("Permission denied");
       }
-      
+
       // I really wanted to do this as a map, but I want to do this in serial,
       // and couldn't get it to work the way I wanted
-      const postAnalytics: Partial<PostAnalyticsResult> = {}
+      const postAnalytics: Partial<PostAnalyticsResult> = {};
       for (const [key, queryFunc] of Object.entries(queries)) {
-        postAnalytics[key] = await queryFunc(post)
+        postAnalytics[key] = await queryFunc(post);
       }
-      
+
       // There's no good way to tell TS that because we've iterated over all the
       // keys, the partial is no longer partial
-      return postAnalytics as PostAnalyticsResult
+      return postAnalytics as PostAnalyticsResult;
     },
   },
-})
+});
 
 addGraphQLSchema(`
   type PostAnalyticsResult {
     uniqueClientViews: Int
     uniqueClientViews10Sec: Int
   }
-`)
+`);
 
-addGraphQLQuery("PostAnalytics(postId: String!): PostAnalyticsResult!")
+addGraphQLQuery("PostAnalytics(postId: String!): PostAnalyticsResult!");


### PR DESCRIPTION
This is a PR building on top of: https://github.com/LessWrong2/Lesswrong2/pull/4208 . It fixes a bug with that PR causing an extraneous error with post analytics in certain situations. You'll want to change the base branch of this PR to `master` and merge, soonish after merging #4208 . (No rush, as it would only affect admins on LW.)

Already reviewed in: https://github.com/centre-for-effective-altruism/EAForum/pull/206 .

---

Correctly return that the document returned might be undefined when an error is set or when it's loading (fixes run-time bugs with reloading graphql data when navigating between pages).

