### PR TITLE
Misc fixes

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -269,7 +269,10 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
         )}
 
         {showPostTitle && !isChild && hasPostField(comment) && comment.post && <LWTooltip tooltip={false} title={<PostsPreviewTooltipSingle postId={comment.postId}/>}>
-            <Link className={classes.postTitle} to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>{comment.post.title}</Link>
+            <Link className={classes.postTitle} to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>
+              {comment.post.draft && "[Draft] "}
+              {comment.post.title}
+            </Link>
           </LWTooltip>}
         {showPostTitle && !isChild && hasTagField(comment) && comment.tag && <Link className={classes.postTitle} to={tagGetUrl(comment.tag)}>{comment.tag.name}</Link>}
 

--- a/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostBodyPrefix.tsx
@@ -44,7 +44,14 @@ const PostBodyPrefix = ({post, query, classes}: {
 
     <AlignmentCrosspostMessage post={post} />
     <AlignmentPendingApprovalMessage post={post} />
-    { post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>
+    
+    {post.shortform && post.draft && <div className={classes.contentNotice}>
+      This is a special post that holds your short-form writing. Because it's
+      marked as a draft, your short-form posts will not be displayed. To un-draft
+      it, pick Edit from the menu above, then click Publish.
+    </div>}
+    
+    {post.authorIsUnreviewed && !post.draft && <div className={classes.contentNotice}>
       Because this is your first post, this post is awaiting moderator approval.
       <LWTooltip title={<p>
         New users' first posts on {siteNameWithArticleSetting.get()} are checked by moderators before they appear on the site.

--- a/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsTopSequencesNav.tsx
@@ -6,6 +6,7 @@ import { useGlobalKeydown } from '../../common/withGlobalKeydown';
 import withErrorBoundary from '../../common/withErrorBoundary'
 import { sequenceGetPageUrl } from '../../../lib/collections/sequences/helpers';
 import { postGetPageUrl } from '../../../lib/collections/posts/helpers';
+import { useCurrentUser } from '../../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -29,6 +30,7 @@ const PostsTopSequencesNav = ({post, classes}: {
   classes: ClassesType,
 }) => {
   const { history } = useNavigation();
+  const currentUser = useCurrentUser();
 
   const handleKey = useCallback((ev) => {
     // Only if Shift and no other modifiers
@@ -54,6 +56,10 @@ const PostsTopSequencesNav = ({post, classes}: {
   if (!post?.sequence)
     return null;
 
+  if (post.sequence.draft && (!currentUser || currentUser._id!=post.sequence.userId) && !currentUser?.isAdmin) {
+    return null;
+  }
+  
   return (
     <div className={classes.root}>
       <Components.SequencesNavigationLink
@@ -61,6 +67,7 @@ const PostsTopSequencesNav = ({post, classes}: {
         direction="left" />
 
       <div className={classes.title}>
+        {post.sequence.draft && "[Draft] "}
         <Link to={sequenceGetPageUrl(post.sequence)}>{ post.sequence.title }</Link>
       </div>
 

--- a/packages/lesswrong/components/sequences/BottomNavigation.tsx
+++ b/packages/lesswrong/components/sequences/BottomNavigation.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { legacyBreakpoints } from '../../lib/utils/theme';
 import withErrorBoundary from '../common/withErrorBoundary'
 import classnames from 'classnames';
+import { useCurrentUser } from '../common/withUser';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -70,10 +71,17 @@ const BottomNavigation = ({post, classes}: {
   post: PostSequenceNavigation,
   classes: ClassesType,
 }) => {
-  const { nextPost, prevPost } = post;
+  const { nextPost, prevPost, sequence } = post;
+  const currentUser = useCurrentUser();
   
   if (!nextPost && !prevPost)
     return null;
+  
+  if (!post?.sequence)
+    return null;
+  if (post.sequence.draft && (!currentUser || currentUser._id!=post.sequence.userId) && !currentUser?.isAdmin) {
+    return null;
+  }
   
   return <div className={classes.root}>
     {prevPost &&

--- a/packages/lesswrong/components/sequences/SequencesPage.tsx
+++ b/packages/lesswrong/components/sequences/SequencesPage.tsx
@@ -111,8 +111,12 @@ const SequencesPage = ({ documentId, classes }: {
     ContentItemBody, Typography, SectionButton,
   } = Components
   
-  if (document && document.isDeleted) return <h3>This sequence has been deleted</h3>
-  if (loading || !document) return <Loading />
+  if (document?.isDeleted) return <h3>This sequence has been deleted</h3>
+  if (loading) return <Loading />
+  
+  if (!document) {
+    return <Components.Error404/>
+  }
   if (edit) return (
     <SequencesEditForm
       documentId={documentId}

--- a/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
+++ b/packages/lesswrong/components/shortform/ShortformTimeBlock.tsx
@@ -45,15 +45,18 @@ const ShortformTimeBlock  = ({reportEmpty, terms, classes}: {
       <div className={classes.subtitle}>
         <ContentType type="shortform" label="Shortform"/>
       </div>
-      {comments?.map((comment, i) =>
-        <CommentsNode
+      {comments?.map((comment, i) => {
+        if (!comment.post)
+          return null;
+        return <CommentsNode
           treeOptions={{
             post: comment.post || undefined,
           }}
           comment={comment}
           key={comment._id}
           forceSingleLine loadChildrenSeparately
-        />)}
+        />
+      })}
       {comments?.length < totalCount! &&
         <div className={classes.loadMore}>
           <LoadMore

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -308,6 +308,8 @@ registerFragment(`
     sequence(sequenceId: $sequenceId) {
       _id
       title
+      draft
+      userId
     }
     prevPost(sequenceId: $sequenceId) {
       _id

--- a/packages/lesswrong/lib/collections/sequences/permissions.ts
+++ b/packages/lesswrong/lib/collections/sequences/permissions.ts
@@ -1,4 +1,5 @@
-import { membersGroup, adminsGroup } from '../../vulcan-users/permissions';
+import { membersGroup, adminsGroup, userCanDo, userOwns } from '../../vulcan-users/permissions';
+import { Sequences } from './collection';
 
 const membersActions = [
   'sequences.edit.own',
@@ -17,9 +18,25 @@ const adminActions= [
 ]
 adminsGroup.can(adminActions);
 
-// Ray 5/2/2018 – is this commented out code still relevant?
-
-// Sequences.checkAccess = (user, document) => {
-//   console.log("Sequences checkAccess function: ", user, document);
-//   if (!user || !document) return false;
-//   return userOwns(user, document) ? userCanDo(user, 'sequences.view.own') : (userCanDo(user, `sequences.view.all`) || !document.draft)};
+Sequences.checkAccess = async (user, document) => {
+  if (!document) {
+    return false;
+  }
+  
+  // If it isn't a draft and isn't deleted, it's public
+  if (!document.draft && !document.isDeleted) {
+    return true;
+  }
+  
+  if (!user) {
+    return false;
+  }
+  
+  if (userOwns(user, document)) {
+    return true;
+  } else if (userCanDo(user, `sequences.view.all`)) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -473,6 +473,8 @@ interface PostSequenceNavigation { // fragment on Posts
 interface PostSequenceNavigation_sequence { // fragment on Sequences
   readonly _id: string,
   readonly title: string,
+  readonly draft: boolean,
+  readonly userId: string,
 }
 
 interface PostSequenceNavigation_prevPost { // fragment on Posts

--- a/packages/lesswrong/server/fieldChanges.ts
+++ b/packages/lesswrong/server/fieldChanges.ts
@@ -20,10 +20,10 @@ export const logFieldChanges = async <T extends DbObject>({currentUser, collecti
     //  * The logChanges option is present on the field, and false
     //  * The logChanges option is undefined on the field, and is false on the collection
     if (before===after) continue;
-    if (schema[key].denormalized) continue;
-    if (schema[key].logChanges != undefined && !schema[key].logChanges)
+    if (schema[key]?.denormalized) continue;
+    if (schema[key]?.logChanges != undefined && !schema[key]?.logChanges)
       continue;
-    if (!schema[key].logChanges && !collection.options.logChanges)
+    if (!schema[key]?.logChanges && !collection.options.logChanges)
       continue;
     
     // As a special case, don't log changes from null to undefined (or vise versa).

--- a/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
+++ b/packages/lesswrong/server/resolvers/recentDiscussionFeed.ts
@@ -21,7 +21,7 @@ defineFeedResolver<Date>({
     const {af} = args;
     const {currentUser} = context;
     
-    const shouldSuggestMeetupSubscription = currentUser && !currentUser.nearbyEventsNotifications; //TODO: Check some more fields
+    const shouldSuggestMeetupSubscription = currentUser && !currentUser.nearbyEventsNotifications && !currentUser.hideMeetupsPoke; //TODO: Check some more fields
     
     return await mergeFeedQueries<SortKeyType>({
       limit, cutoff, offset,


### PR DESCRIPTION
* Fix don't-ask-me-again button not working on the meetup-notifications poke
* Fix breakage in field-change logging when editing a field that's nested or not in the schema
* Fix: When a Sequence is a draft, sequence-navigation UI still appears on posts in it, but the sequence link leads to a broken page
* Permissions limit access to sequences that are marked as drafts
* Post-title on comments shows if the post is a draft
* Don't show shortform on all-posts page if the container is a draft. Put a notice on the shortform container if it's a draft.