### PR TITLE
Fix crash on submitting reset-password form

### DIFF
--- a/packages/lesswrong/server/fieldChanges.ts
+++ b/packages/lesswrong/server/fieldChanges.ts
@@ -32,8 +32,9 @@ export const logFieldChanges = async <T extends DbObject>({currentUser, collecti
     if (before===undefined && after===null) continue;
     if (after===undefined && before===null) continue;
     
-    loggedChangesBefore[key] = before;
-    loggedChangesAfter[key] = after;
+    const sanitizedKey = sanitizeKey(key);
+    loggedChangesBefore[sanitizedKey] = before;
+    loggedChangesAfter[sanitizedKey] = after;
   }
   
   if (Object.keys(loggedChangesAfter).length > 0) {
@@ -53,4 +54,8 @@ export const logFieldChanges = async <T extends DbObject>({currentUser, collecti
       validate: false,
     })
   }
+}
+
+function sanitizeKey(key: string): string {
+  return key.replace(/\./g, "_");
 }


### PR DESCRIPTION
This one is quite subtle. The field-change logging would create entries in `LWEvents` containing the names of updated keys. The password-reset mutation updates a nested object, using a key with a dotted path. When field-change logging was introduced, this would fail because the dotted path is not on the schema. Fixing the field-change logging to handle that case correctly resulted in sending a mongodb query with an invalid field name, which causes an exception deep inside mongodb internals.

It's possible that this was causing stochastic errors in seemingly-unrelated places (ie 502s).