### PR TITLE
Remove "beta" from Community page, and hide newly created in-person events in Recent Discussion

### DIFF
--- a/packages/lesswrong/components/localGroups/CommunityHome.tsx
+++ b/packages/lesswrong/components/localGroups/CommunityHome.tsx
@@ -122,7 +122,7 @@ const CommunityHome = ({classes}: {
                   {currentUser?.mapLocation ? "Edit my location on the map" : "Add me to the map"}
                 </a>}
                 <a onClick={openEventNotificationsForm}>
-                  {currentUser?.nearbyEventsNotifications ? `Edit my event/groups notification settings` : `Sign up for event/group notifications`} [Beta]
+                  {currentUser?.nearbyEventsNotifications ? `Edit my event/groups notification settings` : `Sign up for event/group notifications`}
                 </a>
               </SectionFooter>
             </SingleColumnSection>

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -35,6 +35,7 @@ defineFeedResolver<Date>({
           selector: {
             baseScore: {$gt:0},
             hideFrontpageComments: false,
+            $or: [{isEvent: false}, {commentCount: {$nin:[0,null]}}],
             hiddenRelatedQuestion: undefined,
             shortform: undefined,
             groupId: undefined,

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -35,7 +35,7 @@ defineFeedResolver<Date>({
           selector: {
             baseScore: {$gt:0},
             hideFrontpageComments: false,
-            $or: [{isEvent: false}, {commentCount: {$nin:[0,null]}}],
+            $or: [{isEvent: false}, {onlineEvent: true}, {commentCount: {$nin:[0,null]}}],
             hiddenRelatedQuestion: undefined,
             shortform: undefined,
             groupId: undefined,


### PR DESCRIPTION
This PR removes the word "beta" from the Community page, and it excludes newly created in-person events from the Recent Discussion section. A **comment** on an event will make it appear in Recent Discussion. Online events still appear in Recent Discussion.