### PR TITLE
Nofollow on allPosts internal links

### DIFF
--- a/packages/lesswrong/components/posts/PostsListSettings.tsx
+++ b/packages/lesswrong/components/posts/PostsListSettings.tsx
@@ -152,6 +152,7 @@ const SettingsColumn = ({type, title, options, currentOption, classes, setSettin
           // TODO: Can the query have an ordering that matches the column ordering?
           query={{ [type]: name }}
           merge
+          rel="nofollow"
         >
           <MetaInfo className={classNames(classes.menuItem, {[classes.selected]: currentOption === name})}>
             {optionValue.tooltip ?
@@ -233,6 +234,7 @@ const PostsListSettings = ({persistentSettings, hidden, currentTimeframe, curren
             onClick={() => setSetting('showLowKarma', !currentShowLowKarma)}
             query={{karmaThreshold: (currentShowLowKarma ? DEFAULT_LOW_KARMA_THRESHOLD : MAX_LOW_KARMA_THRESHOLD)}}
             merge
+            rel="nofollow"
           >
             <Checkbox classes={{root: classes.checkbox, checked: classes.checkboxChecked}} checked={currentShowLowKarma} />
 

--- a/packages/lesswrong/components/posts/PostsTimeBlock.tsx
+++ b/packages/lesswrong/components/posts/PostsTimeBlock.tsx
@@ -126,7 +126,7 @@ const PostsTimeBlock = ({ terms, timeBlockLoadComplete, startDate, hideIfEmpty, 
 
     return (
       <div className={classes.root}>
-        <QueryLink merge query={{
+        <QueryLink merge rel="nofollow" query={{
           after: moment.tz(startDate, timezone).startOf(timeBlock).format("YYYY-MM-DD"), 
           before: moment.tz(startDate, timezone).endOf(timeBlock).add(1, 'd').format("YYYY-MM-DD"),
           limit: 100

--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -42,7 +42,7 @@ export const Link = (props) => {
   return <HashLink {...props} onMouseDown={handleClick}/>
 }
 
-export const QueryLink: any = (reactRouter.withRouter as any)(({query, location, staticContext, merge=false, ...rest}) => {
+export const QueryLink: any = (reactRouter.withRouter as any)(({query, location, staticContext, merge=false, history, match, ...rest}) => {
   // Merge determines whether we do a shallow merge with the existing query parameters, or replace them completely
   const newSearchString = merge ? qs.stringify({...parseQuery(location), ...query}) : qs.stringify(query)
   return <reactRouterDom.Link


### PR DESCRIPTION
This should maybe stop a crawler from being stuck on the allPosts page forever. Or at least prevent future crawlers from doing the same.